### PR TITLE
Add global hotkey system and UI cleanup fixes

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Menu, Tray, nativeImage } from 'electron';
+import { app, BrowserWindow, Menu, nativeImage } from 'electron';
 import path from 'path';
 import { registerAuthHandlers } from './ipc/authHandlers';
 import { registerProxyHandlers } from './ipc/proxyHandlers';
@@ -16,7 +16,6 @@ process.stderr?.on?.('error', () => {});
 app.name = 'XNAT Viewer';
 
 let mainWindow: BrowserWindow | null = null;
-let tray: Tray | null = null;
 
 const isDev = !app.isPackaged;
 
@@ -43,21 +42,6 @@ function loadIcon(filename: string): Electron.NativeImage {
     // file not found — return empty
   }
   return nativeImage.createEmpty();
-}
-
-function createTrayIcon(): Electron.NativeImage {
-  if (process.platform === 'darwin') {
-    // macOS: Use iconTemplate.png (22×22 @1x) with iconTemplate@2x.png (44×44)
-    // for Retina. The "Template" suffix tells Electron/macOS to treat this as a
-    // template image — only alpha is used; the system tints it for light/dark mode.
-    // Electron auto-loads the @2x variant when it exists alongside the @1x file.
-    const p = getIconPath('iconTemplate.png');
-    const img = nativeImage.createFromPath(p);
-    if (!img.isEmpty()) return img;
-    // Fallback: return the full color icon
-  }
-  // Windows/Linux: use the full color icon for the tray
-  return loadIcon('icon.png');
 }
 
 // ─── App Menu ───────────────────────────────────────────────────
