### PR TITLE
Add RTSTRUCT support and pinnable bookmarks

### DIFF
--- a/src/main/ipc/exportHandlers.ts
+++ b/src/main/ipc/exportHandlers.ts
@@ -179,6 +179,38 @@ export function registerExportHandlers(): void {
     },
   );
 
+  // ─── Save DICOM RTSTRUCT File ───────────────────────────────────
+  ipcMain.handle(
+    IPC.EXPORT_SAVE_DICOM_RTSTRUCT,
+    async (_event, dicomBase64: string, defaultName?: string) => {
+      try {
+        const win = BrowserWindow.getFocusedWindow();
+        if (!win) return { ok: false, error: 'No focused window' };
+
+        const result = await dialog.showSaveDialog(win, {
+          defaultPath: defaultName ?? 'rtstruct.dcm',
+          filters: [
+            { name: 'DICOM RTSTRUCT File', extensions: ['dcm'] },
+            { name: 'All Files', extensions: ['*'] },
+          ],
+        });
+
+        if (result.canceled || !result.filePath) {
+          return { ok: false };
+        }
+
+        const buffer = Buffer.from(dicomBase64, 'base64');
+        await fs.writeFile(result.filePath, buffer);
+        console.log(`[exportHandlers] Saved DICOM RTSTRUCT (${buffer.length} bytes) to ${result.filePath}`);
+        return { ok: true, path: result.filePath };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[exportHandlers] saveDicomRtStruct error:', msg);
+        return { ok: false, error: msg };
+      }
+    },
+  );
+
   // ─── Save DICOM File ─────────────────────────────────────────
   ipcMain.handle(
     IPC.EXPORT_SAVE_DICOM,

--- a/src/main/ipc/uploadHandlers.ts
+++ b/src/main/ipc/uploadHandlers.ts
@@ -1,8 +1,8 @@
 /**
- * Upload & Download IPC Handlers — handles uploading DICOM SEG files to XNAT
- * and downloading raw DICOM scan files from XNAT.
+ * Upload & Download IPC Handlers — handles uploading DICOM SEG and RTSTRUCT
+ * files to XNAT and downloading raw DICOM scan files from XNAT.
  *
- * Upload: Renderer sends DICOM SEG data as base64 through IPC → main process
+ * Upload: Renderer sends DICOM data as base64 through IPC → main process
  * creates a new scan on the session (bypassing Session Importer).
  *
  * Download: Renderer requests raw DICOM bytes for a scan → main process
@@ -78,6 +78,48 @@ export function registerUploadHandlers(): void {
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error('[uploadHandlers] Upload failed:', msg);
+        return { ok: false, error: msg };
+      }
+    },
+  );
+
+  // ─── Upload DICOM RTSTRUCT to XNAT (as a scan) ─────────────────
+  ipcMain.handle(
+    IPC.XNAT_UPLOAD_DICOM_RTSTRUCT,
+    async (
+      _event,
+      projectId: string,
+      subjectId: string,
+      sessionId: string,
+      sessionLabel: string,
+      sourceScanId: string,
+      dicomRtStructBase64: string,
+    ) => {
+      const client = sessionManager.getClient();
+      if (!client) {
+        return { ok: false, error: 'Not connected to XNAT' };
+      }
+
+      try {
+        const buffer = Buffer.from(dicomRtStructBase64, 'base64');
+        console.log(
+          `[uploadHandlers] Uploading DICOM RTSTRUCT (${buffer.length} bytes)`,
+          `to ${projectId}/${subjectId}/${sessionLabel} (source scan: ${sourceScanId})`,
+        );
+
+        const result = await client.uploadDicomRtStructAsScan(
+          projectId,
+          subjectId,
+          sessionId,
+          sessionLabel,
+          sourceScanId,
+          buffer,
+        );
+
+        return { ok: true, url: result.url, scanId: result.scanId };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[uploadHandlers] RTSTRUCT upload failed:', msg);
         return { ok: false, error: msg };
       }
     },

--- a/src/main/xnat/xnatClient.ts
+++ b/src/main/xnat/xnatClient.ts
@@ -539,6 +539,105 @@ export class XnatClient {
     return { url: scanUrl, scanId: targetScanId };
   }
 
+  /**
+   * Upload a DICOM RTSTRUCT file to an XNAT session as a new scan.
+   *
+   * Same three-step process as uploadDicomSegAsScan(), but:
+   * - Scan numbering convention: 40xx (then 41xx, 42xx, etc.)
+   * - xnat:otherDicomScanData/type = 'RTSTRUCT'
+   * - series_description = 'RT Structure Set'
+   * - filename = rtstruct.dcm
+   */
+  async uploadDicomRtStructAsScan(
+    projectId: string,
+    subjectId: string,
+    sessionId: string,
+    sessionLabel: string,
+    sourceScanId: string,
+    dicomBuffer: Buffer,
+    seriesDescription: string = 'RT Structure Set',
+  ): Promise<{ url: string; scanId: string }> {
+    if (!this.token) throw new Error('Not authenticated');
+
+    // ── Step 1: Find unused scan number ──────────────────────────
+    const existingScans = await this.getScans(sessionId);
+    const existingScanIds = new Set(existingScans.map((s) => s.id));
+
+    const srcNum = parseInt(sourceScanId, 10);
+    const suffix = isNaN(srcNum)
+      ? sourceScanId
+      : String(srcNum).padStart(2, '0');
+
+    let targetScanId = '';
+    for (let prefix = 40; prefix < 100; prefix++) {
+      const candidate = `${prefix}${suffix}`;
+      if (!existingScanIds.has(candidate)) {
+        targetScanId = candidate;
+        break;
+      }
+    }
+    if (!targetScanId) {
+      throw new Error(`Could not find unused scan number for source scan ${sourceScanId}`);
+    }
+
+    console.log(
+      `[xnatClient] Uploading DICOM RTSTRUCT as scan ${targetScanId}`,
+      `(source scan: ${sourceScanId}, ${(dicomBuffer.length / 1024).toFixed(1)} KB)`,
+    );
+
+    const basePath = `/data/projects/${encodeURIComponent(projectId)}`
+      + `/subjects/${encodeURIComponent(subjectId)}`
+      + `/experiments/${encodeURIComponent(sessionLabel)}`
+      + `/scans/${encodeURIComponent(targetScanId)}`;
+
+    // ── Step 2: Create the scan ──────────────────────────────────
+    const createParams = new URLSearchParams({
+      'xsiType': 'xnat:otherDicomScanData',
+      'xnat:otherDicomScanData/type': 'RTSTRUCT',
+      'xnat:otherDicomScanData/series_description': seriesDescription,
+    });
+
+    const createUrl = `${this.baseUrl}${basePath}?${createParams.toString()}`;
+    const createResp = await fetch(createUrl, {
+      method: 'PUT',
+      headers: this.buildAuthHeaders(),
+    });
+
+    if (!createResp.ok) {
+      const text = await createResp.text().catch(() => '');
+      if (createResp.status === 403) {
+        throw new Error('Permission denied: you do not have write access to this project');
+      }
+      throw new Error(`Failed to create scan ${targetScanId}: ${createResp.status} ${text}`.trim());
+    }
+    console.log(`[xnatClient] Created scan ${targetScanId}`);
+
+    // ── Step 3: Upload DICOM file to scan resource ───────────────
+    const fileParams = new URLSearchParams({
+      'format': 'DICOM',
+      'content': 'RTSTRUCT',
+    });
+
+    const fileUrl = `${this.baseUrl}${basePath}/resources/DICOM/files/rtstruct.dcm?${fileParams.toString()}`;
+    const fileResp = await fetch(fileUrl, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/dicom',
+        ...this.buildAuthHeaders(),
+      },
+      body: new Uint8Array(dicomBuffer),
+    });
+
+    if (!fileResp.ok) {
+      const text = await fileResp.text().catch(() => '');
+      throw new Error(`Failed to upload file to scan ${targetScanId}: ${fileResp.status} ${text}`.trim());
+    }
+
+    const scanUrl = `${this.baseUrl}${basePath}`;
+    console.log(`[xnatClient] RTSTRUCT upload successful: ${scanUrl}`);
+    return { url: scanUrl, scanId: targetScanId };
+  }
+
   // ─── Getters ───────────────────────────────────────────────────
 
   get isAuthenticated(): boolean {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -46,6 +46,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
     uploadDicomSeg: (projectId: string, subjectId: string, sessionId: string, sessionLabel: string, sourceScanId: string, dicomBase64: string) =>
       ipcRenderer.invoke(IPC.XNAT_UPLOAD_DICOM_SEG, projectId, subjectId, sessionId, sessionLabel, sourceScanId, dicomBase64),
+
+    uploadDicomRtStruct: (projectId: string, subjectId: string, sessionId: string, sessionLabel: string, sourceScanId: string, dicomBase64: string) =>
+      ipcRenderer.invoke(IPC.XNAT_UPLOAD_DICOM_RTSTRUCT, projectId, subjectId, sessionId, sessionLabel, sourceScanId, dicomBase64),
   },
 
   export: {
@@ -61,6 +64,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke(IPC.EXPORT_SAVE_REPORT, text, defaultName),
     saveDicomSeg: (dicomBase64: string, defaultName?: string) =>
       ipcRenderer.invoke(IPC.EXPORT_SAVE_DICOM_SEG, dicomBase64, defaultName),
+    saveDicomRtStruct: (dicomBase64: string, defaultName?: string) =>
+      ipcRenderer.invoke(IPC.EXPORT_SAVE_DICOM_RTSTRUCT, dicomBase64, defaultName),
   },
 
   on: (channel: string, callback: (...args: unknown[]) => void) => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -13,9 +13,23 @@ import { matchProtocol, applyProtocol } from './lib/hangingProtocolService';
 import { panelId } from '@shared/types/viewer';
 import { BUILT_IN_PROTOCOLS } from '@shared/types/hangingProtocol';
 import type { XnatScan } from '@shared/types/xnat';
-import { IconFolder, IconOpenFile, XnatLogo } from './components/icons';
+import { IconFolder, IconOpenFile, IconPin, IconChevronDown, XnatLogo } from './components/icons';
 import { volumeService } from './lib/cornerstone/volumeService';
+import {
+  loadPinnedItems,
+  addPinnedItem,
+  removePinnedItem,
+  isPinned as isPinnedCheck,
+  loadRecentSessions,
+  saveRecentSession as saveRecentSessionUtil,
+  removeRecentSession,
+  migrateOldStorage,
+  type PinnedItem,
+  type RecentSession,
+  type NavigateToTarget,
+} from './lib/pinnedItems';
 import { segmentationService } from './lib/cornerstone/segmentationService';
+import { rtStructService } from './lib/cornerstone/rtStructService';
 import { viewportService } from './lib/cornerstone/viewportService';
 import { imageLoader, cache, metaData } from '@cornerstonejs/core';
 import * as dicomParser from 'dicom-parser';
@@ -23,9 +37,23 @@ import * as dicomParser from 'dicom-parser';
 /** DICOM SEG SOP Class UID */
 const SEG_SOP_CLASS_UID = '1.2.840.10008.5.1.4.1.1.66.4';
 
+/** DICOM RTSTRUCT SOP Class UID */
+const RTSTRUCT_SOP_CLASS_UID = '1.2.840.10008.5.1.4.1.1.481.3';
+
 /** Check if a scan is a DICOM SEG scan based on XNAT type metadata */
 function isSegScan(scan: XnatScan): boolean {
   return scan.type?.toUpperCase() === 'SEG';
+}
+
+/** Check if a scan is a DICOM RTSTRUCT scan based on XNAT type metadata */
+function isRtStructScan(scan: XnatScan): boolean {
+  const t = scan.type?.toUpperCase();
+  return t === 'RTSTRUCT' || t === 'RT';
+}
+
+/** Check if a scan is a derived object (SEG or RTSTRUCT) */
+function isDerivedScan(scan: XnatScan): boolean {
+  return isSegScan(scan) || isRtStructScan(scan);
 }
 
 /**
@@ -126,8 +154,8 @@ async function findSourceScanBySeriesUID(
   targetSeriesUID: string,
   scans: XnatScan[],
 ): Promise<{ scanId: string; imageIds: string[] } | null> {
-  // Only check non-SEG scans
-  const candidates = scans.filter((s) => s.type?.toUpperCase() !== 'SEG');
+  // Only check non-derived scans (exclude SEG, RTSTRUCT)
+  const candidates = scans.filter((s) => !isDerivedScan(s));
   console.log(`[App] Searching ${candidates.length} scans for SeriesInstanceUID ${targetSeriesUID}`);
 
   for (const scan of candidates) {
@@ -251,6 +279,13 @@ export default function App() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [showBrowser, setShowBrowser] = useState(true);
 
+  // ─── Bookmarks (pinned items & recent sessions) ───────────────
+  const [pinnedItems, setPinnedItems] = useState<PinnedItem[]>([]);
+  const [recentSessions, setRecentSessions] = useState<RecentSession[]>([]);
+  const [navigateTo, setNavigateTo] = useState<NavigateToTarget | null>(null);
+  const [showBookmarks, setShowBookmarks] = useState(false);
+  const bookmarksRef = useRef<HTMLDivElement>(null);
+
   /**
    * Pending DICOM SEG load — when loading a SEG that requires loading new
    * source images into a panel, we can't load the SEG immediately because
@@ -294,6 +329,87 @@ export default function App() {
   /** Count total loaded images across all panels */
   const totalImages = Object.values(panelImageIds).reduce((sum, ids) => sum + ids.length, 0);
 
+  // ─── Bookmarks: migrate old storage on mount ──────────────────
+  useEffect(() => {
+    migrateOldStorage();
+  }, []);
+
+  // ─── Bookmarks: refresh pins & recents when server changes ────
+  const refreshBookmarks = useCallback(() => {
+    const url = connection?.serverUrl;
+    if (url) {
+      setPinnedItems(loadPinnedItems(url));
+      setRecentSessions(loadRecentSessions(url));
+    } else {
+      setPinnedItems([]);
+      setRecentSessions([]);
+    }
+  }, [connection?.serverUrl]);
+
+  useEffect(() => {
+    refreshBookmarks();
+  }, [refreshBookmarks]);
+
+  // ─── Bookmarks: close dropdown on outside click ───────────────
+  useEffect(() => {
+    if (!showBookmarks) return;
+    function handleClick(e: MouseEvent) {
+      if (bookmarksRef.current && !bookmarksRef.current.contains(e.target as Node)) {
+        setShowBookmarks(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [showBookmarks]);
+
+  // ─── Bookmarks: handlers ──────────────────────────────────────
+  const handleTogglePin = useCallback(
+    (item: PinnedItem) => {
+      const url = connection?.serverUrl;
+      if (!url) return;
+      const id =
+        item.type === 'project' ? item.projectId :
+        item.type === 'subject' ? item.subjectId :
+        item.sessionId;
+      if (isPinnedCheck(pinnedItems, item.type, id)) {
+        removePinnedItem(item.type, id, url);
+      } else {
+        addPinnedItem(item);
+      }
+      refreshBookmarks();
+    },
+    [connection?.serverUrl, pinnedItems, refreshBookmarks],
+  );
+
+  /** Navigate to a pinned or recent item via the bookmarks dropdown. */
+  const handleBookmarkNavigate = useCallback(
+    (target: NavigateToTarget) => {
+      setNavigateTo(target);
+      setShowBookmarks(false);
+      if (!showBrowser) setShowBrowser(true);
+    },
+    [showBrowser],
+  );
+
+  /** Promote a recent session to a pinned item. */
+  const handlePromoteRecent = useCallback(
+    (recent: RecentSession) => {
+      addPinnedItem({
+        type: 'session',
+        serverUrl: recent.serverUrl,
+        projectId: recent.projectId,
+        projectName: recent.projectName,
+        subjectId: recent.subjectId,
+        subjectLabel: recent.subjectLabel,
+        sessionId: recent.sessionId,
+        sessionLabel: recent.sessionLabel,
+        timestamp: Date.now(),
+      });
+      refreshBookmarks();
+    },
+    [refreshBookmarks],
+  );
+
   /**
    * Load local DICOM files using Cornerstone's file manager.
    * Creates wadouri: image IDs backed by in-memory File objects.
@@ -315,10 +431,11 @@ export default function App() {
     // Sort files by name for consistent ordering
     dicomFiles.sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
 
-    // Separate DICOM SEG files from regular image files.
+    // Separate DICOM SEG / RTSTRUCT files from regular image files.
     // We peek at the SOP Class UID tag (0008,0016) in each file.
     const regularFiles: File[] = [];
     const segFiles: File[] = [];
+    const rtStructFiles: File[] = [];
 
     for (const file of dicomFiles) {
       try {
@@ -330,6 +447,8 @@ export default function App() {
 
         if (sopClassUid === SEG_SOP_CLASS_UID) {
           segFiles.push(file);
+        } else if (sopClassUid === RTSTRUCT_SOP_CLASS_UID) {
+          rtStructFiles.push(file);
         } else {
           regularFiles.push(file);
         }
@@ -387,6 +506,45 @@ export default function App() {
       const segStore = useSegmentationStore.getState();
       if (!segStore.showPanel) {
         segStore.togglePanel();
+      }
+    }
+
+    // Load DICOM RTSTRUCT files as contour segmentation overlays
+    if (rtStructFiles.length > 0) {
+      const sourceImageIds = newImageIds.length > 0
+        ? newImageIds
+        : (panelImageIdsRef.current[targetPanel] ?? []);
+
+      if (sourceImageIds.length === 0) {
+        console.warn('[App] Cannot load DICOM RTSTRUCT — no source images loaded in active panel');
+        return;
+      }
+
+      // Small delay to let Cornerstone register the source images (if loaded together)
+      if (newImageIds.length > 0) {
+        await new Promise((r) => setTimeout(r, 200));
+      }
+
+      // Pre-load source images for metadata
+      await preloadImages(sourceImageIds);
+
+      for (const file of rtStructFiles) {
+        try {
+          const arrayBuffer = await file.arrayBuffer();
+          const parsed = rtStructService.parseRtStruct(arrayBuffer);
+          const { segmentationId, firstReferencedImageId } =
+            await rtStructService.loadRtStructAsContours(parsed, sourceImageIds, targetPanel);
+          await jumpViewportToReferencedImage(targetPanel, firstReferencedImageId);
+          console.log(`[App] Loaded RTSTRUCT file "${file.name}" as ${segmentationId}`);
+        } catch (err) {
+          console.error(`[App] Failed to load RTSTRUCT "${file.name}":`, err);
+        }
+      }
+
+      // Open the segmentation panel
+      const segStore2 = useSegmentationStore.getState();
+      if (!segStore2.showPanel) {
+        segStore2.togglePanel();
       }
     }
   }, []);
@@ -467,7 +625,7 @@ export default function App() {
     sessionId: string,
     scanId: string,
     scan: XnatScan,
-    context: { projectId: string; subjectId: string; sessionLabel: string },
+    context: { projectId: string; subjectId: string; sessionLabel: string; projectName?: string; subjectLabel?: string },
   ) => {
     if (!isConnected) return;
 
@@ -481,6 +639,20 @@ export default function App() {
       sessionLabel: context.sessionLabel,
       scanId,
     });
+
+    // Remember this session for "Load Recent" on next visit
+    const serverUrl = useConnectionStore.getState().connection?.serverUrl;
+    if (serverUrl) {
+      saveRecentSessionUtil(serverUrl, {
+        projectId: context.projectId,
+        projectName: context.projectName ?? context.projectId,
+        subjectId: context.subjectId,
+        subjectLabel: context.subjectLabel ?? context.subjectId,
+        sessionId,
+        sessionLabel: context.sessionLabel,
+      });
+      refreshBookmarks();
+    }
 
     try {
       setLoading(true);
@@ -588,6 +760,76 @@ export default function App() {
         // 7. Open segmentation panel
         const segStore = useSegmentationStore.getState();
         if (!segStore.showPanel) segStore.togglePanel();
+      } else if (isRtStructScan(scan)) {
+        // ─── RTSTRUCT scan: load contours as segmentation overlay ──
+
+        // 1. Download the RTSTRUCT file
+        const arrayBuffer = await downloadSegArrayBuffer(sessionId, scanId);
+        console.log(`[App] Downloaded RTSTRUCT file (${arrayBuffer.byteLength} bytes)`);
+
+        // 2. Parse the RTSTRUCT
+        const parsed = rtStructService.parseRtStruct(arrayBuffer);
+
+        // 3. Find source images
+        let sourceIds: string[] | null = null;
+        let rtTargetPanel = targetPanel;
+
+        if (parsed.referencedSeriesUID) {
+          const match = findPanelBySeriesUID(parsed.referencedSeriesUID, panelImageIdsRef.current);
+          if (match) {
+            console.log(`[App] RTSTRUCT matched to ${match.panelId} via SeriesInstanceUID`);
+            sourceIds = match.imageIds;
+            rtTargetPanel = match.panelId;
+          }
+        }
+
+        // 4. If source not loaded, find and load it
+        if (!sourceIds) {
+          if (parsed.referencedSeriesUID) {
+            let sessionScans = useViewerStore.getState().sessionScans;
+            if (!sessionScans || sessionScans.length === 0) {
+              sessionScans = await window.electronAPI.xnat.getScans(sessionId);
+            }
+            if (sessionScans.length > 0) {
+              const match = await findSourceScanBySeriesUID(sessionId, parsed.referencedSeriesUID, sessionScans);
+              if (match) {
+                sourceIds = match.imageIds;
+                // Load source images into panel, then load RTSTRUCT after settling
+                segmentationService.removeSegmentationsFromViewport(rtTargetPanel);
+                setPanelImageIds((prev) => ({ ...prev, [rtTargetPanel]: sourceIds! }));
+                useViewerStore.getState().setPanelScan(rtTargetPanel, match.scanId);
+
+                // Wait for viewport to settle
+                let attempts = 0;
+                while (attempts < 40) {
+                  const vp = viewportService.getViewport(rtTargetPanel);
+                  if (vp && vp.getImageIds().length > 0) break;
+                  await new Promise((r) => setTimeout(r, 100));
+                  attempts++;
+                }
+                await new Promise((r) => setTimeout(r, 300));
+              }
+            }
+          }
+
+          if (!sourceIds) {
+            setLoadError(`Cannot find source images for RTSTRUCT scan #${scanId}`);
+            return;
+          }
+        }
+
+        // 5. Pre-load source images for metadata
+        await preloadImages(sourceIds);
+
+        // 6. Load the RTSTRUCT as contour segmentation
+        const { segmentationId, firstReferencedImageId } =
+          await rtStructService.loadRtStructAsContours(parsed, sourceIds, rtTargetPanel);
+        await jumpViewportToReferencedImage(rtTargetPanel, firstReferencedImageId);
+        console.log(`[App] Loaded RTSTRUCT from XNAT as ${segmentationId} on ${rtTargetPanel}`);
+
+        // 7. Open segmentation panel
+        const segStore2 = useSegmentationStore.getState();
+        if (!segStore2.showPanel) segStore2.togglePanel();
       } else {
         // ─── Regular scan: load as image stack ────────────────────
 
@@ -631,7 +873,7 @@ export default function App() {
     } finally {
       setLoading(false);
     }
-  }, [isConnected]);
+  }, [isConnected, refreshBookmarks]);
 
   /**
    * Load ALL scans from an XNAT session using hanging protocols.
@@ -645,7 +887,7 @@ export default function App() {
     async (
       sessionId: string,
       scans: XnatScan[],
-      context: { projectId: string; subjectId: string; sessionLabel: string },
+      context: { projectId: string; subjectId: string; sessionLabel: string; projectName?: string; subjectLabel?: string },
     ) => {
       if (!isConnected) return;
 
@@ -653,12 +895,16 @@ export default function App() {
         setLoading(true);
         setLoadError(null);
 
-        // Separate SEG scans from imaging scans
-        const imagingScans = scans.filter((s) => !isSegScan(s));
+        // Separate derived scans (SEG, RTSTRUCT) from imaging scans
+        const imagingScans = scans.filter((s) => !isDerivedScan(s));
         const segScans = scans.filter((s) => isSegScan(s));
+        const rtStructScans = scans.filter((s) => isRtStructScan(s));
 
         if (segScans.length > 0) {
           console.log(`[App] Found ${segScans.length} SEG scan(s) — will auto-load as overlays`);
+        }
+        if (rtStructScans.length > 0) {
+          console.log(`[App] Found ${rtStructScans.length} RTSTRUCT scan(s) — will auto-load as contour overlays`);
         }
 
         // Match imaging scans to a hanging protocol
@@ -682,6 +928,20 @@ export default function App() {
           sessionLabel: context.sessionLabel,
           scanId: imagingScans[0]?.id ?? scans[0]?.id ?? '1',
         });
+
+        // Remember this session for "Load Recent" on next visit
+        const serverUrl = useConnectionStore.getState().connection?.serverUrl;
+        if (serverUrl) {
+          saveRecentSessionUtil(serverUrl, {
+            projectId: context.projectId,
+            projectName: context.projectName ?? context.projectId,
+            subjectId: context.subjectId,
+            subjectLabel: context.subjectLabel ?? context.subjectId,
+            sessionId,
+            sessionLabel: context.sessionLabel,
+          });
+          refreshBookmarks();
+        }
 
         // Fetch imageIds for all assigned panels in parallel
         const loadPromises = Array.from(assignments.entries()).map(
@@ -785,6 +1045,80 @@ export default function App() {
             if (!segStore.showPanel) segStore.togglePanel();
           }
         }
+
+        // ─── Auto-load RTSTRUCT scans as contour overlays ──────────
+        if (rtStructScans.length > 0) {
+          // Wait for viewports to be ready (may already be ready from SEG loading above)
+          if (segScans.length === 0) {
+            let attempts = 0;
+            while (attempts < 40) {
+              const allReady = results.every(({ panelIdx }) => {
+                const vp = viewportService.getViewport(panelId(panelIdx));
+                return vp && vp.getImageIds().length > 0;
+              });
+              if (allReady) break;
+              await new Promise((r) => setTimeout(r, 100));
+              attempts++;
+            }
+            await new Promise((r) => setTimeout(r, 300));
+
+            // Pre-load all source images
+            const allImageIds = Array.from(scanIdToPanelInfo.values()).flatMap((p) => p.ids);
+            await preloadImages(allImageIds);
+          }
+
+          let rtLoaded = false;
+
+          for (const rtScan of rtStructScans) {
+            try {
+              // Download the RTSTRUCT file
+              const arrayBuffer = await downloadSegArrayBuffer(sessionId, rtScan.id);
+              console.log(`[App] Downloaded RTSTRUCT #${rtScan.id} (${arrayBuffer.byteLength} bytes)`);
+
+              // Parse the RTSTRUCT
+              const parsed = rtStructService.parseRtStruct(arrayBuffer);
+
+              // Match to a loaded panel via Referenced Series UID
+              let matchedPanel: { pid: string; ids: string[] } | null = null;
+              if (parsed.referencedSeriesUID) {
+                const match = findPanelBySeriesUID(parsed.referencedSeriesUID, newPanelImageIds);
+                if (match) {
+                  matchedPanel = { pid: match.panelId, ids: match.imageIds };
+                  console.log(`[App] RTSTRUCT #${rtScan.id} matched to ${match.panelId} via SeriesInstanceUID`);
+                }
+              }
+
+              // Fallback: use the first panel with images
+              if (!matchedPanel) {
+                const firstEntry = Object.entries(newPanelImageIds).find(([, ids]) => ids.length > 0);
+                if (firstEntry) {
+                  matchedPanel = { pid: firstEntry[0], ids: firstEntry[1] };
+                  console.log(`[App] RTSTRUCT #${rtScan.id} falling back to first panel: ${firstEntry[0]}`);
+                }
+              }
+
+              if (!matchedPanel) {
+                console.warn(`[App] Could not find source images for RTSTRUCT #${rtScan.id}, skipping`);
+                continue;
+              }
+
+              // Pre-load source images
+              await preloadImages(matchedPanel.ids);
+
+              const { segmentationId, firstReferencedImageId } =
+                await rtStructService.loadRtStructAsContours(parsed, matchedPanel.ids, matchedPanel.pid);
+              await jumpViewportToReferencedImage(matchedPanel.pid, firstReferencedImageId);
+              rtLoaded = true;
+            } catch (err) {
+              console.error(`[App] Failed to load RTSTRUCT #${rtScan.id}:`, err);
+            }
+          }
+
+          if (rtLoaded) {
+            const segStore = useSegmentationStore.getState();
+            if (!segStore.showPanel) segStore.togglePanel();
+          }
+        }
       } catch (err) {
         console.error('Session load failed:', err);
         setLoadError(err instanceof Error ? err.message : String(err));
@@ -792,7 +1126,7 @@ export default function App() {
         setLoading(false);
       }
     },
-    [isConnected],
+    [isConnected, refreshBookmarks],
   );
 
   /**
@@ -1022,6 +1356,155 @@ export default function App() {
           />
         </label>
 
+        {/* Bookmarks dropdown — pinned items & recent sessions */}
+        {(pinnedItems.length > 0 || recentSessions.length > 0) && (
+          <div ref={bookmarksRef} className="relative">
+            <button
+              onClick={() => setShowBookmarks((v) => !v)}
+              className={`flex items-center gap-1 text-xs font-medium px-2 py-1.5 rounded whitespace-nowrap transition-colors ${
+                showBookmarks
+                  ? 'bg-amber-600/20 text-amber-300'
+                  : 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200'
+              }`}
+              title="Pinned & Recent"
+            >
+              <IconPin className="w-3.5 h-3.5" filled={pinnedItems.length > 0} />
+              <IconChevronDown className="w-3 h-3" />
+            </button>
+
+            {showBookmarks && (
+              <div className="absolute top-full left-0 mt-1 w-72 bg-zinc-900 border border-zinc-700 rounded-lg shadow-xl z-50 py-1 max-h-80 overflow-y-auto">
+                {/* Pinned items section */}
+                {pinnedItems.length > 0 && (
+                  <>
+                    <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+                      Pinned
+                    </div>
+                    {pinnedItems.map((item) => {
+                      const key =
+                        item.type === 'project' ? `pin-p-${item.projectId}` :
+                        item.type === 'subject' ? `pin-s-${item.subjectId}` :
+                        `pin-x-${item.sessionId}`;
+                      const label =
+                        item.type === 'project' ? item.projectName :
+                        item.type === 'subject' ? `${item.subjectLabel || item.subjectId}` :
+                        `${item.sessionLabel || item.sessionId}`;
+                      const sublabel =
+                        item.type === 'project' ? null :
+                        item.type === 'subject' ? item.projectName :
+                        `${item.subjectLabel || item.subjectId} / ${item.projectName}`;
+                      const icon =
+                        item.type === 'project' ? 'text-blue-400' :
+                        item.type === 'subject' ? 'text-violet-400' :
+                        'text-emerald-400';
+                      const typeLabel =
+                        item.type === 'project' ? 'P' :
+                        item.type === 'subject' ? 'S' : 'E';
+
+                      return (
+                        <div
+                          key={key}
+                          className="flex items-center gap-2 px-3 py-1.5 hover:bg-zinc-800 cursor-pointer group"
+                          onClick={() => {
+                            const target: NavigateToTarget = {
+                              type: item.type,
+                              projectId: item.projectId,
+                              projectName: item.projectName,
+                              ...(item.type !== 'project' && {
+                                subjectId: item.subjectId,
+                                subjectLabel: item.subjectLabel,
+                              }),
+                              ...(item.type === 'session' && {
+                                sessionId: item.sessionId,
+                                sessionLabel: item.sessionLabel,
+                              }),
+                            };
+                            handleBookmarkNavigate(target);
+                          }}
+                        >
+                          <span className={`text-[10px] font-bold ${icon} shrink-0 w-4 text-center`}>
+                            {typeLabel}
+                          </span>
+                          <div className="flex-1 min-w-0">
+                            <div className="text-xs text-zinc-200 truncate">{label}</div>
+                            {sublabel && (
+                              <div className="text-[10px] text-zinc-500 truncate">{sublabel}</div>
+                            )}
+                          </div>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleTogglePin(item);
+                            }}
+                            className="text-zinc-500 hover:text-red-400 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+                            title="Unpin"
+                          >
+                            <svg className="w-3 h-3" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+                              <line x1="4" y1="4" x2="12" y2="12" />
+                              <line x1="12" y1="4" x2="4" y2="12" />
+                            </svg>
+                          </button>
+                        </div>
+                      );
+                    })}
+                  </>
+                )}
+
+                {/* Recent sessions section */}
+                {recentSessions.length > 0 && (
+                  <>
+                    {pinnedItems.length > 0 && (
+                      <div className="border-t border-zinc-800 my-1" />
+                    )}
+                    <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+                      Recent
+                    </div>
+                    {recentSessions.map((recent) => (
+                      <div
+                        key={`recent-${recent.sessionId}`}
+                        className="flex items-center gap-2 px-3 py-1.5 hover:bg-zinc-800 cursor-pointer group"
+                        onClick={() => {
+                          handleBookmarkNavigate({
+                            type: 'session',
+                            projectId: recent.projectId,
+                            projectName: recent.projectName,
+                            subjectId: recent.subjectId,
+                            subjectLabel: recent.subjectLabel,
+                            sessionId: recent.sessionId,
+                            sessionLabel: recent.sessionLabel,
+                          });
+                        }}
+                      >
+                        <span className="text-[10px] font-bold text-emerald-400 shrink-0 w-4 text-center">
+                          E
+                        </span>
+                        <div className="flex-1 min-w-0">
+                          <div className="text-xs text-zinc-200 truncate">
+                            {recent.sessionLabel || recent.sessionId}
+                          </div>
+                          <div className="text-[10px] text-zinc-500 truncate">
+                            {recent.subjectLabel || recent.subjectId} / {recent.projectName || recent.projectId}
+                          </div>
+                        </div>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handlePromoteRecent(recent);
+                          }}
+                          className="text-zinc-500 hover:text-amber-400 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+                          title="Pin this session"
+                        >
+                          <IconPin className="w-3 h-3" />
+                        </button>
+                      </div>
+                    ))}
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
         {/* Spacer pushes status info to the right */}
         <div className="flex-1" />
 
@@ -1058,7 +1541,14 @@ export default function App() {
         {/* XNAT Browser sidebar */}
         {showBrowser && (
           <div className="w-72 shrink-0 border-r border-zinc-800 bg-zinc-950 overflow-hidden flex flex-col">
-            <XnatBrowser onLoadScan={loadFromXnatScan} onLoadSession={loadSessionFromXnat} />
+            <XnatBrowser
+              onLoadScan={loadFromXnatScan}
+              onLoadSession={loadSessionFromXnat}
+              navigateTo={navigateTo}
+              onNavigateComplete={() => setNavigateTo(null)}
+              pinnedItems={pinnedItems}
+              onTogglePin={handleTogglePin}
+            />
           </div>
         )}
 

--- a/src/renderer/components/connection/XnatBrowser.tsx
+++ b/src/renderer/components/connection/XnatBrowser.tsx
@@ -14,18 +14,32 @@ import type {
   XnatScan,
 } from '@shared/types/xnat';
 import { useViewerStore } from '../../stores/viewerStore';
+import { useConnectionStore } from '../../stores/connectionStore';
+import { IconPin } from '../icons';
+import type { PinnedItem, NavigateToTarget } from '../../lib/pinnedItems';
+import { isPinned } from '../../lib/pinnedItems';
+
+// ─── Component Props ──────────────────────────────────────────────
 
 interface XnatBrowserProps {
   onLoadScan: (sessionId: string, scanId: string, scan: XnatScan, context: {
     projectId: string;
     subjectId: string;
     sessionLabel: string;
+    projectName?: string;
+    subjectLabel?: string;
   }) => void;
   onLoadSession?: (sessionId: string, scans: XnatScan[], context: {
     projectId: string;
     subjectId: string;
     sessionLabel: string;
+    projectName?: string;
+    subjectLabel?: string;
   }) => void;
+  navigateTo?: NavigateToTarget | null;
+  onNavigateComplete?: () => void;
+  pinnedItems?: PinnedItem[];
+  onTogglePin?: (item: PinnedItem) => void;
 }
 
 type Level = 'projects' | 'subjects' | 'sessions' | 'scans';
@@ -98,6 +112,25 @@ function ClearIcon() {
   );
 }
 
+function RefreshIcon({ spinning }: { spinning?: boolean }) {
+  return (
+    <svg
+      className={`w-3.5 h-3.5 ${spinning ? 'animate-spin' : ''}`}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M2.5 8a5.5 5.5 0 0 1 9.3-4" />
+      <polyline points="12 2 12 5 9 5" />
+      <path d="M13.5 8a5.5 5.5 0 0 1-9.3 4" />
+      <polyline points="4 14 4 11 7 11" />
+    </svg>
+  );
+}
+
 // ─── Loading Spinner ──────────────────────────────────────────────
 
 function Spinner() {
@@ -113,7 +146,14 @@ function Spinner() {
 
 // ─── Component ────────────────────────────────────────────────────
 
-export default function XnatBrowser({ onLoadScan, onLoadSession }: XnatBrowserProps) {
+export default function XnatBrowser({
+  onLoadScan,
+  onLoadSession,
+  navigateTo,
+  onNavigateComplete,
+  pinnedItems: pinnedItemsProp,
+  onTogglePin,
+}: XnatBrowserProps) {
   const [level, setLevel] = useState<Level>('projects');
   const [loading, setLoading] = useState(false);
   const [search, setSearch] = useState('');
@@ -129,6 +169,66 @@ export default function XnatBrowser({ onLoadScan, onLoadSession }: XnatBrowserPr
   const [selectedProject, setSelectedProject] = useState<XnatProject | null>(null);
   const [selectedSubject, setSelectedSubject] = useState<XnatSubject | null>(null);
   const [selectedSession, setSelectedSession] = useState<XnatSession | null>(null);
+
+  const connection = useConnectionStore((s) => s.connection);
+  const pins = pinnedItemsProp ?? [];
+
+  // ─── Navigate-to Handler ───────────────────────────────────────
+  useEffect(() => {
+    if (!navigateTo) return;
+
+    async function doNavigate(target: NavigateToTarget) {
+      setLoading(true);
+      try {
+        if (target.type === 'project') {
+          const project: XnatProject = { id: target.projectId, name: target.projectName };
+          setSelectedProject(project);
+          setSelectedSubject(null);
+          setSelectedSession(null);
+          setLevel('subjects');
+          const data = await window.electronAPI.xnat.getSubjects(target.projectId);
+          setSubjects(data);
+        } else if (target.type === 'subject' && target.subjectId != null) {
+          const project: XnatProject = { id: target.projectId, name: target.projectName };
+          const subject: XnatSubject = { id: target.subjectId, label: target.subjectLabel ?? '', projectId: target.projectId };
+          setSelectedProject(project);
+          setSelectedSubject(subject);
+          setSelectedSession(null);
+          setLevel('sessions');
+          const data = await window.electronAPI.xnat.getSessions(target.projectId, target.subjectId);
+          setSessions(data);
+        } else if (target.type === 'session' && target.subjectId != null && target.sessionId != null) {
+          const project: XnatProject = { id: target.projectId, name: target.projectName };
+          const subject: XnatSubject = { id: target.subjectId, label: target.subjectLabel ?? '', projectId: target.projectId };
+          const session: XnatSession = { id: target.sessionId, label: target.sessionLabel ?? '', projectId: target.projectId, subjectId: target.subjectId };
+          setSelectedProject(project);
+          setSelectedSubject(subject);
+          setSelectedSession(session);
+          setLevel('scans');
+          const data = await window.electronAPI.xnat.getScans(target.sessionId);
+          setScans(data);
+          // Auto-load session
+          if (onLoadSession && data.length > 0) {
+            onLoadSession(target.sessionId, data, {
+              projectId: target.projectId,
+              subjectId: target.subjectId!,
+              sessionLabel: target.sessionLabel!,
+              projectName: target.projectName,
+              subjectLabel: target.subjectLabel,
+            });
+          }
+        }
+      } catch (err) {
+        console.error('[XnatBrowser] Navigation failed:', err);
+      } finally {
+        setLoading(false);
+        onNavigateComplete?.();
+      }
+    }
+
+    doNavigate(navigateTo);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [navigateTo]);
 
   // Clear search when level changes
   useEffect(() => {
@@ -252,6 +352,8 @@ export default function XnatBrowser({ onLoadScan, onLoadSession }: XnatBrowserPr
         projectId: selectedProject.id,
         subjectId: selectedSubject.id,
         sessionLabel: selectedSession.label,
+        projectName: selectedProject.name,
+        subjectLabel: selectedSubject.label,
       });
     },
     [selectedSession, selectedProject, selectedSubject, onLoadScan],
@@ -274,6 +376,60 @@ export default function XnatBrowser({ onLoadScan, onLoadSession }: XnatBrowserPr
   function goToSessions() {
     setLevel('sessions');
     setSelectedSession(null);
+  }
+
+  // Refresh the current level's data
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      if (level === 'projects') {
+        const data = await window.electronAPI.xnat.getProjects();
+        setProjects(data);
+      } else if (level === 'subjects' && selectedProject) {
+        const data = await window.electronAPI.xnat.getSubjects(selectedProject.id);
+        setSubjects(data);
+      } else if (level === 'sessions' && selectedProject && selectedSubject) {
+        const data = await window.electronAPI.xnat.getSessions(selectedProject.id, selectedSubject.id);
+        setSessions(data);
+      } else if (level === 'scans' && selectedSession) {
+        const data = await window.electronAPI.xnat.getScans(selectedSession.id);
+        setScans(data);
+      }
+    } catch (err) {
+      console.error(`Failed to refresh ${level}:`, err);
+    } finally {
+      setLoading(false);
+    }
+  }, [level, selectedProject, selectedSubject, selectedSession]);
+
+  // ─── Pin Helpers ───────────────────────────────────────────────
+  const serverUrl = connection?.serverUrl ?? '';
+
+  function makePinItem(type: 'project', project: XnatProject): PinnedItem;
+  function makePinItem(type: 'subject', subject: XnatSubject): PinnedItem;
+  function makePinItem(type: 'session', session: XnatSession): PinnedItem;
+  function makePinItem(type: PinnedItem['type'], item: XnatProject | XnatSubject | XnatSession): PinnedItem {
+    if (type === 'project') {
+      const p = item as XnatProject;
+      return { type: 'project', serverUrl, projectId: p.id, projectName: p.name, timestamp: Date.now() };
+    } else if (type === 'subject') {
+      const s = item as XnatSubject;
+      return {
+        type: 'subject', serverUrl,
+        projectId: selectedProject?.id ?? '', projectName: selectedProject?.name ?? '',
+        subjectId: s.id, subjectLabel: s.label,
+        timestamp: Date.now(),
+      };
+    } else {
+      const sess = item as XnatSession;
+      return {
+        type: 'session', serverUrl,
+        projectId: selectedProject?.id ?? '', projectName: selectedProject?.name ?? '',
+        subjectId: selectedSubject?.id ?? '', subjectLabel: selectedSubject?.label ?? '',
+        sessionId: sess.id, sessionLabel: sess.label,
+        timestamp: Date.now(),
+      };
+    }
   }
 
   // Label for the search placeholder
@@ -340,33 +496,43 @@ export default function XnatBrowser({ onLoadScan, onLoadSession }: XnatBrowserPr
         )}
       </div>
 
-      {/* Search bar */}
+      {/* Search bar + Refresh */}
       {!loading && totalCount > 0 && (
         <div className="px-3 py-2 border-b border-zinc-800 shrink-0">
-          <div className="relative">
-            <div className="absolute left-2 top-1/2 -translate-y-1/2 pointer-events-none">
-              <SearchIcon />
+          <div className="flex items-center gap-1.5">
+            <div className="relative flex-1">
+              <div className="absolute left-2 top-1/2 -translate-y-1/2 pointer-events-none">
+                <SearchIcon />
+              </div>
+              <input
+                ref={searchRef}
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder={searchPlaceholder}
+                className="w-full pl-7 pr-7 py-1.5 text-xs bg-zinc-900 border border-zinc-700 rounded-md text-zinc-300 placeholder-zinc-600 outline-none focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500/30"
+              />
+              {search && (
+                <button
+                  onClick={() => {
+                    setSearch('');
+                    searchRef.current?.focus();
+                  }}
+                  className="absolute right-1.5 top-1/2 -translate-y-1/2 p-0.5 text-zinc-500 hover:text-zinc-300 transition-colors rounded hover:bg-zinc-700"
+                  title="Clear search"
+                >
+                  <ClearIcon />
+                </button>
+              )}
             </div>
-            <input
-              ref={searchRef}
-              type="text"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder={searchPlaceholder}
-              className="w-full pl-7 pr-7 py-1.5 text-xs bg-zinc-900 border border-zinc-700 rounded-md text-zinc-300 placeholder-zinc-600 outline-none focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500/30"
-            />
-            {search && (
-              <button
-                onClick={() => {
-                  setSearch('');
-                  searchRef.current?.focus();
-                }}
-                className="absolute right-1.5 top-1/2 -translate-y-1/2 p-0.5 text-zinc-500 hover:text-zinc-300 transition-colors rounded hover:bg-zinc-700"
-                title="Clear search"
-              >
-                <ClearIcon />
-              </button>
-            )}
+            <button
+              onClick={refresh}
+              disabled={loading}
+              className="p-1.5 text-zinc-500 hover:text-zinc-300 hover:bg-zinc-700 rounded-md transition-colors disabled:opacity-40 shrink-0"
+              title={`Refresh ${level}`}
+            >
+              <RefreshIcon />
+            </button>
           </div>
           {q && (
             <div className="text-[10px] text-zinc-600 mt-1 px-0.5">
@@ -401,6 +567,22 @@ export default function XnatBrowser({ onLoadScan, onLoadSession }: XnatBrowserPr
                     </div>
                   </div>
                 )}
+                renderAction={onTogglePin ? (p) => {
+                  const pinned = isPinned(pins, 'project', p.id);
+                  return (
+                    <button
+                      onClick={() => onTogglePin(makePinItem('project', p))}
+                      className={`p-1 rounded transition-colors ${
+                        pinned
+                          ? 'text-amber-400 hover:text-amber-300 opacity-100'
+                          : 'text-zinc-600 hover:text-amber-400 opacity-0 group-hover:opacity-100'
+                      }`}
+                      title={pinned ? 'Unpin' : 'Pin'}
+                    >
+                      <IconPin className="w-3 h-3" filled={pinned} />
+                    </button>
+                  );
+                } : undefined}
                 onSelect={selectProject}
                 emptyMessage={q ? `No projects matching "${search}"` : 'No accessible projects found'}
               />
@@ -420,6 +602,22 @@ export default function XnatBrowser({ onLoadScan, onLoadSession }: XnatBrowserPr
                     </div>
                   </div>
                 )}
+                renderAction={onTogglePin ? (s) => {
+                  const pinned = isPinned(pins, 'subject', s.id);
+                  return (
+                    <button
+                      onClick={() => onTogglePin(makePinItem('subject', s))}
+                      className={`p-1 rounded transition-colors ${
+                        pinned
+                          ? 'text-amber-400 hover:text-amber-300 opacity-100'
+                          : 'text-zinc-600 hover:text-amber-400 opacity-0 group-hover:opacity-100'
+                      }`}
+                      title={pinned ? 'Unpin' : 'Pin'}
+                    >
+                      <IconPin className="w-3 h-3" filled={pinned} />
+                    </button>
+                  );
+                } : undefined}
                 onSelect={selectSubject}
                 emptyMessage={q ? `No subjects matching "${search}"` : 'No subjects found'}
               />
@@ -448,14 +646,33 @@ export default function XnatBrowser({ onLoadScan, onLoadSession }: XnatBrowserPr
                     </div>
                   </div>
                 )}
+                renderAction={onTogglePin ? (e) => {
+                  const pinned = isPinned(pins, 'session', e.id);
+                  return (
+                    <button
+                      onClick={() => onTogglePin(makePinItem('session', e))}
+                      className={`p-1 rounded transition-colors ${
+                        pinned
+                          ? 'text-amber-400 hover:text-amber-300 opacity-100'
+                          : 'text-zinc-600 hover:text-amber-400 opacity-0 group-hover:opacity-100'
+                      }`}
+                      title={pinned ? 'Unpin' : 'Pin'}
+                    >
+                      <IconPin className="w-3 h-3" filled={pinned} />
+                    </button>
+                  );
+                } : undefined}
                 onSelect={selectSession}
                 emptyMessage={q ? `No sessions matching "${search}"` : 'No sessions found'}
               />
             )}
 
             {level === 'scans' && onLoadSession && scans.length > 1 && selectedSession && (() => {
-              const imagingScans = scans.filter((s) => s.type?.toUpperCase() !== 'SEG');
-              const segCount = scans.length - imagingScans.length;
+              const imagingScans = scans.filter((s) => {
+                const t = s.type?.toUpperCase();
+                return t !== 'SEG' && t !== 'RTSTRUCT' && t !== 'RT';
+              });
+              const derivedCount = scans.length - imagingScans.length;
               return (
                 <div className="px-3 py-2.5 border-b border-zinc-800">
                   <button
@@ -465,13 +682,15 @@ export default function XnatBrowser({ onLoadScan, onLoadSession }: XnatBrowserPr
                           projectId: selectedProject.id,
                           subjectId: selectedSubject.id,
                           sessionLabel: selectedSession.label,
+                          projectName: selectedProject.name,
+                          subjectLabel: selectedSubject.label,
                         });
                       }
                     }}
                     className="w-full bg-blue-600 hover:bg-blue-500 text-white text-xs font-medium px-3 py-2 rounded-md transition-colors flex items-center justify-center gap-2"
                   >
                     <LoadAllIcon />
-                    Load All Scans ({imagingScans.length}{segCount > 0 ? ` + ${segCount} SEG` : ''})
+                    Load All Scans ({imagingScans.length}{derivedCount > 0 ? ` + ${derivedCount} derived` : ''})
                   </button>
                 </div>
               );
@@ -482,6 +701,8 @@ export default function XnatBrowser({ onLoadScan, onLoadSession }: XnatBrowserPr
                 items={filteredScans}
                 renderItem={(s) => {
                   const isSeg = s.type?.toUpperCase() === 'SEG';
+                  const isRT = s.type?.toUpperCase() === 'RTSTRUCT' || s.type?.toUpperCase() === 'RT';
+                  const isDerived = isSeg || isRT;
                   return (
                     <div className="flex items-center justify-between w-full gap-2">
                       <div className="flex items-start gap-2.5 min-w-0">
@@ -495,7 +716,12 @@ export default function XnatBrowser({ onLoadScan, onLoadSession }: XnatBrowserPr
                                 SEG
                               </span>
                             )}
-                            {s.modality && !isSeg && (
+                            {isRT && (
+                              <span className="ml-2 text-[10px] bg-green-500/20 text-green-300 px-1.5 py-0.5 rounded font-normal">
+                                RTSTRUCT
+                              </span>
+                            )}
+                            {s.modality && !isDerived && (
                               <span className="ml-2 text-[10px] bg-zinc-700/80 text-zinc-300 px-1.5 py-0.5 rounded font-normal">
                                 {s.modality}
                               </span>
@@ -527,11 +753,12 @@ export default function XnatBrowser({ onLoadScan, onLoadSession }: XnatBrowserPr
 interface ItemListProps<T> {
   items: T[];
   renderItem: (item: T) => React.ReactNode;
+  renderAction?: (item: T) => React.ReactNode;
   onSelect: (item: T) => void;
   emptyMessage: string;
 }
 
-function ItemList<T>({ items, renderItem, onSelect, emptyMessage }: ItemListProps<T>) {
+function ItemList<T>({ items, renderItem, renderAction, onSelect, emptyMessage }: ItemListProps<T>) {
   if (items.length === 0) {
     return (
       <div className="flex items-center justify-center py-8 text-zinc-600 text-xs">
@@ -543,13 +770,21 @@ function ItemList<T>({ items, renderItem, onSelect, emptyMessage }: ItemListProp
   return (
     <div className="divide-y divide-zinc-800/50">
       {items.map((item, i) => (
-        <button
+        <div
           key={i}
           onClick={() => onSelect(item)}
-          className="w-full text-left px-3 py-2.5 hover:bg-zinc-800/50 transition-colors"
+          className="w-full text-left px-3 py-2.5 hover:bg-zinc-800/50 transition-colors cursor-pointer flex items-center group"
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect(item); } }}
         >
-          {renderItem(item)}
-        </button>
+          <div className="flex-1 min-w-0">{renderItem(item)}</div>
+          {renderAction && (
+            <div className="shrink-0 ml-1" onClick={(e) => e.stopPropagation()}>
+              {renderAction(item)}
+            </div>
+          )}
+        </div>
       ))}
     </div>
   );

--- a/src/renderer/components/icons.tsx
+++ b/src/renderer/components/icons.tsx
@@ -510,6 +510,17 @@ export function XnatLogo({ className, size }: IconProps) {
   );
 }
 
+/** Pin — pushpin icon (filled or outline) */
+export function IconPin(props: IconProps & { filled?: boolean }) {
+  const p = defaults(props);
+  return (
+    <svg {...p} fill={props.filled ? 'currentColor' : 'none'}>
+      <path d="M9.5 2L13 5.5 9.5 9l-1-1-3 3.5L2 14l2.5-3.5L8 7.5l-1-1z" />
+      <line x1="10" y1="6" x2="13" y2="3" />
+    </svg>
+  );
+}
+
 /** Upload — arrow up into cloud */
 export function IconUpload(props: IconProps) {
   return (

--- a/src/renderer/components/viewer/SegmentationPanel.tsx
+++ b/src/renderer/components/viewer/SegmentationPanel.tsx
@@ -20,6 +20,7 @@ import { useSegmentationStore } from '../../stores/segmentationStore';
 import { useViewerStore } from '../../stores/viewerStore';
 import { useConnectionStore } from '../../stores/connectionStore';
 import { segmentationService } from '../../lib/cornerstone/segmentationService';
+import { rtStructService } from '../../lib/cornerstone/rtStructService';
 import { ToolName, LABELMAP_SEG_TOOLS } from '@shared/types/viewer';
 import {
   IconPlus,
@@ -251,6 +252,57 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
     }
   }, [xnatContext]);
 
+  const handleSaveRtStructLocal = useCallback(async (segmentationId: string) => {
+    setSaveMenuOpen(null);
+    setSaving(true);
+    try {
+      const base64 = await rtStructService.exportToRtStruct(segmentationId);
+      const result = await window.electronAPI.export.saveDicomRtStruct(base64, 'rtstruct.dcm');
+      if (result.ok && result.path) {
+        setToast({ message: `Saved RTSTRUCT to ${result.path.split('/').pop()}`, type: 'success' });
+      } else if (result.error) {
+        setToast({ message: `Save failed: ${result.error}`, type: 'error' });
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'RTSTRUCT export failed';
+      setToast({ message: msg, type: 'error' });
+      console.error('[SegmentationPanel] saveRtStructLocal error:', err);
+    } finally {
+      setSaving(false);
+    }
+  }, []);
+
+  const handleUploadRtStructXnat = useCallback(async (segmentationId: string) => {
+    setSaveMenuOpen(null);
+    if (!xnatContext) {
+      setToast({ message: 'No XNAT session context — load images from XNAT first', type: 'error' });
+      return;
+    }
+    setSaving(true);
+    try {
+      const base64 = await rtStructService.exportToRtStruct(segmentationId);
+      const result = await window.electronAPI.xnat.uploadDicomRtStruct(
+        xnatContext.projectId,
+        xnatContext.subjectId,
+        xnatContext.sessionId,
+        xnatContext.sessionLabel,
+        xnatContext.scanId,
+        base64,
+      );
+      if (result.ok) {
+        setToast({ message: 'Uploaded RTSTRUCT to XNAT successfully', type: 'success' });
+      } else {
+        setToast({ message: `Upload failed: ${result.error}`, type: 'error' });
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'RTSTRUCT upload failed';
+      setToast({ message: msg, type: 'error' });
+      console.error('[SegmentationPanel] uploadRtStructXnat error:', err);
+    } finally {
+      setSaving(false);
+    }
+  }, [xnatContext]);
+
   const isXnatConnected = connectionStatus === 'connected';
 
   return (
@@ -345,7 +397,35 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
                             className="w-full text-left px-3 py-1.5 text-zinc-300 hover:bg-zinc-800 transition-colors flex items-center gap-2 disabled:opacity-40 disabled:cursor-not-allowed"
                           >
                             <IconUpload className="w-3.5 h-3.5 text-zinc-400" />
-                            Upload to XNAT
+                            Upload SEG to XNAT
+                            {(!isXnatConnected || !xnatContext) && (
+                              <span className="text-[9px] text-zinc-600 ml-auto">
+                                {!isXnatConnected ? 'Not connected' : 'No session'}
+                              </span>
+                            )}
+                          </button>
+                          <div className="border-t border-zinc-700 my-1" />
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleSaveRtStructLocal(seg.segmentationId);
+                            }}
+                            disabled={saving}
+                            className="w-full text-left px-3 py-1.5 text-zinc-300 hover:bg-zinc-800 transition-colors flex items-center gap-2 disabled:opacity-40"
+                          >
+                            <IconSave className="w-3.5 h-3.5 text-green-400" />
+                            Save DICOM RTSTRUCT to file...
+                          </button>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleUploadRtStructXnat(seg.segmentationId);
+                            }}
+                            disabled={saving || !isXnatConnected || !xnatContext}
+                            className="w-full text-left px-3 py-1.5 text-zinc-300 hover:bg-zinc-800 transition-colors flex items-center gap-2 disabled:opacity-40 disabled:cursor-not-allowed"
+                          >
+                            <IconUpload className="w-3.5 h-3.5 text-green-400" />
+                            Upload RTSTRUCT to XNAT
                             {(!isXnatConnected || !xnatContext) && (
                               <span className="text-[9px] text-zinc-600 ml-auto">
                                 {!isXnatConnected ? 'Not connected' : 'No session'}

--- a/src/renderer/lib/cornerstone/rtStructService.ts
+++ b/src/renderer/lib/cornerstone/rtStructService.ts
@@ -1,0 +1,800 @@
+/**
+ * RT Structure Set Service — parses, loads, and exports DICOM RTSTRUCT files.
+ *
+ * Parse:  Binary DICOM → RtStructParseResult (ROIs + contours in world coordinates)
+ * Load:   RtStructParseResult → Cornerstone contour segmentation annotations
+ * Export: Cornerstone contour segmentation → DICOM RTSTRUCT binary (base64)
+ *
+ * The parser uses dicom-parser directly (no Cornerstone adapter for RTSTRUCT import).
+ * The exporter uses @cornerstonejs/adapters' generateRTSSFromRepresentation().
+ */
+import * as dicomParser from 'dicom-parser';
+import {
+  metaData,
+  utilities as csUtilities,
+  getEnabledElementByViewportId,
+} from '@cornerstonejs/core';
+import type { Types as CoreTypes } from '@cornerstonejs/core';
+import {
+  segmentation as csSegmentation,
+  annotation as csAnnotation,
+  Enums as ToolEnums,
+  utilities as csToolUtilities,
+} from '@cornerstonejs/tools';
+import { data as dcmjsData } from 'dcmjs';
+import { useSegmentationStore } from '../../stores/segmentationStore';
+import { segmentationService } from './segmentationService';
+
+// ─── Bridge: register a global 'frameModule' metadata provider ──────────
+//
+// The @cornerstonejs/adapters referencedMetadataProvider expects
+// metaData.get('frameModule', imageId) → { sopClassUID, sopInstanceUID, ... }
+// but the DICOMweb image loader doesn't register this module. It puts
+// SOP UID data in 'sopCommonModule' instead. We register a low-priority
+// provider that bridges the gap.
+metaData.addProvider((type: string, imageId: string) => {
+  if (type !== 'frameModule') return undefined;
+  const sop = metaData.get('sopCommonModule', imageId) as
+    | { sopClassUID?: string; sopInstanceUID?: string }
+    | undefined;
+  if (!sop) return undefined;
+  return {
+    sopClassUID: sop.sopClassUID ?? '',
+    sopInstanceUID: sop.sopInstanceUID ?? '',
+    frameNumber: 1,
+    numberOfFrames: 1,
+  };
+}, 100); // priority 100 — low enough to not override real providers
+
+// ─── Types ──────────────────────────────────────────────────────
+
+export interface RtStructContour {
+  /** Flat coordinate array [x,y,z, x,y,z, ...] in DICOM LPS world coordinates */
+  points: number[];
+  /** SOP Instance UID of the referenced CT/MR image for this contour slice */
+  referencedSOPInstanceUID: string | null;
+  /** Contour geometric type (e.g. 'CLOSED_PLANAR') */
+  geometricType: string;
+}
+
+export interface RtStructROI {
+  roiNumber: number;
+  name: string;
+  /** Display color [R, G, B] 0-255 */
+  color: [number, number, number];
+  /** RT ROI Interpreted Type (e.g. 'ORGAN', 'PTV', 'CTV', 'EXTERNAL') */
+  interpretedType: string;
+  contours: RtStructContour[];
+}
+
+export interface RtStructParseResult {
+  rois: RtStructROI[];
+  /** Series Instance UID of the referenced imaging series */
+  referencedSeriesUID: string | null;
+  structureSetLabel: string;
+  structureSetName: string;
+}
+
+export interface LoadedRtStruct {
+  segmentationId: string;
+  /** A referenced image ID from the first contour (for viewport scrolling) */
+  firstReferencedImageId: string | null;
+}
+
+// ─── DICOM Tag Helpers ──────────────────────────────────────────
+
+// RTSTRUCT sequence tags (DICOM group 3006)
+const TAG = {
+  // Structure Set ROI Sequence
+  StructureSetROISequence: 'x30060020',
+  ROINumber: 'x30060022',
+  ROIName: 'x30060026',
+  ReferencedFrameOfReferenceUID_ROI: 'x30060024',
+
+  // ROI Contour Sequence
+  ROIContourSequence: 'x30060039',
+  ReferencedROINumber: 'x30060084',
+  ROIDisplayColor: 'x3006002a',
+
+  // Contour Sequence (within ROI Contour)
+  ContourSequence: 'x30060040',
+  ContourGeometricType: 'x30060042',
+  NumberOfContourPoints: 'x30060046',
+  ContourData: 'x30060050',
+
+  // Contour Image Sequence (within Contour)
+  ContourImageSequence: 'x30060016',
+  ReferencedSOPInstanceUID: 'x00081155',
+
+  // RT ROI Observations Sequence
+  RTROIObservationsSequence: 'x30060080',
+  ObservationNumber: 'x30060082',
+  RTROIInterpretedType: 'x300600a4',
+
+  // Referenced Frame of Reference Sequence (for getting Series UID)
+  ReferencedFrameOfReferenceSequence: 'x30060010',
+  RTReferencedStudySequence: 'x30060012',
+  RTReferencedSeriesSequence: 'x30060014',
+  SeriesInstanceUID: 'x0020000e',
+
+  // Referenced Series Sequence (0008,1115) — flat, used by Cornerstone adapters export
+  ReferencedSeriesSequence: 'x00081115',
+
+  // Structure Set metadata
+  StructureSetLabel: 'x30060002',
+  StructureSetName: 'x30060004',
+};
+
+// ─── Default colors for ROIs without color ──────────────────────
+
+const DEFAULT_ROI_COLORS: [number, number, number][] = [
+  [220, 50, 50],    // Red
+  [50, 200, 50],    // Green
+  [50, 100, 220],   // Blue
+  [230, 200, 40],   // Yellow
+  [200, 50, 200],   // Magenta
+  [50, 200, 200],   // Cyan
+  [240, 140, 40],   // Orange
+  [150, 80, 200],   // Purple
+  [50, 220, 130],   // Spring Green
+  [255, 130, 130],  // Light Red
+];
+
+let rtStructCounter = 0;
+
+// ─── Parse ──────────────────────────────────────────────────────
+
+/**
+ * Parse a DICOM RTSTRUCT binary into a structured result.
+ * Uses dicom-parser to read the raw DICOM dataset.
+ */
+function parseRtStruct(arrayBuffer: ArrayBuffer): RtStructParseResult {
+  const byteArray = new Uint8Array(arrayBuffer);
+  const dataSet = dicomParser.parseDicom(byteArray);
+
+  const structureSetLabel = dataSet.string(TAG.StructureSetLabel) ?? 'RT Structure Set';
+  const structureSetName = dataSet.string(TAG.StructureSetName) ?? '';
+
+  // ── Step 1: Parse StructureSetROISequence → map roiNumber → { name, frameOfRefUID }
+  const roiInfoMap = new Map<number, { name: string; frameOfRefUID: string }>();
+  const ssROISeq = dataSet.elements[TAG.StructureSetROISequence];
+  if (ssROISeq?.items) {
+    for (const item of ssROISeq.items) {
+      const ds = item.dataSet;
+      if (!ds) continue;
+      const num = ds.intString(TAG.ROINumber);
+      const name = ds.string(TAG.ROIName) ?? `ROI ${num}`;
+      const frameOfRefUID = ds.string(TAG.ReferencedFrameOfReferenceUID_ROI) ?? '';
+      if (num !== undefined) {
+        roiInfoMap.set(num, { name, frameOfRefUID });
+      }
+    }
+  }
+
+  // ── Step 2: Parse RTROIObservationsSequence → map roiNumber → interpretedType
+  const roiObsMap = new Map<number, string>();
+  const obsSeq = dataSet.elements[TAG.RTROIObservationsSequence];
+  if (obsSeq?.items) {
+    for (const item of obsSeq.items) {
+      const ds = item.dataSet;
+      if (!ds) continue;
+      const refROI = ds.intString(TAG.ReferencedROINumber);
+      const interpType = ds.string(TAG.RTROIInterpretedType) ?? '';
+      if (refROI !== undefined) {
+        roiObsMap.set(refROI, interpType);
+      }
+    }
+  }
+
+  // ── Step 3: Parse ROIContourSequence → build ROIs with contours
+  const rois: RtStructROI[] = [];
+  const roiContourSeq = dataSet.elements[TAG.ROIContourSequence];
+  if (roiContourSeq?.items) {
+    for (const roiItem of roiContourSeq.items) {
+      const roiDs = roiItem.dataSet;
+      if (!roiDs) continue;
+
+      const refROINumber = roiDs.intString(TAG.ReferencedROINumber);
+      if (refROINumber === undefined) continue;
+
+      // Parse display color (backslash-delimited "R\G\B")
+      let color: [number, number, number] =
+        DEFAULT_ROI_COLORS[rois.length % DEFAULT_ROI_COLORS.length];
+      const colorStr = roiDs.string(TAG.ROIDisplayColor);
+      if (colorStr) {
+        const parts = colorStr.split('\\').map(Number);
+        if (parts.length >= 3 && parts.every((n) => !isNaN(n))) {
+          color = [parts[0], parts[1], parts[2]];
+        }
+      }
+
+      // Parse contours
+      const contours: RtStructContour[] = [];
+      const contourSeq = roiDs.elements[TAG.ContourSequence];
+      if (contourSeq?.items) {
+        for (const cItem of contourSeq.items) {
+          const cDs = cItem.dataSet;
+          if (!cDs) continue;
+
+          const geometricType = cDs.string(TAG.ContourGeometricType) ?? 'CLOSED_PLANAR';
+          const numPoints = cDs.intString(TAG.NumberOfContourPoints) ?? 0;
+
+          // Parse contour data (backslash-delimited floats: x1\y1\z1\x2\y2\z2\...)
+          const contourDataStr = cDs.string(TAG.ContourData);
+          const points: number[] = [];
+          if (contourDataStr) {
+            const vals = contourDataStr.split('\\');
+            for (const v of vals) {
+              points.push(parseFloat(v));
+            }
+          }
+
+          // Sanity check: points should be multiple of 3
+          if (points.length < 9 || points.length % 3 !== 0) {
+            console.warn(
+              `[rtStructService] Skipping contour with ${points.length} coordinates ` +
+              `(expected multiple of 3, >= 9 for a triangle)`,
+            );
+            continue;
+          }
+
+          // Get referenced SOP Instance UID
+          let referencedSOPInstanceUID: string | null = null;
+          const contourImageSeq = cDs.elements[TAG.ContourImageSequence];
+          if (contourImageSeq?.items?.[0]?.dataSet) {
+            referencedSOPInstanceUID =
+              contourImageSeq.items[0].dataSet.string(TAG.ReferencedSOPInstanceUID) ?? null;
+          }
+
+          contours.push({
+            points,
+            referencedSOPInstanceUID,
+            geometricType,
+          });
+        }
+      }
+
+      const info = roiInfoMap.get(refROINumber);
+      rois.push({
+        roiNumber: refROINumber,
+        name: info?.name ?? `ROI ${refROINumber}`,
+        color,
+        interpretedType: roiObsMap.get(refROINumber) ?? '',
+        contours,
+      });
+    }
+  }
+
+  // ── Step 4: Extract Referenced Series UID
+  const referencedSeriesUID = extractReferencedSeriesUID(dataSet);
+
+  console.log(
+    `[rtStructService] Parsed RTSTRUCT: "${structureSetLabel}"`,
+    `— ${rois.length} ROIs, ${rois.reduce((s, r) => s + r.contours.length, 0)} contours`,
+    referencedSeriesUID ? `(series: ${referencedSeriesUID})` : '(no series ref)',
+  );
+
+  return { rois, referencedSeriesUID, structureSetLabel, structureSetName };
+}
+
+/**
+ * Extract the referenced SeriesInstanceUID from the RTSTRUCT.
+ *
+ * Checks three locations (in order):
+ *
+ * 1. Traditional RTSTRUCT nested path:
+ *    ReferencedFrameOfReferenceSequence (3006,0010)
+ *      → RTReferencedStudySequence (3006,0012)
+ *        → RTReferencedSeriesSequence (3006,0014)
+ *          → SeriesInstanceUID (0020,000E)
+ *
+ * 2. Flat ReferencedSeriesSequence (0008,1115) at dataset root:
+ *    This is produced by Cornerstone adapters' RTSS export.
+ *    ReferencedSeriesSequence → SeriesInstanceUID (0020,000E)
+ *
+ * 3. Contour-level references: scan ContourImageSequence for
+ *    ReferencedSOPInstanceUID and look up the series UID from contours.
+ *    (Not implemented — would need SOP → Series mapping)
+ */
+function extractReferencedSeriesUID(
+  dataSet: ReturnType<typeof dicomParser.parseDicom>,
+): string | null {
+  // ── Method 1: Traditional nested RTSTRUCT path ──
+  const refFrameSeq = dataSet.elements[TAG.ReferencedFrameOfReferenceSequence];
+  if (refFrameSeq?.items?.length) {
+    for (const frameItem of refFrameSeq.items) {
+      const studySeq = frameItem.dataSet?.elements[TAG.RTReferencedStudySequence];
+      if (!studySeq?.items?.length) continue;
+
+      for (const studyItem of studySeq.items) {
+        const seriesSeq = studyItem.dataSet?.elements[TAG.RTReferencedSeriesSequence];
+        if (!seriesSeq?.items?.length) continue;
+
+        const uid = seriesSeq.items[0].dataSet?.string(TAG.SeriesInstanceUID);
+        if (uid) return uid;
+      }
+    }
+  }
+
+  // ── Method 2: Flat ReferencedSeriesSequence (0008,1115) at root ──
+  // Cornerstone adapters produce this format when exporting RTSTRUCT.
+  const refSeriesSeq = dataSet.elements[TAG.ReferencedSeriesSequence];
+  if (refSeriesSeq?.items?.length) {
+    for (const item of refSeriesSeq.items) {
+      const uid = item.dataSet?.string(TAG.SeriesInstanceUID);
+      if (uid) return uid;
+    }
+  }
+
+  return null;
+}
+
+// ─── Load ───────────────────────────────────────────────────────
+
+/**
+ * Build a lookup map from SOP Instance UID → Cornerstone imageId.
+ * Used to map RTSTRUCT contour references to viewport images.
+ */
+function buildSOPToImageIdMap(imageIds: string[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const imageId of imageIds) {
+    try {
+      const sopModule = metaData.get('sopCommonModule', imageId) as
+        | { sopInstanceUID?: string } | undefined;
+      if (sopModule?.sopInstanceUID) {
+        map.set(sopModule.sopInstanceUID, imageId);
+      }
+    } catch {
+      // Metadata not available for this image
+    }
+  }
+  return map;
+}
+
+/**
+ * Load a parsed RTSTRUCT as a Cornerstone contour segmentation.
+ *
+ * Creates one segmentation with one segment per ROI. Each contour becomes
+ * a PlanarFreehandContourSegmentationTool annotation registered in the
+ * segmentation's annotationUIDsMap.
+ */
+async function loadRtStructAsContours(
+  parsed: RtStructParseResult,
+  sourceImageIds: string[],
+  viewportId: string,
+): Promise<LoadedRtStruct> {
+  rtStructCounter++;
+  const segmentationId = `rtstruct_${Date.now()}_${rtStructCounter}`;
+
+  // Build SOP Instance UID → imageId lookup
+  const sopToImageId = buildSOPToImageIdMap(sourceImageIds);
+
+  // Get FrameOfReferenceUID from any source image
+  let frameOfReferenceUID = '';
+  for (const imageId of sourceImageIds) {
+    const planeMeta = metaData.get('imagePlaneModule', imageId) as
+      | { frameOfReferenceUID?: string } | undefined;
+    if (planeMeta?.frameOfReferenceUID) {
+      frameOfReferenceUID = planeMeta.frameOfReferenceUID;
+      break;
+    }
+  }
+
+  // Build segments config: one segment per ROI (1-indexed)
+  const segments: Record<number, any> = {};
+  const annotationUIDsMap = new Map<number, Set<string>>();
+  let firstReferencedImageId: string | null = null;
+
+  // Register segmentation with Cornerstone
+  const segLabel = parsed.structureSetLabel || `RTSTRUCT ${rtStructCounter}`;
+  for (let roiIdx = 0; roiIdx < parsed.rois.length; roiIdx++) {
+    const roi = parsed.rois[roiIdx];
+    const segmentIndex = roiIdx + 1; // 1-based
+    segments[segmentIndex] = {
+      segmentIndex,
+      label: roi.name,
+      locked: false,
+      active: segmentIndex === 1,
+      cachedStats: {},
+    };
+    annotationUIDsMap.set(segmentIndex, new Set<string>());
+  }
+
+  csSegmentation.addSegmentations([
+    {
+      segmentationId,
+      representation: {
+        type: ToolEnums.SegmentationRepresentations.Contour,
+        data: {
+          annotationUIDsMap,
+        } as any,
+      },
+      config: {
+        label: segLabel,
+        segments,
+      },
+    },
+  ]);
+
+  // Create contour annotations for each ROI
+  for (let roiIdx = 0; roiIdx < parsed.rois.length; roiIdx++) {
+    const roi = parsed.rois[roiIdx];
+    const segmentIndex = roiIdx + 1;
+    const annotationUIDSet = annotationUIDsMap.get(segmentIndex)!;
+
+    for (const contour of roi.contours) {
+      // Convert flat points to Point3 array
+      const polyline: CoreTypes.Point3[] = [];
+      for (let i = 0; i < contour.points.length; i += 3) {
+        polyline.push([
+          contour.points[i],
+          contour.points[i + 1],
+          contour.points[i + 2],
+        ] as CoreTypes.Point3);
+      }
+
+      if (polyline.length < 3) continue;
+
+      // Map SOP Instance UID → imageId
+      let referencedImageId = '';
+      if (contour.referencedSOPInstanceUID) {
+        referencedImageId = sopToImageId.get(contour.referencedSOPInstanceUID) ?? '';
+      }
+
+      // If no direct SOP mapping, try to find the closest image by Z position
+      if (!referencedImageId && polyline.length > 0) {
+        referencedImageId = findClosestImageByZ(polyline[0][2], sourceImageIds) ?? '';
+      }
+
+      if (!firstReferencedImageId && referencedImageId) {
+        firstReferencedImageId = referencedImageId;
+      }
+
+      const annotationUID = csUtilities.uuidv4();
+
+      // Create the annotation object matching Cornerstone's
+      // PlanarFreehandContourSegmentationTool format
+      const ann: any = {
+        annotationUID,
+        metadata: {
+          toolName: 'PlanarFreehandContourSegmentationTool',
+          referencedImageId,
+          FrameOfReferenceUID: frameOfReferenceUID,
+        },
+        data: {
+          contour: {
+            polyline,
+            closed: contour.geometricType === 'CLOSED_PLANAR' ||
+                    contour.geometricType === 'CLOSED_PLANAR ',
+          },
+          segmentation: {
+            segmentationId,
+            segmentIndex,
+          },
+          handles: {
+            points: [],
+            activeHandleIndex: null,
+            textBox: {
+              hasMoved: false,
+              worldPosition: [0, 0, 0] as CoreTypes.Point3,
+              worldBoundingBox: {
+                topLeft: [0, 0, 0] as CoreTypes.Point3,
+                topRight: [0, 0, 0] as CoreTypes.Point3,
+                bottomLeft: [0, 0, 0] as CoreTypes.Point3,
+                bottomRight: [0, 0, 0] as CoreTypes.Point3,
+              },
+            },
+          },
+        },
+        highlighted: false,
+        isLocked: false,
+        isVisible: true,
+        invalidated: false,
+      };
+
+      // Register annotation with Cornerstone's annotation state
+      csAnnotation.state.addAnnotation(ann, viewportId);
+      annotationUIDSet.add(annotationUID);
+    }
+  }
+
+  // Track source imageIds for re-export
+  segmentationService.trackSourceImageIds(segmentationId, sourceImageIds);
+
+  // Add contour representation to viewport
+  try {
+    csSegmentation.addContourRepresentationToViewport(viewportId, [
+      { segmentationId },
+    ]);
+  } catch (err) {
+    console.error('[rtStructService] Failed to add contour representation:', err);
+  }
+
+  // Set as active segmentation
+  try {
+    csSegmentation.activeSegmentation.setActiveSegmentation(viewportId, segmentationId);
+  } catch (err) {
+    console.debug('[rtStructService] setActiveSegmentation:', err);
+  }
+
+  // Set segment colors
+  for (let roiIdx = 0; roiIdx < parsed.rois.length; roiIdx++) {
+    const roi = parsed.rois[roiIdx];
+    const segmentIndex = roiIdx + 1;
+    try {
+      csSegmentation.config.color.setSegmentIndexColor(
+        viewportId,
+        segmentationId,
+        segmentIndex,
+        [roi.color[0], roi.color[1], roi.color[2], 255] as any,
+      );
+    } catch {
+      // Color setting may fail if representation not ready
+    }
+  }
+
+  // Apply contour style
+  segmentationService.updateContourStyle();
+
+  // Trigger render
+  try {
+    csSegmentation.triggerSegmentationEvents.triggerSegmentationDataModified(segmentationId);
+    csToolUtilities.segmentation.triggerSegmentationRender(viewportId);
+    const enabledEl = getEnabledElementByViewportId(viewportId);
+    const vp = enabledEl?.viewport as any;
+    vp?.render?.();
+  } catch (err) {
+    console.debug('[rtStructService] render trigger:', err);
+  }
+
+  // Update store
+  const store = useSegmentationStore.getState();
+  store.setActiveSegmentation(segmentationId);
+  store.setActiveSegmentIndex(1);
+  csSegmentation.segmentIndex.setActiveSegmentIndex(segmentationId, 1);
+
+  // Sync segmentations to store
+  segmentationService.sync();
+
+  console.log(
+    `[rtStructService] Loaded RTSTRUCT as contour segmentation: ${segmentationId}`,
+    `(${parsed.rois.length} ROIs, ${parsed.rois.reduce((s, r) => s + r.contours.length, 0)} contours)`,
+  );
+
+  return { segmentationId, firstReferencedImageId };
+}
+
+/**
+ * Find the source image closest to a given Z position (slice location).
+ */
+function findClosestImageByZ(z: number, imageIds: string[]): string | null {
+  let bestId: string | null = null;
+  let bestDist = Infinity;
+
+  for (const imageId of imageIds) {
+    try {
+      const planeMeta = metaData.get('imagePlaneModule', imageId) as
+        | { imagePositionPatient?: number[] } | undefined;
+      if (planeMeta?.imagePositionPatient) {
+        const iz = planeMeta.imagePositionPatient[2];
+        const dist = Math.abs(iz - z);
+        if (dist < bestDist) {
+          bestDist = dist;
+          bestId = imageId;
+        }
+      }
+    } catch {
+      // Skip images without position metadata
+    }
+  }
+
+  return bestId;
+}
+
+// ─── DICOM Write Helper ─────────────────────────────────────────
+
+/**
+ * Serialize a denaturalized DICOM dataset to an ArrayBuffer via dcmjs.
+ *
+ * First attempts a normal DicomDict.write(). If dcmjs throws "Not a number"
+ * (caused by NaN in its internal byte-count arithmetic), retries once with
+ * a scoped NaN-guard on WriteBufferStream.prototype. The guard is removed
+ * in a finally block — no permanent prototype mutation.
+ *
+ * Same pattern as segmentationService.writeDicomDict().
+ */
+function writeDicomDict(
+  DicomDictClass: any,
+  denaturalizedMeta: any,
+  denaturalizedDict: any,
+): ArrayBuffer {
+  const dict = new DicomDictClass(denaturalizedMeta);
+  dict.dict = denaturalizedDict;
+
+  // Attempt 1: normal write — no prototype patching
+  try {
+    return dict.write();
+  } catch (firstErr: any) {
+    if (!(firstErr instanceof Error) || !firstErr.message.includes('Not a number')) {
+      throw firstErr; // not the NaN error — rethrow
+    }
+    console.warn(
+      '[rtStructService] DicomDict.write() hit NaN in dcmjs internals; retrying with NaN guard',
+    );
+  }
+
+  // Attempt 2: scoped NaN-guard fallback
+  const { WriteBufferStream } = dcmjsData as any;
+  const proto = WriteBufferStream?.prototype;
+  if (!proto) {
+    return dict.write();
+  }
+
+  const origWrite16 = proto.writeUint16;
+  const origWrite32 = proto.writeUint32;
+  try {
+    proto.writeUint16 = function (value: any) {
+      return origWrite16.call(this, isNaN(value) ? 0 : value);
+    };
+    proto.writeUint32 = function (value: any) {
+      return origWrite32.call(this, isNaN(value) ? 0 : value);
+    };
+
+    const retryDict = new DicomDictClass(denaturalizedMeta);
+    retryDict.dict = denaturalizedDict;
+    return retryDict.write();
+  } finally {
+    proto.writeUint16 = origWrite16;
+    proto.writeUint32 = origWrite32;
+  }
+}
+
+// ─── Export ─────────────────────────────────────────────────────
+
+/**
+ * Export a contour segmentation as DICOM RTSTRUCT binary (base64 string).
+ *
+ * Uses @cornerstonejs/adapters' generateRTSSFromContour() which reads
+ * contour annotations from the segmentation's annotationUIDsMap and
+ * builds a complete RTSS dataset. We then serialize it to DICOM binary
+ * using dcmjs.
+ *
+ * IMPORTANT: We use generateRTSSFromContour (not generateRTSSFromRepresentation)
+ * because the latter checks Labelmap first and invokes generateContourSetsFromLabelmap
+ * via a web worker — which fails in Electron/Vite dev mode. Since our segmentations
+ * always have a Contour representation (ensured before export), we bypass the
+ * Labelmap path entirely.
+ */
+async function exportToRtStruct(segmentationId: string): Promise<string> {
+  // Import the RTSS adapter functions via the package exports map:
+  //   @cornerstonejs/adapters/cornerstone3D/RTStruct/RTSS → named exports
+  let generateContourFn: any = null;
+
+  // Approach 1: top-level import → adaptersRT.Cornerstone3D.RTSS
+  try {
+    const adaptersModule = await import('@cornerstonejs/adapters');
+    const rtss = (adaptersModule as any).adaptersRT?.Cornerstone3D?.RTSS;
+    if (rtss?.generateRTSSFromContour) generateContourFn = rtss.generateRTSSFromContour;
+  } catch {
+    // Fall through
+  }
+
+  // Approach 2: wildcard subpath import (works with Vite's resolution)
+  if (!generateContourFn) {
+    try {
+      // @ts-ignore — the exports map maps this correctly
+      const rtssModule = await import('@cornerstonejs/adapters/cornerstone3D/RTStruct/RTSS');
+      generateContourFn = rtssModule.generateRTSSFromContour;
+    } catch {
+      // Fall through
+    }
+  }
+
+  if (!generateContourFn) {
+    throw new Error(
+      '[rtStructService] Could not find generateRTSSFromContour in @cornerstonejs/adapters. ' +
+      'RTSTRUCT export requires this function.',
+    );
+  }
+
+  const seg = csSegmentation.state.getSegmentation(segmentationId);
+  if (!seg) {
+    throw new Error(`[rtStructService] Segmentation not found: ${segmentationId}`);
+  }
+
+  // Ensure the segmentation has a Contour representation with annotations
+  if (!seg.representationData?.Contour?.annotationUIDsMap) {
+    throw new Error(
+      '[rtStructService] Segmentation has no contour representation. ' +
+      'Draw contours or load an RTSTRUCT before exporting.',
+    );
+  }
+
+  console.log('[rtStructService] Exporting RTSTRUCT for segmentation:', segmentationId);
+
+  // Build a custom metadataProvider that bridges gaps between what the
+  // adapters' referencedMetadataProvider expects and what our DICOMweb
+  // image loader actually registers.
+  //
+  // Key issue: the adapter calls metaData.get('frameModule', imageId)
+  // expecting { sopClassUID, sopInstanceUID, frameNumber, numberOfFrames }
+  // but our image loader doesn't register a 'frameModule' — it puts those
+  // values in 'sopCommonModule' and 'multiframeModule'.
+  const exportMetadataProvider = {
+    get: (type: string, ...args: any[]) => {
+      const imageId = args[0] as string;
+
+      if (type === 'frameModule') {
+        // The adapter needs sopClassUID + sopInstanceUID from frameModule.
+        // Our loader puts them in sopCommonModule.
+        const sopModule = metaData.get('sopCommonModule', imageId) as any;
+        if (sopModule) {
+          return {
+            sopClassUID: sopModule.sopClassUID,
+            sopInstanceUID: sopModule.sopInstanceUID,
+            frameNumber: 1,
+            numberOfFrames: 1,
+          };
+        }
+        return undefined;
+      }
+
+      // For all other module types, delegate to Cornerstone's provider chain
+      return metaData.get(type, imageId);
+    },
+  };
+
+  // Generate the RTSS dataset using the contour-specific adapter.
+  // generateRTSSFromContour is synchronous — it reads annotation state directly.
+  // Must pass a metadataProvider in options so createInstance() can destructure
+  // { metadataProvider = metaData } without throwing on undefined, AND so
+  // the referencedMetadataProvider gets frameModule data from our bridge.
+  const rtssDataset: any = generateContourFn(seg, {
+    metadataProvider: exportMetadataProvider,
+  });
+
+  // Serialize to DICOM binary via dcmjs
+  //
+  // The adapter's _meta (from metaRTSSContour constant) is ALREADY in
+  // denaturalized format (tag-keyed with {Value, vr} objects). Do NOT
+  // call denaturalizeDataset on it again — that would corrupt the
+  // ArrayBuffer in FileMetaInformationVersion and cause DataView errors.
+  //
+  // The dataset body (everything except _meta) IS in naturalized format
+  // and needs denaturalization.
+  const meta = rtssDataset._meta || {};
+  delete rtssDataset._meta;
+
+  const denaturalizedDataset = dcmjsData.DicomMetaDictionary.denaturalizeDataset(rtssDataset);
+
+  // _meta is already denaturalized — use directly as the file meta header.
+  // Use NaN-guarded write: dcmjs internals can hit "Not a number" errors
+  // in WriteBufferStream when the dataset has empty/undefined numeric fields.
+  const arrayBuffer: ArrayBuffer = writeDicomDict(
+    dcmjsData.DicomDict,
+    meta,
+    denaturalizedDataset,
+  );
+
+  // Convert to base64 for IPC transport
+  const bytes = new Uint8Array(arrayBuffer);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  const base64 = btoa(binary);
+
+  console.log(
+    `[rtStructService] Exported RTSTRUCT: ${(arrayBuffer.byteLength / 1024).toFixed(1)} KB`,
+  );
+
+  return base64;
+}
+
+// ─── Public API ─────────────────────────────────────────────────
+
+export const rtStructService = {
+  parseRtStruct,
+  loadRtStructAsContours,
+  exportToRtStruct,
+};

--- a/src/renderer/lib/cornerstone/segmentationService.ts
+++ b/src/renderer/lib/cornerstone/segmentationService.ts
@@ -1956,6 +1956,14 @@ export const segmentationService = {
   },
 
   /**
+   * Track source image IDs for a segmentation (used for DICOM SEG/RTSTRUCT export).
+   * Called by rtStructService when loading RTSTRUCT contours.
+   */
+  trackSourceImageIds(segmentationId: string, imageIds: string[]): void {
+    sourceImageIdsMap.set(segmentationId, [...imageIds]);
+  },
+
+  /**
    * Force a re-sync of segmentation summaries (e.g. after viewport changes).
    */
   sync: syncSegmentations,

--- a/src/renderer/lib/pinnedItems.ts
+++ b/src/renderer/lib/pinnedItems.ts
@@ -1,0 +1,280 @@
+/**
+ * Pinned Items & Recent Sessions — localStorage persistence.
+ *
+ * Centralizes all bookmark/recent-session storage logic.
+ * Items are scoped per XNAT server URL.
+ */
+
+// ─── Types ────────────────────────────────────────────────────────
+
+export interface PinnedProject {
+  type: 'project';
+  serverUrl: string;
+  projectId: string;
+  projectName: string;
+  timestamp: number;
+}
+
+export interface PinnedSubject {
+  type: 'subject';
+  serverUrl: string;
+  projectId: string;
+  projectName: string;
+  subjectId: string;
+  subjectLabel: string;
+  timestamp: number;
+}
+
+export interface PinnedSession {
+  type: 'session';
+  serverUrl: string;
+  projectId: string;
+  projectName: string;
+  subjectId: string;
+  subjectLabel: string;
+  sessionId: string;
+  sessionLabel: string;
+  timestamp: number;
+}
+
+export type PinnedItem = PinnedProject | PinnedSubject | PinnedSession;
+
+export interface RecentSession {
+  serverUrl: string;
+  projectId: string;
+  projectName: string;
+  subjectId: string;
+  subjectLabel: string;
+  sessionId: string;
+  sessionLabel: string;
+  timestamp: number;
+}
+
+/** Target for programmatic navigation of the XnatBrowser. */
+export interface NavigateToTarget {
+  type: 'project' | 'subject' | 'session';
+  projectId: string;
+  projectName: string;
+  subjectId?: string;
+  subjectLabel?: string;
+  sessionId?: string;
+  sessionLabel?: string;
+}
+
+// ─── Constants ────────────────────────────────────────────────────
+
+const PINNED_KEY = 'xnat-viewer:pinned-items';
+const RECENT_KEY = 'xnat-viewer:recent-sessions';
+const OLD_KEY = 'xnat-viewer:recent-session'; // Legacy key to migrate from
+const MAX_RECENT = 5;
+
+function normalize(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+// ─── Pinned Items ─────────────────────────────────────────────────
+
+function readPinned(): PinnedItem[] {
+  try {
+    const raw = localStorage.getItem(PINNED_KEY);
+    if (!raw) return [];
+    const arr = JSON.parse(raw);
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
+function writePinned(items: PinnedItem[]): void {
+  try {
+    localStorage.setItem(PINNED_KEY, JSON.stringify(items));
+  } catch { /* ignore */ }
+}
+
+export function loadPinnedItems(serverUrl: string): PinnedItem[] {
+  const norm = normalize(serverUrl);
+  return readPinned()
+    .filter((i) => normalize(i.serverUrl) === norm)
+    .sort((a, b) => b.timestamp - a.timestamp);
+}
+
+export function addPinnedItem(item: PinnedItem): void {
+  const all = readPinned();
+  // Remove existing duplicate
+  const filtered = all.filter((i) => !isSameItem(i, item));
+  filtered.unshift({ ...item, timestamp: Date.now() });
+  writePinned(filtered);
+}
+
+export function removePinnedItem(
+  type: PinnedItem['type'],
+  id: string,
+  serverUrl: string,
+): void {
+  const norm = normalize(serverUrl);
+  const all = readPinned();
+  writePinned(
+    all.filter((i) => {
+      if (normalize(i.serverUrl) !== norm || i.type !== type) return true;
+      return getItemId(i) !== id;
+    }),
+  );
+}
+
+export function isPinned(
+  items: PinnedItem[],
+  type: PinnedItem['type'],
+  id: string,
+): boolean {
+  return items.some((i) => i.type === type && getItemId(i) === id);
+}
+
+/** Get the primary identifier for a pinned item. */
+function getItemId(item: PinnedItem): string {
+  switch (item.type) {
+    case 'project':
+      return item.projectId;
+    case 'subject':
+      return item.subjectId;
+    case 'session':
+      return item.sessionId;
+  }
+}
+
+function isSameItem(a: PinnedItem, b: PinnedItem): boolean {
+  if (a.type !== b.type) return false;
+  if (normalize(a.serverUrl) !== normalize(b.serverUrl)) return false;
+  return getItemId(a) === getItemId(b);
+}
+
+// ─── Recent Sessions ──────────────────────────────────────────────
+
+function readRecent(): RecentSession[] {
+  try {
+    const raw = localStorage.getItem(RECENT_KEY);
+    if (!raw) return [];
+    const arr = JSON.parse(raw);
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeRecent(sessions: RecentSession[]): void {
+  try {
+    localStorage.setItem(RECENT_KEY, JSON.stringify(sessions));
+  } catch { /* ignore */ }
+}
+
+export function loadRecentSessions(serverUrl: string): RecentSession[] {
+  const norm = normalize(serverUrl);
+  return readRecent()
+    .filter((s) => normalize(s.serverUrl) === norm)
+    .sort((a, b) => b.timestamp - a.timestamp)
+    .slice(0, MAX_RECENT);
+}
+
+export function saveRecentSession(
+  serverUrl: string,
+  context: {
+    projectId: string;
+    projectName: string;
+    subjectId: string;
+    subjectLabel: string;
+    sessionId: string;
+    sessionLabel: string;
+  },
+): void {
+  const norm = normalize(serverUrl);
+  const all = readRecent();
+
+  // Remove duplicate
+  const filtered = all.filter(
+    (s) => !(s.sessionId === context.sessionId && normalize(s.serverUrl) === norm),
+  );
+
+  filtered.unshift({
+    serverUrl: norm,
+    projectId: context.projectId,
+    projectName: context.projectName,
+    subjectId: context.subjectId,
+    subjectLabel: context.subjectLabel,
+    sessionId: context.sessionId,
+    sessionLabel: context.sessionLabel,
+    timestamp: Date.now(),
+  });
+
+  // Trim per server: keep MAX_RECENT per serverUrl
+  const byServer = new Map<string, RecentSession[]>();
+  for (const s of filtered) {
+    const key = normalize(s.serverUrl);
+    if (!byServer.has(key)) byServer.set(key, []);
+    byServer.get(key)!.push(s);
+  }
+  const trimmed: RecentSession[] = [];
+  for (const sessions of byServer.values()) {
+    trimmed.push(...sessions.slice(0, MAX_RECENT));
+  }
+
+  writeRecent(trimmed);
+}
+
+export function removeRecentSession(sessionId: string, serverUrl: string): void {
+  const norm = normalize(serverUrl);
+  const all = readRecent();
+  writeRecent(
+    all.filter(
+      (s) => !(s.sessionId === sessionId && normalize(s.serverUrl) === norm),
+    ),
+  );
+}
+
+// ─── Migration from Old Format ────────────────────────────────────
+
+/**
+ * Migrate from the old `xnat-viewer:recent-session` key (array of objects
+ * with optional `pinned` flag) to the new split keys.
+ * Call once on app start.
+ */
+export function migrateOldStorage(): void {
+  try {
+    const raw = localStorage.getItem(OLD_KEY);
+    if (!raw) return;
+
+    const old = JSON.parse(raw);
+    const items: any[] = Array.isArray(old) ? old : [old];
+
+    for (const item of items) {
+      if (!item.serverUrl || !item.sessionId) continue;
+
+      if (item.pinned) {
+        addPinnedItem({
+          type: 'session',
+          serverUrl: item.serverUrl,
+          projectId: item.projectId ?? '',
+          projectName: item.sessionLabel ?? '', // best effort — old format didn't store projectName
+          subjectId: item.subjectId ?? '',
+          subjectLabel: '', // not available in old format
+          sessionId: item.sessionId,
+          sessionLabel: item.sessionLabel ?? '',
+          timestamp: item.timestamp ?? Date.now(),
+        });
+      } else {
+        saveRecentSession(item.serverUrl, {
+          projectId: item.projectId ?? '',
+          projectName: '', // not available in old format
+          subjectId: item.subjectId ?? '',
+          subjectLabel: '',
+          sessionId: item.sessionId,
+          sessionLabel: item.sessionLabel ?? '',
+        });
+      }
+    }
+
+    localStorage.removeItem(OLD_KEY);
+    console.log('[pinnedItems] Migrated old recent-session storage');
+  } catch {
+    // Migration failed — not critical, just remove old key
+    try { localStorage.removeItem(OLD_KEY); } catch { /* ignore */ }
+  }
+}

--- a/src/shared/ipcChannels.ts
+++ b/src/shared/ipcChannels.ts
@@ -3,7 +3,7 @@
  *
  * renderer → main (invoke/handle):
  *   XNAT_LOGIN, XNAT_LOGOUT, XNAT_VALIDATE, XNAT_GET_CONNECTION, XNAT_DICOMWEB_FETCH,
- *   XNAT_UPLOAD_DICOM_SEG
+ *   XNAT_UPLOAD_DICOM_SEG, XNAT_UPLOAD_DICOM_RTSTRUCT
  *
  * main → renderer (send/on):
  *   XNAT_SESSION_EXPIRED
@@ -30,6 +30,7 @@ export const IPC = {
 
   // XNAT upload (renderer → main)
   XNAT_UPLOAD_DICOM_SEG: 'xnat:upload-dicom-seg',
+  XNAT_UPLOAD_DICOM_RTSTRUCT: 'xnat:upload-dicom-rtstruct',
 
   // Session events (main → renderer)
   XNAT_SESSION_EXPIRED: 'xnat:session-expired',
@@ -41,6 +42,7 @@ export const IPC = {
   EXPORT_SAVE_DICOM_SEG: 'export:save-dicom-seg',
   EXPORT_SAVE_ALL_SLICES: 'export:save-all-slices',
   EXPORT_SAVE_REPORT: 'export:save-report',
+  EXPORT_SAVE_DICOM_RTSTRUCT: 'export:save-dicom-rtstruct',
 } as const;
 
 export type IpcChannel = (typeof IPC)[keyof typeof IPC];

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -47,6 +47,14 @@ export interface ElectronAPI {
       sourceScanId: string,
       dicomBase64: string,
     ): Promise<XnatUploadResult>;
+    uploadDicomRtStruct(
+      projectId: string,
+      subjectId: string,
+      sessionId: string,
+      sessionLabel: string,
+      sourceScanId: string,
+      dicomBase64: string,
+    ): Promise<XnatUploadResult>;
   };
   export: {
     saveScreenshot(
@@ -67,6 +75,10 @@ export interface ElectronAPI {
       defaultName?: string,
     ): Promise<{ ok: boolean; path?: string; error?: string }>;
     saveDicomSeg(
+      dicomBase64: string,
+      defaultName?: string,
+    ): Promise<{ ok: boolean; path?: string; error?: string }>;
+    saveDicomRtStruct(
       dicomBase64: string,
       defaultName?: string,
     ): Promise<{ ok: boolean; path?: string; error?: string }>;


### PR DESCRIPTION
## Summary
- **RTSTRUCT support**: Parse DICOM RT Structure Sets and render contour overlays on source images. Auto-loads RTSTRUCT scans when loading sessions. Fixes reload failure by checking flat `ReferencedSeriesSequence`.
- **Contour export**: "Save to XNAT" in the segmentation panel exports contour segmentations as DICOM RTSTRUCT files back to XNAT.
- **Pinnable bookmarks**: Pin projects, subjects, and sessions from the browser sidebar. Header dropdown shows pinned items and recent sessions with one-click navigation. Pin icons on browser rows with hover reveal.

## Test plan
- [ ] Load a session with RTSTRUCT scans — contours render on source images
- [ ] Export contours via "Save to XNAT" — RTSTRUCT file appears in XNAT
- [ ] Re-load the exported RTSTRUCT — contours render correctly (roundtrip)
- [ ] Pin a project, subject, and session from the browser — pin icons turn amber
- [ ] Open bookmarks dropdown — all three levels appear with correct type badges
- [ ] Click a pinned session — browser navigates and session auto-loads
- [ ] Load a session manually — appears in "Recent" section of dropdown
- [ ] Promote a recent session to pinned — moves to Pinned section

🤖 Generated with [Claude Code](https://claude.com/claude-code)