@@ -155,7 +139,7 @@ function createWindow(): void {
   const appIcon = loadIcon('icon.png');
 
   mainWindow = new BrowserWindow({
-    width: 1400,
+    width: 1600,
     height: 900,
     minWidth: 800,
     minHeight: 600,
@@ -183,38 +167,6 @@ function createWindow(): void {
   });
 }
 
-function createTray(): void {
-  const icon = createTrayIcon();
-  tray = new Tray(icon);
-  tray.setToolTip('XNAT Viewer');
-
-  const contextMenu = Menu.buildFromTemplate([
-    {
-      label: 'Show XNAT Viewer',
-      click: () => {
-        if (mainWindow) {
-          mainWindow.show();
-          mainWindow.focus();
-        }
-      },
-    },
-    { type: 'separator' },
-    {
-      label: 'Quit',
-      click: () => app.quit(),
-    },
-  ]);
-  tray.setContextMenu(contextMenu);
-
-  // Click on tray icon shows the window (macOS/Linux behavior)
-  tray.on('click', () => {
-    if (mainWindow) {
-      mainWindow.show();
-      mainWindow.focus();
-    }
-  });
-}
-
 app.whenReady().then(() => {
   // Register IPC handlers before creating the window
   registerAuthHandlers();
@@ -222,17 +174,28 @@ app.whenReady().then(() => {
   registerExportHandlers();
   registerUploadHandlers();
 
-  // Set the macOS dock icon (dev mode only — packaged app uses Info.plist)
+  // Set the macOS dock icon (dev mode only — packaged app uses Info.plist).
+  // In dev mode we can only use PNG; macOS won't apply the rounded-square
+  // treatment but the icon is still correct. Production uses .icns from
+  // the app bundle which gets full macOS styling automatically.
   if (process.platform === 'darwin' && app.dock) {
     const dockIcon = loadIcon('icon.png');
     if (!dockIcon.isEmpty()) app.dock.setIcon(dockIcon);
+  }
+
+  // Configure macOS About panel metadata.
+  // Note: iconPath is linux/win32 only — macOS About panel inherits
+  // the dock icon automatically, so no icon property is needed here.
+  if (process.platform === 'darwin') {
+    app.setAboutPanelOptions({
+      applicationName: 'XNAT Viewer',
+    });
   }
 
   // Set up the application menu (replaces "Electron" with "XNAT Viewer")
   buildAppMenu();
 
   createWindow();
-  createTray();
 });
 
 app.on('window-all-closed', () => {

--- a/src/renderer/components/connection/XnatBrowser.tsx
+++ b/src/renderer/components/connection/XnatBrowser.tsx
@@ -508,13 +508,6 @@ export default function XnatBrowser({ onLoadScan, onLoadSession }: XnatBrowserPr
                           </div>
                         </div>
                       </div>
-                      <span className={`text-[11px] font-medium shrink-0 px-2 py-0.5 rounded ${
-                        isSeg
-                          ? 'text-purple-400 bg-purple-500/10'
-                          : 'text-blue-400 bg-blue-500/10'
-                      }`}>
-                        {isSeg ? 'Load SEG' : 'Load'}
-                      </span>
                     </div>
                   );
                 }}

--- a/src/renderer/components/viewer/MPRViewportGrid.tsx
+++ b/src/renderer/components/viewer/MPRViewportGrid.tsx
@@ -14,8 +14,11 @@
  * Panel 3: CornerstoneViewport (original stack for reference)
  *
  * Includes a volume loading overlay with progress bar.
+ *
+ * Keyboard shortcuts (including MPR slice navigation) are handled globally
+ * by hotkeyService — see src/renderer/lib/hotkeys/hotkeyService.ts.
  */
-import { useEffect, useCallback, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useViewerStore } from '../../stores/viewerStore';
 import { mprPanelId, MPR_PANELS } from '@shared/types/viewer';
 import { mprService } from '../../lib/cornerstone/mprService';
@@ -35,65 +38,6 @@ export default function MPRViewportGrid({ volumeId, sourceImageIds }: MPRViewpor
   const activeViewportId = useViewerStore((s) => s.activeViewportId);
   const setActiveViewport = useViewerStore((s) => s.setActiveViewport);
   const mprVolumeProgress = useViewerStore((s) => s.mprVolumeProgress);
-
-  // ─── Keyboard Navigation (for MPR panels) ───────────────────
-  const handleKeyboard = useCallback(
-    (e: KeyboardEvent) => {
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
-
-      const state = useViewerStore.getState();
-      const pid = state.activeViewportId;
-
-      // Only handle keyboard for MPR panels (not the stack panel)
-      if (!pid.startsWith('mpr_panel_')) return;
-
-      const mprState = state.mprViewports[pid];
-      if (!mprState || mprState.totalSlices <= 1) return;
-
-      let delta = 0;
-      let jumpTo: number | null = null;
-
-      switch (e.key) {
-        case 'ArrowUp':
-        case 'ArrowLeft':
-          delta = -1;
-          break;
-        case 'ArrowDown':
-        case 'ArrowRight':
-          delta = 1;
-          break;
-        case 'PageUp':
-          delta = -10;
-          break;
-        case 'PageDown':
-          delta = 10;
-          break;
-        case 'Home':
-          jumpTo = 0;
-          break;
-        case 'End':
-          jumpTo = mprState.totalSlices - 1;
-          break;
-        default:
-          return;
-      }
-
-      e.preventDefault();
-
-      if (jumpTo !== null) {
-        mprService.scrollToIndex(pid, jumpTo);
-      } else if (delta !== 0) {
-        mprService.scroll(pid, delta);
-      }
-    },
-    [],
-  );
-
-  useEffect(() => {
-    window.addEventListener('keydown', handleKeyboard);
-    return () => window.removeEventListener('keydown', handleKeyboard);
-  }, [handleKeyboard]);
 
   // Is volume still loading?
   const isLoading = mprVolumeProgress !== null && mprVolumeProgress.percent < 100;

--- a/src/renderer/components/viewer/Toolbar.tsx
+++ b/src/renderer/components/viewer/Toolbar.tsx
@@ -349,7 +349,7 @@ export default function Toolbar({ showDicomPanel = false, onToggleDicomPanel, on
       {/* ─── W/L Presets ──────────────────────────────── */}
       <div className="relative">
         <select
-          className="appearance-none bg-zinc-800 text-zinc-300 text-xs rounded px-2 py-1.5 pr-6 border border-zinc-700 cursor-pointer hover:bg-zinc-700 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          className="appearance-none bg-zinc-800 text-zinc-300 text-xs rounded px-2 py-1.5 pr-6 w-[80px] border border-zinc-700 cursor-pointer hover:bg-zinc-700 focus:outline-none focus:ring-1 focus:ring-blue-500"
           value=""
           onChange={(e) => {
             const preset = WL_PRESETS.find((p) => p.name === e.target.value);

--- a/src/renderer/components/viewer/ViewportGrid.tsx
+++ b/src/renderer/components/viewer/ViewportGrid.tsx
@@ -4,15 +4,12 @@
  *
  * Each panel contains a CornerstoneViewport + ViewportOverlay + ScrollSlider.
  * Clicking a panel sets it as active (blue border highlight).
- * Empty panels (no images) show a placeholder.
  *
- * Keyboard navigation: Up/Down arrows scroll one slice, PageUp/PageDown scroll
- * 10 slices, Home/End jump to first/last slice — all targeting the active viewport.
+ * Keyboard shortcuts (including slice navigation) are handled globally
+ * by hotkeyService — see src/renderer/lib/hotkeys/hotkeyService.ts.
  */
-import { useEffect, useCallback } from 'react';
 import { useViewerStore } from '../../stores/viewerStore';
 import { LAYOUT_CONFIGS, panelId } from '@shared/types/viewer';
-import { viewportService } from '../../lib/cornerstone/viewportService';
 import CornerstoneViewport from './CornerstoneViewport';
 import ViewportOverlay from './ViewportOverlay';
 import ScrollSlider from './ScrollSlider';
@@ -27,61 +24,6 @@ export default function ViewportGrid({ panelImageIds }: ViewportGridProps) {
   const setActiveViewport = useViewerStore((s) => s.setActiveViewport);
 
   const config = LAYOUT_CONFIGS[layout];
-
-  // ─── Keyboard Navigation ──────────────────────────────────────
-  const handleKeyboard = useCallback(
-    (e: KeyboardEvent) => {
-      // Don't intercept if focus is in an input, select, or textarea
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
-
-      const state = useViewerStore.getState();
-      const vp = state.viewports[state.activeViewportId];
-      if (!vp || vp.totalImages <= 1) return;
-
-      let delta = 0;
-      let jumpTo: number | null = null;
-
-      switch (e.key) {
-        case 'ArrowUp':
-        case 'ArrowLeft':
-          delta = -1;
-          break;
-        case 'ArrowDown':
-        case 'ArrowRight':
-          delta = 1;
-          break;
-        case 'PageUp':
-          delta = -10;
-          break;
-        case 'PageDown':
-          delta = 10;
-          break;
-        case 'Home':
-          jumpTo = 0;
-          break;
-        case 'End':
-          jumpTo = vp.totalImages - 1;
-          break;
-        default:
-          return; // Not a navigation key
-      }
-
-      e.preventDefault();
-
-      if (jumpTo !== null) {
-        viewportService.scrollToIndex(state.activeViewportId, jumpTo);
-      } else if (delta !== 0) {
-        viewportService.scroll(state.activeViewportId, delta);
-      }
-    },
-    [], // No deps — reads from store directly
-  );
-
-  useEffect(() => {
-    window.addEventListener('keydown', handleKeyboard);
-    return () => window.removeEventListener('keydown', handleKeyboard);
-  }, [handleKeyboard]);
 
   return (
     <div

--- a/src/renderer/components/viewer/ViewportOverlay.tsx
+++ b/src/renderer/components/viewer/ViewportOverlay.tsx
@@ -29,6 +29,7 @@ const EMPTY_VP = {
 
 export default function ViewportOverlay({ panelId }: ViewportOverlayProps) {
   const viewport = useViewerStore((s) => s.viewports[panelId] ?? EMPTY_VP);
+  const sessionLabel = useViewerStore((s) => s.xnatContext?.sessionLabel ?? '');
   const overlay = useMetadataStore((s) => s.overlays[panelId] ?? EMPTY_OVERLAY);
 
   // Don't render if no images loaded
@@ -46,6 +47,9 @@ export default function ViewportOverlay({ panelId }: ViewportOverlayProps) {
           )}
           {overlay.studyDate && (
             <span className="text-zinc-400">{overlay.studyDate}</span>
+          )}
+          {sessionLabel && (
+            <span className="text-zinc-400">{sessionLabel}</span>
           )}
         </div>
 

--- a/src/renderer/hooks/useHotkeys.ts
+++ b/src/renderer/hooks/useHotkeys.ts
@@ -1,0 +1,18 @@
+/**
+ * useHotkeys — React hook that installs/removes the global hotkey listener.
+ *
+ * Call once at the viewer page level. The hook is intentionally thin:
+ * it delegates all logic to hotkeyService.
+ */
+import { useEffect } from 'react';
+import { hotkeyService } from '../lib/hotkeys/hotkeyService';
+
+/**
+ * Install the global hotkey listener on mount, remove on unmount.
+ */
+export function useHotkeys(): void {
+  useEffect(() => {
+    hotkeyService.install();
+    return () => hotkeyService.uninstall();
+  }, []);
+}

--- a/src/renderer/lib/cornerstone/metadataService.ts
+++ b/src/renderer/lib/cornerstone/metadataService.ts
@@ -15,6 +15,11 @@ import { EMPTY_OVERLAY } from '@shared/types/dicom';
  */
 function formatDicomDate(dateVal: unknown): string {
   if (dateVal === undefined || dateVal === null) return '';
+  // DICOM values can arrive as objects — unwrap or skip
+  if (typeof dateVal === 'object') {
+    if ((dateVal as any).Alphabetic) dateVal = (dateVal as any).Alphabetic;
+    else return '';
+  }
   // DICOM dates can arrive as numbers (e.g. 20121231) — coerce to string
   const dateStr = String(dateVal);
   if (dateStr.length < 8) return dateStr;
@@ -27,11 +32,15 @@ function formatDicomDate(dateVal: unknown): string {
 /**
  * Format a patient name from DICOM format (Last^First^Middle) to readable.
  */
-function formatPatientName(name: string | undefined): string {
+function formatPatientName(name: unknown): string {
   if (!name) return '';
   // Handle object format { Alphabetic: "..." }
-  if (typeof name === 'object' && (name as any).Alphabetic) {
-    name = (name as any).Alphabetic;
+  if (typeof name === 'object') {
+    if ((name as any).Alphabetic) {
+      name = (name as any).Alphabetic;
+    } else {
+      return '';
+    }
   }
   return String(name).replace(/\^/g, ', ');
 }
@@ -43,6 +52,11 @@ function toStr(val: unknown): string {
   if (val === undefined || val === null) return '';
   if (typeof val === 'number') {
     return Number.isInteger(val) ? String(val) : val.toFixed(2);
+  }
+  // Handle DICOM objects (e.g., PersonName { Alphabetic: "..." })
+  if (typeof val === 'object') {
+    if ((val as any).Alphabetic) return String((val as any).Alphabetic);
+    return '';
   }
   return String(val);
 }

--- a/src/renderer/lib/cornerstone/toolService.ts
+++ b/src/renderer/lib/cornerstone/toolService.ts
@@ -151,6 +151,12 @@ function rebuildToolGroup(primaryTool: ToolName): ToolTypes.IToolGroup | undefin
     toolGroup.addViewport(vpId, viewportService.ENGINE_ID);
   }
 
+  // Restore the brush size from the store — addAllTools creates fresh tool
+  // instances with Cornerstone's default (25), so we must re-apply the
+  // user's chosen size.
+  const brushSize = useSegmentationStore.getState().brushSize;
+  segmentationService.setBrushSize(brushSize);
+
   // Apply bindings using public APIs only
   applyBindings(toolGroup, primaryTool);
 
@@ -326,6 +332,12 @@ export const toolService = {
 
     addAllTools(toolGroup);
 
+    // Restore the brush size from the store — addAllTools creates fresh tool
+    // instances with Cornerstone's default (25), so we must re-apply the
+    // user's chosen size.
+    const brushSize = useSegmentationStore.getState().brushSize;
+    segmentationService.setBrushSize(brushSize);
+
     // Apply initial bindings with W/L as primary
     currentActiveTool = ToolName.WindowLevel;
     applyBindings(toolGroup, currentActiveTool);
@@ -344,6 +356,13 @@ export const toolService = {
       return;
     }
     toolGroup.addViewport(viewportId, viewportService.ENGINE_ID);
+
+    // Sync the store's brush size to Cornerstone3D now that the tool group
+    // has at least one viewport — setBrushSizeForToolGroup is a no-op when
+    // the tool group has no viewports.
+    const brushSize = useSegmentationStore.getState().brushSize;
+    segmentationService.setBrushSize(brushSize);
+
     console.log('[toolService] Viewport added to tool group:', viewportId);
   },
 

--- a/src/renderer/lib/cornerstone/viewportService.ts
+++ b/src/renderer/lib/cornerstone/viewportService.ts
@@ -189,21 +189,22 @@ export const viewportService = {
   },
 
   /**
-   * Toggle horizontal flip via setViewPresentation.
+   * Toggle horizontal flip.
+   *
+   * Cornerstone3D's viewport.flip() treats any truthy value as "toggle"
+   * (i.e., `flip({ flipHorizontal: true })` toggles the current state).
+   * We must NOT use setViewPresentation() here because it passes the
+   * desired state to flip(), but flip() interprets truthy/falsy as
+   * "should I toggle?" — causing setViewPresentation({ flipHorizontal: false })
+   * to be a no-op since false is falsy.
    */
   flipH(viewportId: string): void {
     const viewport = getStackViewport(viewportId);
     if (!viewport) return;
 
     const vp = viewport as any;
-    const current = vp.flipHorizontal ?? false;
-
     try {
-      if (typeof vp.setViewPresentation === 'function') {
-        vp.setViewPresentation({ flipHorizontal: !current });
-      } else if (typeof vp.flip === 'function') {
-        vp.flip({ flipHorizontal: true });
-      }
+      vp.flip({ flipHorizontal: true });
     } catch (err) {
       console.error('[viewportService] flipH failed:', err);
     }
@@ -211,21 +212,16 @@ export const viewportService = {
   },
 
   /**
-   * Toggle vertical flip via setViewPresentation.
+   * Toggle vertical flip.
+   * See flipH() for explanation of why we use flip() directly.
    */
   flipV(viewportId: string): void {
     const viewport = getStackViewport(viewportId);
     if (!viewport) return;
 
     const vp = viewport as any;
-    const current = vp.flipVertical ?? false;
-
     try {
-      if (typeof vp.setViewPresentation === 'function') {
-        vp.setViewPresentation({ flipVertical: !current });
-      } else if (typeof vp.flip === 'function') {
-        vp.flip({ flipVertical: true });
-      }
+      vp.flip({ flipVertical: true });
     } catch (err) {
       console.error('[viewportService] flipV failed:', err);
     }
@@ -266,6 +262,17 @@ export const viewportService = {
   },
 
   /**
+   * Zoom by a relative factor (e.g., 1.2 to zoom in 20%, 0.8 to zoom out 20%).
+   */
+  zoomBy(viewportId: string, factor: number): void {
+    const viewport = getStackViewport(viewportId);
+    if (!viewport) return;
+    const currentZoom = viewport.getZoom();
+    viewport.setZoom(currentZoom * factor);
+    viewport.render();
+  },
+
+  /**
    * Get current camera rotation in degrees.
    */
   getRotation(viewportId: string): number {
@@ -280,10 +287,12 @@ export const viewportService = {
   getFlipState(viewportId: string): { flipH: boolean; flipV: boolean } {
     const viewport = getStackViewport(viewportId);
     if (!viewport) return { flipH: false, flipV: false };
-    const camera = viewport.getCamera();
+    // Read from the viewport's own instance properties (maintained by
+    // setViewPresentation/flip), not getCamera() which may be stale.
+    const vp = viewport as any;
     return {
-      flipH: camera.flipHorizontal ?? false,
-      flipV: camera.flipVertical ?? false,
+      flipH: vp.flipHorizontal ?? false,
+      flipV: vp.flipVertical ?? false,
     };
   },
 };

--- a/src/renderer/lib/hotkeys/defaultHotkeyMap.ts
+++ b/src/renderer/lib/hotkeys/defaultHotkeyMap.ts
@@ -1,0 +1,70 @@
+/**
+ * Default hotkey map — sensible radiology viewer shortcuts.
+ *
+ * Conventions:
+ * - Single lowercase letters for frequent tools (OHIF-inspired)
+ * - No Ctrl+letter combos that conflict with Electron/OS defaults
+ *   (Ctrl+C/V/X/Z/A/S/W/Q all avoided)
+ * - Arrow keys + PageUp/Down for slice navigation (standard DICOM viewer)
+ * - Numbers 1-4 for layout switching
+ * - Ctrl+1..5 for W/L presets (avoids conflict with layout keys)
+ */
+import type { HotkeyMap } from '@shared/types/hotkeys';
+
+export const DEFAULT_HOTKEY_MAP: HotkeyMap = {
+  // ─── Tool Switching ──────────────────────────────────────────
+  'tool.windowLevel': [{ key: 'w' }, { key: 'Escape' }],
+  'tool.pan':         [{ key: 'p' }],
+  'tool.zoom':        [{ key: 'z' }],
+  'tool.length':      [{ key: 'l' }],
+  'tool.angle':       [{ key: 'a' }],
+  'tool.brush':       [{ key: 'b' }],
+  'tool.eraser':      [{ key: 'e' }],
+  'tool.crosshairs':  [{ key: 'c' }],
+  'tool.probe':       [{ key: 'd' }],   // D for density probe
+  'tool.arrowAnnotate': [{ key: 't' }], // T for text annotation
+  'tool.stackScroll': [{ key: 's' }],
+
+  // ─── Viewport Actions ────────────────────────────────────────
+  'viewport.reset':         [{ key: 'r' }],
+  'viewport.rotate90':      [{ key: 'r', modifiers: { shift: true } }],
+  'viewport.toggleInvert':  [{ key: 'i' }],
+  'viewport.flipH':         [{ key: 'h' }],
+  'viewport.flipV':         [{ key: 'v' }],
+
+  // ─── Zoom ─────────────────────────────────────────────────────
+  'viewport.zoomIn':  [{ key: '=' }, { key: '+' }],  // = is unshifted + on US keyboards
+  'viewport.zoomOut': [{ key: '-' }],
+
+  // ─── Cine ────────────────────────────────────────────────────
+  'viewport.toggleCine': [{ key: ' ' }], // Spacebar
+
+  // ─── Layout ──────────────────────────────────────────────────
+  'layout.1x1': [{ key: '1' }],
+  'layout.1x2': [{ key: '2' }],
+  'layout.2x1': [{ key: '3' }],
+  'layout.2x2': [{ key: '4' }],
+
+  // ─── Panel Toggles ──────────────────────────────────────────
+  'panel.toggleAnnotations':  [{ key: 'o' }], // O for list/overview
+  'panel.toggleSegmentation': [{ key: 'g' }], // G for seGmentation
+
+  // ─── Brush Size ──────────────────────────────────────────────
+  'brush.decrease': [{ key: '[' }],
+  'brush.increase': [{ key: ']' }],
+
+  // ─── Slice Navigation ───────────────────────────────────────
+  'slice.prev':     [{ key: 'ArrowUp' }, { key: 'ArrowLeft' }],
+  'slice.next':     [{ key: 'ArrowDown' }, { key: 'ArrowRight' }],
+  'slice.prevPage': [{ key: 'PageUp' }],
+  'slice.nextPage': [{ key: 'PageDown' }],
+  'slice.first':    [{ key: 'Home' }],
+  'slice.last':     [{ key: 'End' }],
+
+  // ─── W/L Presets (Ctrl+number) ──────────────────────────────
+  'preset.wl.0': [{ key: '1', modifiers: { ctrl: true } }], // CT Soft Tissue
+  'preset.wl.1': [{ key: '2', modifiers: { ctrl: true } }], // CT Lung
+  'preset.wl.2': [{ key: '3', modifiers: { ctrl: true } }], // CT Bone
+  'preset.wl.3': [{ key: '4', modifiers: { ctrl: true } }], // CT Brain
+  'preset.wl.4': [{ key: '5', modifiers: { ctrl: true } }], // CT Abdomen
+};

--- a/src/renderer/lib/hotkeys/hotkeyService.ts
+++ b/src/renderer/lib/hotkeys/hotkeyService.ts
@@ -1,0 +1,339 @@
+/**
+ * Hotkey Service — global keyboard shortcut listener and action dispatcher.
+ *
+ * Singleton module that:
+ * 1. Maintains a configurable hotkey map
+ * 2. Installs a single global keydown listener (capture phase)
+ * 3. Matches key events to actions via normalized string lookup
+ * 4. Dispatches actions to the appropriate Zustand stores / services
+ *
+ * Does NOT create any Zustand store of its own. All state mutations go
+ * through existing stores (viewerStore, segmentationStore, annotationStore).
+ */
+import type { HotkeyAction, HotkeyBinding, HotkeyMap } from '@shared/types/hotkeys';
+import { ToolName, WL_PRESETS } from '@shared/types/viewer';
+import type { LayoutType } from '@shared/types/viewer';
+import { DEFAULT_HOTKEY_MAP } from './defaultHotkeyMap';
+import { useViewerStore } from '../../stores/viewerStore';
+import { useSegmentationStore } from '../../stores/segmentationStore';
+import { useAnnotationStore } from '../../stores/annotationStore';
+import { viewportService } from '../cornerstone/viewportService';
+import { mprService } from '../cornerstone/mprService';
+import { segmentationService } from '../cornerstone/segmentationService';
+
+// ─── Reverse Lookup Table ─────────────────────────────────────────
+
+/**
+ * Normalized key string for fast lookup.
+ * Format: "ctrl+shift+alt+meta+key" (modifiers in fixed order, lowercase key).
+ * Only present modifiers are included (e.g., "shift+r", "escape", "ctrl+1").
+ */
+function normalizeBinding(binding: HotkeyBinding): string {
+  const parts: string[] = [];
+  if (binding.modifiers?.ctrl) parts.push('ctrl');
+  if (binding.modifiers?.shift) parts.push('shift');
+  if (binding.modifiers?.alt) parts.push('alt');
+  if (binding.modifiers?.meta) parts.push('meta');
+  parts.push(binding.key.toLowerCase());
+  return parts.join('+');
+}
+
+/**
+ * Build a reverse lookup from normalized key string to action.
+ * Last-write-wins for conflicts (later map entries take precedence).
+ */
+function buildLookup(map: HotkeyMap): Map<string, HotkeyAction> {
+  const lookup = new Map<string, HotkeyAction>();
+  for (const [action, bindings] of Object.entries(map) as [HotkeyAction, HotkeyBinding[]][]) {
+    if (!bindings) continue;
+    for (const binding of bindings) {
+      lookup.set(normalizeBinding(binding), action);
+    }
+  }
+  return lookup;
+}
+
+// ─── Action → ToolName Mapping ────────────────────────────────────
+
+const TOOL_ACTION_MAP: Partial<Record<HotkeyAction, ToolName>> = {
+  'tool.windowLevel':      ToolName.WindowLevel,
+  'tool.pan':              ToolName.Pan,
+  'tool.zoom':             ToolName.Zoom,
+  'tool.length':           ToolName.Length,
+  'tool.angle':            ToolName.Angle,
+  'tool.bidirectional':    ToolName.Bidirectional,
+  'tool.ellipticalROI':    ToolName.EllipticalROI,
+  'tool.rectangleROI':     ToolName.RectangleROI,
+  'tool.circleROI':        ToolName.CircleROI,
+  'tool.probe':            ToolName.Probe,
+  'tool.arrowAnnotate':    ToolName.ArrowAnnotate,
+  'tool.freehandROI':      ToolName.PlanarFreehandROI,
+  'tool.crosshairs':       ToolName.Crosshairs,
+  'tool.brush':            ToolName.Brush,
+  'tool.eraser':           ToolName.Eraser,
+  'tool.thresholdBrush':   ToolName.ThresholdBrush,
+  'tool.freehandContour':  ToolName.FreehandContour,
+  'tool.splineContour':    ToolName.SplineContour,
+  'tool.livewireContour':  ToolName.LivewireContour,
+  'tool.circleScissors':   ToolName.CircleScissors,
+  'tool.rectangleScissors': ToolName.RectangleScissors,
+  'tool.paintFill':        ToolName.PaintFill,
+  'tool.sculptor':         ToolName.Sculptor,
+  'tool.stackScroll':      ToolName.StackScroll,
+};
+
+const LAYOUT_ACTION_MAP: Partial<Record<HotkeyAction, LayoutType>> = {
+  'layout.1x1': '1x1',
+  'layout.1x2': '1x2',
+  'layout.2x1': '2x1',
+  'layout.2x2': '2x2',
+};
+
+// ─── Action Dispatch ──────────────────────────────────────────────
+
+/**
+ * Execute a hotkey action by calling the appropriate store methods.
+ * Returns true if the action was handled (caller should preventDefault).
+ */
+function dispatchAction(action: HotkeyAction): boolean {
+  const viewerState = useViewerStore.getState();
+
+  // ─── Tool switching ─────────────────────────────────────────
+  const toolName = TOOL_ACTION_MAP[action];
+  if (toolName) {
+    viewerState.setActiveTool(toolName);
+    return true;
+  }
+
+  // ─── Layout switching ───────────────────────────────────────
+  const layoutType = LAYOUT_ACTION_MAP[action];
+  if (layoutType) {
+    if (viewerState.mprActive) return false; // Layout locked in MPR
+    viewerState.setLayout(layoutType);
+    return true;
+  }
+
+  // ─── Everything else ────────────────────────────────────────
+  switch (action) {
+    // Viewport actions
+    case 'viewport.reset':
+      viewerState.resetViewport();
+      return true;
+    case 'viewport.toggleInvert':
+      viewerState.toggleInvert();
+      return true;
+    case 'viewport.rotate90':
+      viewerState.rotate90();
+      return true;
+    case 'viewport.flipH':
+      viewerState.flipH();
+      return true;
+    case 'viewport.flipV':
+      viewerState.flipV();
+      return true;
+    case 'viewport.zoomIn':
+      viewportService.zoomBy(viewerState.activeViewportId, 1.2);
+      return true;
+    case 'viewport.zoomOut':
+      viewportService.zoomBy(viewerState.activeViewportId, 1 / 1.2);
+      return true;
+    case 'viewport.toggleCine':
+      if (viewerState.mprActive) return false;
+      viewerState.toggleCine();
+      return true;
+
+    // Panel toggles
+    case 'panel.toggleAnnotations':
+      useAnnotationStore.getState().togglePanel();
+      return true;
+    case 'panel.toggleSegmentation':
+      useSegmentationStore.getState().togglePanel();
+      return true;
+
+    // Brush size
+    case 'brush.decrease': {
+      const segStore = useSegmentationStore.getState();
+      const newSize = Math.max(1, segStore.brushSize - 2);
+      segStore.setBrushSize(newSize);
+      segmentationService.setBrushSize(newSize);
+      return true;
+    }
+    case 'brush.increase': {
+      const segStore = useSegmentationStore.getState();
+      const newSize = Math.min(100, segStore.brushSize + 2);
+      segStore.setBrushSize(newSize);
+      segmentationService.setBrushSize(newSize);
+      return true;
+    }
+
+    // Slice navigation
+    case 'slice.prev':
+    case 'slice.next':
+    case 'slice.prevPage':
+    case 'slice.nextPage':
+    case 'slice.first':
+    case 'slice.last':
+      return handleSliceNavigation(action, viewerState);
+
+    // W/L presets
+    case 'preset.wl.0':
+    case 'preset.wl.1':
+    case 'preset.wl.2':
+    case 'preset.wl.3':
+    case 'preset.wl.4': {
+      const index = parseInt(action.split('.')[2], 10);
+      const preset = WL_PRESETS[index];
+      if (preset) {
+        viewerState.applyWLPreset(preset);
+        viewerState.setActiveTool(ToolName.WindowLevel);
+      }
+      return true;
+    }
+
+    default:
+      return false;
+  }
+}
+
+/**
+ * Handle slice navigation for both stack and MPR viewports.
+ * Replicates the logic from ViewportGrid.tsx and MPRViewportGrid.tsx.
+ */
+function handleSliceNavigation(
+  action: HotkeyAction,
+  viewerState: ReturnType<typeof useViewerStore.getState>,
+): boolean {
+  const pid = viewerState.activeViewportId;
+
+  // MPR panel (volume viewport)
+  if (pid.startsWith('mpr_panel_')) {
+    const mprState = viewerState.mprViewports[pid];
+    if (!mprState || mprState.totalSlices <= 1) return false;
+
+    let delta = 0;
+    let jumpTo: number | null = null;
+
+    switch (action) {
+      case 'slice.prev':     delta = -1;  break;
+      case 'slice.next':     delta = 1;   break;
+      case 'slice.prevPage': delta = -10; break;
+      case 'slice.nextPage': delta = 10;  break;
+      case 'slice.first':    jumpTo = 0;  break;
+      case 'slice.last':     jumpTo = mprState.totalSlices - 1; break;
+    }
+
+    if (jumpTo !== null) {
+      mprService.scrollToIndex(pid, jumpTo);
+    } else if (delta !== 0) {
+      mprService.scroll(pid, delta);
+    }
+    return true;
+  }
+
+  // Stack viewport
+  const vp = viewerState.viewports[pid];
+  if (!vp || vp.totalImages <= 1) return false;
+
+  let delta = 0;
+  let jumpTo: number | null = null;
+
+  switch (action) {
+    case 'slice.prev':     delta = -1;  break;
+    case 'slice.next':     delta = 1;   break;
+    case 'slice.prevPage': delta = -10; break;
+    case 'slice.nextPage': delta = 10;  break;
+    case 'slice.first':    jumpTo = 0;  break;
+    case 'slice.last':     jumpTo = vp.totalImages - 1; break;
+  }
+
+  if (jumpTo !== null) {
+    viewportService.scrollToIndex(pid, jumpTo);
+  } else if (delta !== 0) {
+    viewportService.scroll(pid, delta);
+  }
+  return true;
+}
+
+// ─── Module State ─────────────────────────────────────────────────
+
+let currentMap: HotkeyMap = { ...DEFAULT_HOTKEY_MAP };
+let lookup = buildLookup(currentMap);
+let listenerInstalled = false;
+
+// ─── Keydown Handler ──────────────────────────────────────────────
+
+function handleKeyDown(e: KeyboardEvent): void {
+  // Input guard: don't intercept when focus is in a form element
+  const tag = (e.target as HTMLElement)?.tagName;
+  if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
+
+  // Also guard for contentEditable elements
+  if ((e.target as HTMLElement)?.isContentEditable) return;
+
+  // Build normalized key from the event
+  const parts: string[] = [];
+  if (e.ctrlKey) parts.push('ctrl');
+  if (e.shiftKey) parts.push('shift');
+  if (e.altKey) parts.push('alt');
+  if (e.metaKey) parts.push('meta');
+  parts.push(e.key.toLowerCase());
+  const normalized = parts.join('+');
+
+  const action = lookup.get(normalized);
+  if (!action) return;
+
+  const handled = dispatchAction(action);
+  if (handled) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+}
+
+// ─── Public API ───────────────────────────────────────────────────
+
+export const hotkeyService = {
+  /**
+   * Install the global keydown listener.
+   * Idempotent — calling multiple times is safe.
+   */
+  install(): void {
+    if (listenerInstalled) return;
+    window.addEventListener('keydown', handleKeyDown, { capture: true });
+    listenerInstalled = true;
+    console.log('[hotkeyService] Global keyboard listener installed');
+  },
+
+  /**
+   * Remove the global keydown listener.
+   */
+  uninstall(): void {
+    if (!listenerInstalled) return;
+    window.removeEventListener('keydown', handleKeyDown, { capture: true });
+    listenerInstalled = false;
+    console.log('[hotkeyService] Global keyboard listener removed');
+  },
+
+  /**
+   * Replace the entire hotkey map. Rebuilds the lookup table.
+   */
+  setHotkeyMap(map: HotkeyMap): void {
+    currentMap = map;
+    lookup = buildLookup(currentMap);
+  },
+
+  /**
+   * Merge overrides into the current hotkey map.
+   * Allows partial overrides without replacing the entire map.
+   */
+  mergeOverrides(overrides: HotkeyMap): void {
+    currentMap = { ...currentMap, ...overrides };
+    lookup = buildLookup(currentMap);
+  },
+
+  /**
+   * Get the current hotkey map (for display in a settings UI).
+   */
+  getHotkeyMap(): HotkeyMap {
+    return { ...currentMap };
+  },
+};

--- a/src/renderer/pages/ViewerPage.tsx
+++ b/src/renderer/pages/ViewerPage.tsx
@@ -14,6 +14,7 @@ import DicomHeaderPanel from '../components/viewer/DicomHeaderPanel';
 import { toolService } from '../lib/cornerstone/toolService';
 import { annotationService } from '../lib/cornerstone/annotationService';
 import { segmentationService } from '../lib/cornerstone/segmentationService';
+import { useHotkeys } from '../hooks/useHotkeys';
 import { useAnnotationStore } from '../stores/annotationStore';
 import { useSegmentationStore } from '../stores/segmentationStore';
 import { useViewerStore } from '../stores/viewerStore';
@@ -39,6 +40,9 @@ export default function ViewerPage({ panelImageIds, onApplyProtocol, onToggleMPR
   // Check if the active panel has images loaded (for MPR button enable state)
   const activeViewportId = useViewerStore((s) => s.activeViewportId);
   const hasImages = (panelImageIds[activeViewportId]?.length ?? 0) > 1;
+
+  // Install global keyboard shortcuts.
+  useHotkeys();
 
   // Initialize the shared tool group and annotation service once on mount.
   // Individual CornerstoneViewport instances add/remove themselves.

--- a/src/renderer/stores/segmentationStore.ts
+++ b/src/renderer/stores/segmentationStore.ts
@@ -98,7 +98,7 @@ export const useSegmentationStore = create<SegmentationStore>((set) => ({
   fillAlpha: 0.5,
   showPanel: false,
   renderOutline: true,
-  brushSize: 15,
+  brushSize: 5,
   thresholdRange: [-200, 200],
   activeSegTool: null,
   splineType: 'CATMULLROM',

--- a/src/shared/types/hotkeys.ts
+++ b/src/shared/types/hotkeys.ts
@@ -1,0 +1,100 @@
+/**
+ * Hotkey system types — keyboard shortcut configuration and action definitions.
+ */
+
+/**
+ * All possible hotkey actions. String union ensures compile-time safety
+ * when defining the default map and the action registry.
+ */
+export type HotkeyAction =
+  // Tool switching
+  | 'tool.windowLevel'
+  | 'tool.pan'
+  | 'tool.zoom'
+  | 'tool.length'
+  | 'tool.angle'
+  | 'tool.bidirectional'
+  | 'tool.ellipticalROI'
+  | 'tool.rectangleROI'
+  | 'tool.circleROI'
+  | 'tool.probe'
+  | 'tool.arrowAnnotate'
+  | 'tool.freehandROI'
+  | 'tool.crosshairs'
+  | 'tool.brush'
+  | 'tool.eraser'
+  | 'tool.thresholdBrush'
+  | 'tool.freehandContour'
+  | 'tool.splineContour'
+  | 'tool.livewireContour'
+  | 'tool.circleScissors'
+  | 'tool.rectangleScissors'
+  | 'tool.paintFill'
+  | 'tool.sculptor'
+  | 'tool.stackScroll'
+  // Viewport actions
+  | 'viewport.reset'
+  | 'viewport.toggleInvert'
+  | 'viewport.rotate90'
+  | 'viewport.flipH'
+  | 'viewport.flipV'
+  | 'viewport.zoomIn'
+  | 'viewport.zoomOut'
+  // Cine
+  | 'viewport.toggleCine'
+  // Layout
+  | 'layout.1x1'
+  | 'layout.1x2'
+  | 'layout.2x1'
+  | 'layout.2x2'
+  // Panel toggles
+  | 'panel.toggleAnnotations'
+  | 'panel.toggleSegmentation'
+  // Brush size
+  | 'brush.decrease'
+  | 'brush.increase'
+  // Slice navigation
+  | 'slice.prev'
+  | 'slice.next'
+  | 'slice.prevPage'
+  | 'slice.nextPage'
+  | 'slice.first'
+  | 'slice.last'
+  // W/L presets (by index)
+  | 'preset.wl.0'
+  | 'preset.wl.1'
+  | 'preset.wl.2'
+  | 'preset.wl.3'
+  | 'preset.wl.4';
+
+/**
+ * Modifier keys for a hotkey binding.
+ * All default to false if omitted.
+ */
+export interface HotkeyModifiers {
+  ctrl?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+  meta?: boolean;
+}
+
+/**
+ * A single hotkey binding: a key code + optional modifiers.
+ *
+ * `key` uses KeyboardEvent.key values (case-sensitive):
+ * - Letters: 'w', 'p', 'z' (lowercase for unshifted)
+ * - Numbers: '1', '2', '3', '4'
+ * - Special: 'Escape', 'ArrowUp', 'ArrowDown', ' ' (space), '[', ']'
+ * - Function keys: 'F1', 'F2', etc.
+ */
+export interface HotkeyBinding {
+  key: string;
+  modifiers?: HotkeyModifiers;
+}
+
+/**
+ * The hotkey map: a Record from action identifier to one or more bindings.
+ * Multiple bindings per action allow aliases (e.g., ArrowUp and ArrowLeft
+ * both map to 'slice.prev').
+ */
+export type HotkeyMap = Partial<Record<HotkeyAction, HotkeyBinding[]>>;


### PR DESCRIPTION
Implement a centralized hotkey service with configurable key bindings for tool switching, viewport manipulation, layout changes, slice navigation, W/L presets, and panel toggles. Replace per-component keyboard handlers in ViewportGrid and MPRViewportGrid with the unified system.

UI fixes:
- Default brush size 15 → 5, sync to Cornerstone on tool group rebuild
- Fix flip H/V toggle using viewport.flip() directly (setViewPresentation is broken for toggling due to Cornerstone3D's truthy/falsy semantics)
- Fix [object Object] in viewport overlay (harden toStr, formatPatientName, formatDicomDate for DICOM object values)
- Display XNAT session label in viewport overlay
- Narrow W/L presets dropdown to 80px
- Remove redundant Load/Load SEG badges from scan browser
- Remove system tray icon
- Increase default window width to 1600
- Add About panel options for macOS