### PR TITLE
Add AI-powered finding extraction with local LLaVA-Med inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,8 @@ npm-debug.log*
 # Electron
 release/
 
+# Bundled binaries (downloaded by scripts/download-llama-server.sh)
+extraResources/
+
 # Claude
 .claude/

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -20,11 +20,20 @@ mac:
     - zip
   category: public.app-category.medical
   hardenedRuntime: true
+  extraResources:
+    - from: extraResources/llama-server/darwin-${arch}/
+      to: llama-server/darwin-${arch}/
 win:
   target:
     - nsis
     - portable
+  extraResources:
+    - from: extraResources/llama-server/win32-x64/
+      to: llama-server/win32-x64/
 linux:
   target:
     - AppImage
     - deb
+  extraResources:
+    - from: extraResources/llama-server/linux-x64/
+      to: llama-server/linux-x64/

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "dev:renderer": "vite",
     "postinstall": "node scripts/fix-dev-app-name.js",
     "dev:main": "node scripts/fix-dev-app-name.js && wait-on http://localhost:5173 && tsc -p tsconfig.main.json && electron .",
+    "download:llama-server": "bash scripts/download-llama-server.sh",
+    "prepackage": "npm run build && bash scripts/download-llama-server.sh",
     "build": "npm run build:main && npm run build:renderer",
     "build:main": "tsc -p tsconfig.main.json",
     "build:renderer": "vite build",

--- a/scripts/download-llama-server.sh
+++ b/scripts/download-llama-server.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+#
+# download-llama-server.sh — Download pre-built llama-server binaries
+# from llama.cpp GitHub releases for bundling into the Electron app.
+#
+# Usage:
+#   bash scripts/download-llama-server.sh                        # all platforms
+#   bash scripts/download-llama-server.sh --platform darwin-arm64  # single platform
+#
+# Environment:
+#   LLAMA_CPP_VERSION — release tag to download (default: b5040)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUTPUT_DIR="$PROJECT_ROOT/extraResources/llama-server"
+
+# Pin a known-good release
+VERSION="${LLAMA_CPP_VERSION:-b7989}"
+
+BASE_URL="https://github.com/ggml-org/llama.cpp/releases/download/${VERSION}"
+
+# ─── Platform helpers (bash 3.2 compatible — no associative arrays) ──
+
+get_asset_name() {
+  case "$1" in
+    darwin-arm64) echo "llama-${VERSION}-bin-macos-arm64.tar.gz" ;;
+    darwin-x64)   echo "llama-${VERSION}-bin-macos-x64.tar.gz" ;;
+    win32-x64)    echo "llama-${VERSION}-bin-win-cpu-x64.zip" ;;
+    linux-x64)    echo "llama-${VERSION}-bin-ubuntu-x64.tar.gz" ;;
+    *) echo "" ;;
+  esac
+}
+
+get_binary_name() {
+  case "$1" in
+    win32-x64) echo "llama-server.exe" ;;
+    *)         echo "llama-server" ;;
+  esac
+}
+
+ALL_PLATFORMS="darwin-arm64 darwin-x64 win32-x64 linux-x64"
+
+# ─── Parse CLI args ───────────────────────────────────────────
+PLATFORMS=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --platform)
+      PLATFORMS="${PLATFORMS} $2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$PLATFORMS" ]]; then
+  PLATFORMS="$ALL_PLATFORMS"
+fi
+
+# ─── Download + extract ──────────────────────────────────────
+
+download_platform() {
+  local platform="$1"
+  local asset
+  asset="$(get_asset_name "$platform")"
+  local binary
+  binary="$(get_binary_name "$platform")"
+  local dest_dir="$OUTPUT_DIR/$platform"
+  local dest_path="$dest_dir/$binary"
+
+  if [[ -z "$asset" ]]; then
+    echo "Unknown platform: $platform" >&2
+    echo "Valid platforms: $ALL_PLATFORMS" >&2
+    return 1
+  fi
+
+  # Skip if already exists
+  if [[ -f "$dest_path" ]]; then
+    echo "[$platform] Already exists at $dest_path — skipping"
+    return 0
+  fi
+
+  local url="$BASE_URL/$asset"
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+
+  echo "[$platform] Downloading $url ..."
+  if ! curl -fSL --progress-bar -o "$tmp_dir/$asset" "$url"; then
+    echo "[$platform] ERROR: Download failed" >&2
+    rm -rf "$tmp_dir"
+    return 1
+  fi
+
+  echo "[$platform] Extracting ..."
+  if echo "$asset" | grep -q '\.tar\.gz$'; then
+    tar -xzf "$tmp_dir/$asset" -C "$tmp_dir"
+  elif echo "$asset" | grep -q '\.zip$'; then
+    unzip -q "$tmp_dir/$asset" -d "$tmp_dir"
+  fi
+
+  # Find the llama-server binary inside the extracted archive
+  # It may be in build/bin/, bin/, or flat depending on the release
+  local found
+  found="$(find "$tmp_dir" -name "$binary" -type f | head -1)"
+
+  if [[ -z "$found" ]]; then
+    echo "[$platform] ERROR: Could not find $binary in archive" >&2
+    ls -R "$tmp_dir" >&2
+    rm -rf "$tmp_dir"
+    return 1
+  fi
+
+  # Copy binary + companion shared libraries to destination
+  mkdir -p "$dest_dir"
+  cp "$found" "$dest_path"
+
+  # Copy shared libraries (.dylib, .so, .dll) from the same directory as the binary.
+  # llama-server b7989+ dynamically links against libmtmd, libllama, libggml, etc.
+  local binary_dir
+  binary_dir="$(dirname "$found")"
+
+  local lib_count=0
+  for lib in "$binary_dir"/*.dylib "$binary_dir"/*.so "$binary_dir"/*.so.* "$binary_dir"/*.dll; do
+    if [[ -f "$lib" ]]; then
+      cp "$lib" "$dest_dir/"
+      lib_count=$((lib_count + 1))
+      echo "[$platform]   Copied library: $(basename "$lib")"
+    fi
+  done
+  # Also check parent lib/ directory (some releases put libs there)
+  if [[ -d "$binary_dir/../lib" ]]; then
+    for lib in "$binary_dir/../lib"/*.dylib "$binary_dir/../lib"/*.so "$binary_dir/../lib"/*.so.* "$binary_dir/../lib"/*.dll; do
+      if [[ -f "$lib" ]]; then
+        cp "$lib" "$dest_dir/"
+        lib_count=$((lib_count + 1))
+        echo "[$platform]   Copied library: $(basename "$lib")"
+      fi
+    done
+  fi
+
+  # Make executable on macOS/Linux
+  case "$platform" in
+    win32-*) ;;
+    *) chmod +x "$dest_path"
+       # Also make shared libs executable (needed for some linkers)
+       for lib in "$dest_dir"/*.dylib "$dest_dir"/*.so "$dest_dir"/*.so.*; do
+         if [[ -f "$lib" ]]; then
+           chmod +x "$lib"
+         fi
+       done
+       ;;
+  esac
+
+  rm -rf "$tmp_dir"
+
+  local size
+  size="$(du -sh "$dest_dir" | cut -f1)"
+  echo "[$platform] Installed $dest_path + $lib_count libraries ($size total)"
+}
+
+echo "=== llama-server download (version: $VERSION) ==="
+echo "Output: $OUTPUT_DIR"
+echo ""
+
+FAILED=0
+for platform in $PLATFORMS; do
+  if ! download_platform "$platform"; then
+    FAILED=$((FAILED + 1))
+  fi
+done
+
+echo ""
+if [[ $FAILED -gt 0 ]]; then
+  echo "=== Done ($FAILED platform(s) failed) ==="
+  exit 1
+else
+  echo "=== Done (all platforms OK) ==="
+fi

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,6 +4,8 @@ import { registerAuthHandlers } from './ipc/authHandlers';
 import { registerProxyHandlers } from './ipc/proxyHandlers';
 import { registerExportHandlers } from './ipc/exportHandlers';
 import { registerUploadHandlers } from './ipc/uploadHandlers';
+import { registerAiHandlers } from './ipc/aiHandlers';
+import { aiInferenceService } from './services/aiInferenceService';
 
 // Suppress EPIPE errors from console.log when stdout/stderr pipe is broken.
 // This is common when Electron is launched from a terminal that disconnects.
@@ -173,6 +175,7 @@ app.whenReady().then(() => {
   registerProxyHandlers();
   registerExportHandlers();
   registerUploadHandlers();
+  registerAiHandlers();
 
   // Set the macOS dock icon (dev mode only — packaged app uses Info.plist).
   // In dev mode we can only use PNG; macOS won't apply the rounded-square
@@ -196,6 +199,13 @@ app.whenReady().then(() => {
   buildAppMenu();
 
   createWindow();
+});
+
+// Clean up llama-server child process before quitting
+app.on('will-quit', () => {
+  aiInferenceService.stop().catch((err) => {
+    console.error('[main] Failed to stop AI server on quit:', err);
+  });
 });
 
 app.on('window-all-closed', () => {

--- a/src/main/ipc/aiHandlers.ts
+++ b/src/main/ipc/aiHandlers.ts
@@ -1,0 +1,579 @@
+/**
+ * AI IPC Handlers — registers all AI-related IPC channels.
+ *
+ * Handles server lifecycle (start, stop, status), configuration management,
+ * image analysis requests, model file checks, and utility actions
+ * (browse file, open models directory).
+ */
+import { ipcMain, dialog, shell, BrowserWindow } from 'electron';
+import fs from 'fs';
+import path from 'path';
+import { IPC } from '../../shared/ipcChannels';
+import { aiConfigStore } from '../services/aiConfigStore';
+import { aiInferenceService } from '../services/aiInferenceService';
+import { buildPrompt, extractImageData } from '../services/promptTemplates';
+import type {
+  AiAnalysisRequest,
+  AiAnalysisResult,
+  AiFinding,
+  AiFindingSeverity,
+  AiFindingCategory,
+  ModelFileStatus,
+  ModelPreset,
+} from '../../shared/types/ai';
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+/** Generate a simple UUID v4. */
+function uuid(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+/** Valid severity values. */
+const VALID_SEVERITIES: AiFindingSeverity[] = ['normal', 'mild', 'moderate', 'severe'];
+const VALID_CATEGORIES: AiFindingCategory[] = [
+  'airspace', 'vascular', 'cardiac', 'skeletal', 'soft_tissue', 'device', 'other',
+];
+
+// ─── Keyword-based Severity & Category Inference ──────────────
+
+/** Patterns checked top-down (most severe first). First match wins. */
+const SEVERITY_PATTERNS: Array<{ severity: AiFindingSeverity; patterns: RegExp[] }> = [
+  {
+    severity: 'severe',
+    patterns: [
+      /\bsevere\b/i,
+      /\bcritical\b/i,
+      /\bemergent\b/i,
+      /\btension\s+pneumothorax\b/i,
+      /\bmassive\b/i,
+      /\bcomplete\s+(collapse|occlusion|obstruction)\b/i,
+      /\bdisplaced\s+fracture\b/i,
+      /\blarge\s+(pleural\s+)?effusion\b/i,
+      /\bpulmonary\s+embolism\b/i,
+      /\baortic\s+dissection\b/i,
+      /\bwidened\s+mediastinum\b/i,
+    ],
+  },
+  {
+    severity: 'moderate',
+    patterns: [
+      /\bmoderate\b/i,
+      /\bsignificant\b/i,
+      /\bextensive\b/i,
+      /\blarge\b/i,
+      /\bconsolidation\b/i,
+      /\beffusion\b/i,
+      /\bpneumothorax\b/i,
+      /\bmass\b/i,
+      /\bnodule\b/i,
+      /\bfracture\b/i,
+      /\bcardiomegaly\b/i,
+      /\bedema\b/i,
+      /\bopacity\b/i,
+      /\bopacities\b/i,
+      /\binfiltrate\b/i,
+      /\batelectasis\b/i,
+      /\babnormal\b/i,
+    ],
+  },
+  {
+    severity: 'mild',
+    patterns: [
+      /\bmild\b/i,
+      /\bsmall\b/i,
+      /\bminimal\b/i,
+      /\bsubtle\b/i,
+      /\btrace\b/i,
+      /\bminor\b/i,
+      /\btiny\b/i,
+      /\bfaint\b/i,
+      /\bslight\b/i,
+      /\bdegenerative\b/i,
+      /\bblunting\b/i,
+    ],
+  },
+];
+
+/** Keywords that indicate a normal/negative finding, checked before severity patterns. */
+const NORMAL_PATTERNS: RegExp[] = [
+  /\bnormal\b/i,
+  /\bunremarkable\b/i,
+  /\bno\s+acute\b/i,
+  /\bwithin\s+normal\s+limits\b/i,
+  /\bclear\s+lungs?\b/i,
+  /\bno\s+(significant|notable|definite)\b/i,
+  /\bno\s+(evidence|findings?)\b/i,
+  /\bnegative\b/i,
+  /\bstable\b/i,
+  /\bintact\b/i,
+  /\bpreserved\b/i,
+];
+
+/**
+ * Infer severity from free-text finding description using keyword matching.
+ * Normal patterns are checked first (trumps severity keywords in the same sentence,
+ * e.g. "no evidence of fracture" → normal, not moderate).
+ */
+function inferSeverity(text: string): AiFindingSeverity {
+  // Check for negation / normal patterns first
+  for (const pat of NORMAL_PATTERNS) {
+    if (pat.test(text)) return 'normal';
+  }
+
+  // Check severity patterns top-down (severe → moderate → mild)
+  for (const { severity, patterns } of SEVERITY_PATTERNS) {
+    for (const pat of patterns) {
+      if (pat.test(text)) return severity;
+    }
+  }
+
+  return 'normal';
+}
+
+/** Category keyword patterns. First match wins. */
+const CATEGORY_PATTERNS: Array<{ category: AiFindingCategory; patterns: RegExp[] }> = [
+  {
+    category: 'airspace',
+    patterns: [
+      /\bconsolidation\b/i, /\bopacity\b/i, /\bopacities\b/i, /\binfiltrate\b/i,
+      /\batelectasis\b/i, /\bpneumonia\b/i, /\bpneumothorax\b/i,
+      /\blung\b/i, /\bpulmonary\b/i, /\bpleural\b/i, /\bairspace\b/i,
+      /\beffusion\b/i, /\bedema\b/i,
+    ],
+  },
+  {
+    category: 'cardiac',
+    patterns: [
+      /\bcardiac\b/i, /\bheart\b/i, /\bcardiomegaly\b/i, /\bpericardi/i,
+      /\bventricular\b/i, /\batrial\b/i, /\bvalv/i,
+    ],
+  },
+  {
+    category: 'vascular',
+    patterns: [
+      /\bvascular\b/i, /\baort/i, /\bartery\b/i, /\barterial\b/i,
+      /\bvenous\b/i, /\bembolism\b/i, /\bthromb/i, /\baneurysm\b/i,
+      /\bmediastin/i, /\bhilum\b/i, /\bhilar\b/i,
+    ],
+  },
+  {
+    category: 'skeletal',
+    patterns: [
+      /\bfracture\b/i, /\bbone\b/i, /\bosseous\b/i, /\bskeletal\b/i,
+      /\brib\b/i, /\bspine\b/i, /\bvertebr/i, /\bdegenerative\b/i,
+      /\bjoint\b/i, /\barthritis\b/i, /\bsclerotic\b/i, /\blytic\b/i,
+    ],
+  },
+  {
+    category: 'soft_tissue',
+    patterns: [
+      /\bsoft\s+tissue\b/i, /\bsubcutaneous\b/i, /\bmass\b/i, /\bnodule\b/i,
+      /\blymph\b/i, /\bswelling\b/i, /\bthyroid\b/i,
+    ],
+  },
+  {
+    category: 'device',
+    patterns: [
+      /\bdevice\b/i, /\bcatheter\b/i, /\btube\b/i, /\bpacemaker\b/i,
+      /\bstent\b/i, /\bwire\b/i, /\bhardware\b/i, /\bimplant\b/i,
+      /\bline\b/i, /\bport\b/i, /\bICD\b/, /\bAICD\b/,
+    ],
+  },
+];
+
+/**
+ * Infer anatomical/pathological category from free-text finding description.
+ */
+function inferCategory(text: string): AiFindingCategory {
+  for (const { category, patterns } of CATEGORY_PATTERNS) {
+    for (const pat of patterns) {
+      if (pat.test(text)) return category;
+    }
+  }
+  return 'other';
+}
+
+/**
+ * Wrap a free-text model response into the expected findings structure.
+ * Used as a fallback when the model doesn't produce valid JSON.
+ */
+function parseFreeTextResponse(raw: string): {
+  findings: AiFinding[];
+  impression: string;
+  limitations: string[];
+  rawOutput: string;
+} {
+  const text = raw.trim();
+
+  // Split into sentences/paragraphs for individual findings
+  const sentences = text
+    .split(/(?<=[.!?])\s+/)
+    .map(s => s.trim())
+    .filter(s => s.length > 10);
+
+  const findings: AiFinding[] = sentences.length > 0
+    ? sentences.slice(0, 10).map((sentence) => ({
+        id: uuid(),
+        description: sentence,
+        location: 'See report',
+        severity: inferSeverity(sentence),
+        confidence: 0.5,
+        category: inferCategory(sentence),
+        status: 'pending' as const,
+      }))
+    : [{
+        id: uuid(),
+        description: text.slice(0, 500) || 'Model produced unstructured output',
+        location: 'See report',
+        severity: inferSeverity(text),
+        confidence: 0.5,
+        category: inferCategory(text),
+        status: 'pending' as const,
+      }];
+
+  return {
+    findings,
+    impression: text.slice(0, 500),
+    limitations: [
+      'AI-assisted preliminary read — not a clinical diagnosis',
+      'Free-text response — structured parsing unavailable',
+    ],
+    rawOutput: raw,
+  };
+}
+
+/**
+ * Parse and validate the JSON response from the model.
+ * Handles common LLM output quirks: markdown fences, extra text, etc.
+ * Falls back to free-text extraction if no valid JSON is found.
+ */
+function parseModelResponse(raw: string): {
+  findings: AiFinding[];
+  impression: string;
+  limitations: string[];
+  rawOutput: string;
+} {
+  console.log(`[aiHandlers] Raw model response (${raw.length} chars): ${raw.slice(0, 300)}...`);
+
+  let jsonStr = raw.trim();
+
+  // Strip markdown code fences
+  jsonStr = jsonStr.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '');
+
+  // Find the first { and last } to extract JSON object
+  const firstBrace = jsonStr.indexOf('{');
+  const lastBrace = jsonStr.lastIndexOf('}');
+
+  if (firstBrace === -1 || lastBrace === -1 || lastBrace <= firstBrace) {
+    console.log('[aiHandlers] No JSON braces found in response, using free-text extraction');
+    return parseFreeTextResponse(raw);
+  }
+
+  jsonStr = jsonStr.slice(firstBrace, lastBrace + 1);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let parsed: any;
+  try {
+    parsed = JSON.parse(jsonStr);
+  } catch (err) {
+    console.log(`[aiHandlers] JSON parse failed: ${(err as Error).message}, using free-text extraction`);
+    return parseFreeTextResponse(raw);
+  }
+
+  // Validate and normalize findings
+  const rawFindings = Array.isArray(parsed.findings) ? parsed.findings : [];
+
+  // If parsed JSON has no findings array, treat as free-text
+  if (rawFindings.length === 0 && !parsed.impression) {
+    console.log('[aiHandlers] Parsed JSON has no findings or impression, using free-text extraction');
+    return parseFreeTextResponse(raw);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const findings: AiFinding[] = rawFindings.map((f: any) => {
+    const desc = String(f.description || 'Unspecified finding');
+    return {
+      id: uuid(),
+      description: desc,
+      location: String(f.location || 'Unspecified'),
+      severity: VALID_SEVERITIES.includes(f.severity) ? f.severity : inferSeverity(desc),
+      confidence: Math.max(0, Math.min(1, Number(f.confidence) || 0.5)),
+      category: VALID_CATEGORIES.includes(f.category) ? f.category : inferCategory(desc),
+      status: 'pending' as const,
+    };
+  });
+
+  const impression = String(parsed.impression || 'No impression provided');
+  const limitations = Array.isArray(parsed.limitations)
+    ? parsed.limitations.map(String)
+    : ['AI-assisted preliminary read — not a clinical diagnosis'];
+
+  console.log(`[aiHandlers] Parsed ${findings.length} findings from JSON response`);
+  return { findings, impression, limitations, rawOutput: raw };
+}
+
+// ─── Expected Model Files ───────────────────────────────────────
+
+const LLAVA_MED_FILES = [
+  {
+    filename: 'llava-med-v1.5-mistral-7b.Q4_K_M.gguf',
+    role: 'model' as const,
+    expectedSizeMB: 4370,
+    downloadUrl: 'https://huggingface.co/mradermacher/llava-med-v1.5-mistral-7b-GGUF/resolve/main/llava-med-v1.5-mistral-7b.Q4_K_M.gguf',
+    description: 'LLaVA-Med 7B language model (Q4_K_M quantization)',
+  },
+  {
+    filename: 'mmproj-model-f16.gguf',
+    role: 'mmproj' as const,
+    expectedSizeMB: 624,
+    downloadUrl: 'https://huggingface.co/mradermacher/llava-med-v1.5-mistral-7b-GGUF/resolve/main/mmproj-model-f16.gguf',
+    description: 'Multimodal projector for vision-language alignment',
+  },
+];
+
+// ─── Known Model Presets (for dropdown selector) ────────────────
+
+const KNOWN_PRESETS: Array<Omit<ModelPreset, 'isComplete'>> = [
+  {
+    id: 'llava-med-7b-q4km',
+    displayName: 'LLaVA-Med 7B (Q4_K_M)',
+    backend: 'llava-med',
+    modelFilename: 'llava-med-v1.5-mistral-7b.Q4_K_M.gguf',
+    mmProjFilename: 'mmproj-model-f16.gguf',
+    totalSizeMB: 4994,
+  },
+];
+
+// ─── Handler Registration ───────────────────────────────────────
+
+export function registerAiHandlers(): void {
+  console.log('[ipc] AI handlers registered');
+
+  // ─── Get Config ───────────────────────────────────────────
+  ipcMain.handle(IPC.AI_GET_CONFIG, () => {
+    return aiConfigStore.load();
+  });
+
+  // ─── Set Config ───────────────────────────────────────────
+  ipcMain.handle(
+    IPC.AI_SET_CONFIG,
+    async (_event, partial: Record<string, unknown>) => {
+      try {
+        aiConfigStore.save(partial);
+        return { ok: true };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[aiHandlers] setConfig error:', msg);
+        return { ok: false, error: msg };
+      }
+    },
+  );
+
+  // ─── Start Server ─────────────────────────────────────────
+  ipcMain.handle(IPC.AI_START_SERVER, async () => {
+    try {
+      await aiInferenceService.start();
+      return { ok: true };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error('[aiHandlers] startServer error:', msg);
+      return { ok: false, error: msg };
+    }
+  });
+
+  // ─── Stop Server ──────────────────────────────────────────
+  ipcMain.handle(IPC.AI_STOP_SERVER, async () => {
+    try {
+      await aiInferenceService.stop();
+      return { ok: true };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error('[aiHandlers] stopServer error:', msg);
+      return { ok: false, error: msg };
+    }
+  });
+
+  // ─── Get Status ───────────────────────────────────────────
+  ipcMain.handle(IPC.AI_GET_STATUS, () => {
+    return aiInferenceService.getStatus();
+  });
+
+  // ─── Analyze Image ────────────────────────────────────────
+  ipcMain.handle(
+    IPC.AI_ANALYZE_IMAGE,
+    async (_event, request: AiAnalysisRequest) => {
+      const startTime = Date.now();
+
+      try {
+        // Build prompt with Mistral [INST] template and extract image data
+        const prompt = buildPrompt(request);
+        const imageData = extractImageData(request);
+
+        console.log(`[aiHandlers] Prompt: ${prompt.slice(0, 200)}...`);
+        console.log(`[aiHandlers] Image data: ${imageData.length} image(s), first ${Math.round(imageData[0]?.data.length / 1024)}KB base64`);
+
+        // Send to llama-server /completion endpoint
+        const rawResponse = await aiInferenceService.completion(prompt, imageData);
+
+        // Parse structured response
+        const { findings, impression, limitations, rawOutput } = parseModelResponse(rawResponse);
+
+        const config = aiConfigStore.load();
+
+        const result: AiAnalysisResult = {
+          findings,
+          impression,
+          limitations,
+          modelBackend: config.backend,
+          timestamp: Date.now(),
+          modality: request.modality,
+          processingTimeMs: Date.now() - startTime,
+          rawOutput: findings.length === 0 ? rawOutput : undefined, // Include raw on parse issues
+        };
+
+        console.log(
+          `[aiHandlers] Analysis complete: ${findings.length} findings in ${result.processingTimeMs}ms`,
+        );
+
+        return { ok: true, result };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[aiHandlers] analyzeImage error:', msg);
+        return {
+          ok: false,
+          error: msg,
+          result: {
+            findings: [],
+            impression: '',
+            limitations: ['Analysis failed: ' + msg],
+            modelBackend: aiConfigStore.load().backend,
+            timestamp: Date.now(),
+            modality: request.modality,
+            processingTimeMs: Date.now() - startTime,
+            rawOutput: msg,
+          } satisfies AiAnalysisResult,
+        };
+      }
+    },
+  );
+
+  // ─── Cancel Analysis ──────────────────────────────────────
+  ipcMain.handle(IPC.AI_CANCEL_ANALYSIS, () => {
+    aiInferenceService.cancel();
+    return { ok: true };
+  });
+
+  // ─── Check Models ─────────────────────────────────────────
+  ipcMain.handle(IPC.AI_CHECK_MODELS, () => {
+    const config = aiConfigStore.load();
+    const modelsDir = aiConfigStore.getModelsDir();
+
+    const statuses: ModelFileStatus[] = LLAVA_MED_FILES.map((file) => {
+      // Check configured path first, then default models dir
+      let filePath: string;
+      if (file.role === 'model' && config.modelPath) {
+        filePath = config.modelPath;
+      } else if (file.role === 'mmproj' && config.mmProjPath) {
+        filePath = config.mmProjPath;
+      } else {
+        filePath = path.join(modelsDir, file.filename);
+      }
+
+      let exists = false;
+      let sizeBytes: number | undefined;
+      try {
+        const stat = fs.statSync(filePath);
+        exists = stat.isFile();
+        sizeBytes = stat.size;
+      } catch {
+        exists = false;
+      }
+
+      return {
+        filename: file.filename,
+        role: file.role,
+        path: filePath,
+        exists,
+        sizeBytes,
+        expectedSizeMB: file.expectedSizeMB,
+        downloadUrl: file.downloadUrl,
+        description: file.description,
+      };
+    });
+
+    return statuses;
+  });
+
+  // ─── Open Models Directory ────────────────────────────────
+  ipcMain.handle(IPC.AI_OPEN_MODELS_DIR, async () => {
+    try {
+      const modelsDir = aiConfigStore.getModelsDir();
+      // Create the directory if it doesn't exist
+      if (!fs.existsSync(modelsDir)) {
+        fs.mkdirSync(modelsDir, { recursive: true });
+      }
+      await shell.openPath(modelsDir);
+      return { ok: true };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: msg };
+    }
+  });
+
+  // ─── Browse File ──────────────────────────────────────────
+  ipcMain.handle(
+    IPC.AI_BROWSE_FILE,
+    async (
+      _event,
+      title: string,
+      filters?: Array<{ name: string; extensions: string[] }>,
+    ) => {
+      try {
+        const win = BrowserWindow.getFocusedWindow();
+        if (!win) return { ok: false, error: 'No focused window' };
+
+        const result = await dialog.showOpenDialog(win, {
+          title,
+          properties: ['openFile'],
+          filters: filters ?? [
+            { name: 'GGUF Model Files', extensions: ['gguf'] },
+            { name: 'All Files', extensions: ['*'] },
+          ],
+        });
+
+        if (result.canceled || !result.filePaths[0]) {
+          return { ok: false };
+        }
+
+        return { ok: true, path: result.filePaths[0] };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { ok: false, error: msg };
+      }
+    },
+  );
+
+  // ─── Scan Models (preset dropdown) ───────────────────────────
+  ipcMain.handle(IPC.AI_SCAN_MODELS, () => {
+    const modelsDir = aiConfigStore.getModelsDir();
+
+    const presets: ModelPreset[] = KNOWN_PRESETS.map((preset) => {
+      const modelExists = fs.existsSync(path.join(modelsDir, preset.modelFilename));
+      const mmProjExists = preset.mmProjFilename
+        ? fs.existsSync(path.join(modelsDir, preset.mmProjFilename))
+        : true;
+
+      return {
+        ...preset,
+        isComplete: modelExists && mmProjExists,
+      };
+    });
+
+    return presets;
+  });
+}

--- a/src/main/services/aiConfigStore.ts
+++ b/src/main/services/aiConfigStore.ts
@@ -1,0 +1,92 @@
+/**
+ * AI Config Store — JSON file persistence for AI model configuration.
+ *
+ * Stores configuration in {userData}/ai-config.json with atomic writes
+ * (write to temp, rename). Provides sensible defaults on first run.
+ *
+ * This avoids adding SQLite or any new dependency — plain JSON with
+ * Node built-ins is sufficient for the small config payload.
+ */
+import { app } from 'electron';
+import path from 'path';
+import fs from 'fs';
+import type { AiModelConfig } from '../../shared/types/ai';
+
+// ─── Defaults ────────────────────────────────────────────────────
+
+const DEFAULT_CONFIG: AiModelConfig = {
+  backend: 'llava-med',
+  llamaServerPath: '',
+  modelPath: '',
+  mmProjPath: '',
+  gpuLayers: 999,  // offload all layers to GPU (Metal on macOS, CUDA on Linux/Windows)
+  contextSize: 4096,
+  port: 8800,
+  selectedPresetId: '',
+};
+
+// ─── Internal State ──────────────────────────────────────────────
+
+let cachedConfig: AiModelConfig | null = null;
+
+function getConfigPath(): string {
+  return path.join(app.getPath('userData'), 'ai-config.json');
+}
+
+// ─── Public API ──────────────────────────────────────────────────
+
+export const aiConfigStore = {
+  /** Load config from disk, falling back to defaults for missing fields. */
+  load(): AiModelConfig {
+    if (cachedConfig) return { ...cachedConfig } as AiModelConfig;
+
+    const configPath = getConfigPath();
+    try {
+      if (fs.existsSync(configPath)) {
+        const raw = fs.readFileSync(configPath, 'utf-8');
+        const parsed = JSON.parse(raw) as Partial<AiModelConfig>;
+        cachedConfig = { ...DEFAULT_CONFIG, ...parsed };
+        console.log('[aiConfigStore] Loaded config from', configPath);
+      } else {
+        cachedConfig = { ...DEFAULT_CONFIG };
+        console.log('[aiConfigStore] No config file found, using defaults');
+      }
+    } catch (err) {
+      console.error('[aiConfigStore] Failed to load config, using defaults:', err);
+      cachedConfig = { ...DEFAULT_CONFIG };
+    }
+
+    return { ...cachedConfig } as AiModelConfig;
+  },
+
+  /** Save partial config updates. Merges with existing config and writes atomically. */
+  save(partial: Partial<AiModelConfig>): void {
+    const current = this.load();
+    cachedConfig = { ...current, ...partial };
+
+    const configPath = getConfigPath();
+    const tmpPath = configPath + '.tmp';
+
+    try {
+      fs.writeFileSync(tmpPath, JSON.stringify(cachedConfig, null, 2), 'utf-8');
+      fs.renameSync(tmpPath, configPath);
+      console.log('[aiConfigStore] Config saved');
+    } catch (err) {
+      console.error('[aiConfigStore] Failed to save config:', err);
+      // Clean up temp file if rename failed
+      try { fs.unlinkSync(tmpPath); } catch { /* ignore */ }
+    }
+  },
+
+  /** Get the default models directory path. */
+  getModelsDir(): string {
+    return path.join(app.getPath('userData'), 'models');
+  },
+
+  /** Reset config to defaults. */
+  reset(): void {
+    cachedConfig = { ...DEFAULT_CONFIG };
+    this.save(cachedConfig);
+    console.log('[aiConfigStore] Config reset to defaults');
+  },
+};

--- a/src/main/services/aiInferenceService.ts
+++ b/src/main/services/aiInferenceService.ts
@@ -1,0 +1,564 @@
+/**
+ * AI Inference Service — manages the llama-server child process lifecycle.
+ *
+ * Spawns llama-server (llama.cpp HTTP server) as a child process, monitors
+ * its health via polling /health, and provides an OpenAI-compatible chat
+ * completion interface for image analysis.
+ *
+ * Binary resolution order:
+ *   1. Bundled binary in extraResources/llama-server/{platform}-{arch}/
+ *   2. User-configured path from ai-config.json
+ *   3. 'llama-server' on PATH
+ *
+ * All inference stays local — images never leave the device.
+ */
+import { spawn, ChildProcess } from 'child_process';
+import http from 'http';
+import path from 'path';
+import fs from 'fs';
+import { app, BrowserWindow } from 'electron';
+import { aiConfigStore } from './aiConfigStore';
+import { IPC } from '../../shared/ipcChannels';
+import type { AiServerStatus, AiModelConfig } from '../../shared/types/ai';
+
+// ─── Constants ──────────────────────────────────────────────────
+
+const HEALTH_POLL_INTERVAL_MS = 1500;
+const HEALTH_POLL_TIMEOUT_MS = 60_000; // max wait for server to become ready
+const MAX_RESTART_ATTEMPTS = 3;
+const RESTART_BACKOFF_BASE_MS = 2000;
+const REQUEST_TIMEOUT_MS = 600_000; // 10 minutes for slower hardware / CPU inference
+const ABORT_GRACE_MS = 500;
+
+// ─── Internal State ─────────────────────────────────────────────
+
+let serverProcess: ChildProcess | null = null;
+let currentStatus: AiServerStatus = 'stopped';
+let currentError: string | undefined;
+let restartCount = 0;
+let healthPollTimer: ReturnType<typeof setInterval> | null = null;
+let activeAbortController: AbortController | null = null;
+let isShuttingDown = false;
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+/** Push status update to renderer via main → renderer IPC. */
+function pushStatus(status: AiServerStatus, error?: string): void {
+  currentStatus = status;
+  currentError = error;
+
+  const update = { status, error };
+  for (const win of BrowserWindow.getAllWindows()) {
+    try {
+      win.webContents.send(IPC.AI_STATUS_UPDATE, update);
+    } catch {
+      // Window may be destroyed
+    }
+  }
+}
+
+/** Resolve the llama-server binary path. */
+function resolveBinaryPath(config: AiModelConfig): string | null {
+  // 1. Bundled binary in extraResources
+  const platformArch = `${process.platform}-${process.arch}`;
+  const ext = process.platform === 'win32' ? '.exe' : '';
+  const bundledName = `llama-server${ext}`;
+
+  const bundledPaths = [
+    // Production: resources/llama-server/{platform}-{arch}/llama-server
+    path.join(process.resourcesPath, 'llama-server', platformArch, bundledName),
+    // Dev: project root/extraResources/llama-server/{platform}-{arch}/llama-server
+    path.join(app.getAppPath(), 'extraResources', 'llama-server', platformArch, bundledName),
+  ];
+
+  for (const p of bundledPaths) {
+    if (fs.existsSync(p)) {
+      console.log('[aiInferenceService] Found bundled binary:', p);
+      return p;
+    }
+  }
+
+  // 2. User-configured path
+  if (config.llamaServerPath && fs.existsSync(config.llamaServerPath)) {
+    console.log('[aiInferenceService] Using configured binary:', config.llamaServerPath);
+    return config.llamaServerPath;
+  }
+
+  // 3. Fall back to PATH (will be resolved by child_process.spawn)
+  console.log('[aiInferenceService] Falling back to llama-server on PATH');
+  return 'llama-server';
+}
+
+/** Build CLI arguments for llama-server. */
+function buildArgs(config: AiModelConfig): string[] {
+  const args = [
+    '--model', config.modelPath,
+    '--host', '127.0.0.1',
+    '--port', String(config.port),
+    '--ctx-size', String(config.contextSize),
+    '--n-gpu-layers', String(config.gpuLayers),
+    '--parallel', '1',       // single analysis at a time — maximize per-request context
+    '--n-predict', '1024',   // safety cap matching HTTP max_tokens
+  ];
+
+  // Flash attention requires GPU — only enable when offloading layers
+  if (config.gpuLayers > 0) {
+    args.push('--flash-attn', 'on');
+  }
+
+  // LLaVA-Med requires the multimodal projector
+  if (config.backend === 'llava-med' && config.mmProjPath) {
+    args.push('--mmproj', config.mmProjPath);
+  }
+
+  return args;
+}
+
+/** HTTP GET /health check against the local llama-server. */
+function checkHealth(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const req = http.get(
+      `http://127.0.0.1:${port}/health`,
+      { timeout: 3000 },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
+        res.on('end', () => {
+          try {
+            const json = JSON.parse(data) as { status?: string };
+            resolve(json.status === 'ok');
+          } catch {
+            // Some versions return plain text
+            resolve(res.statusCode === 200);
+          }
+        });
+      },
+    );
+    req.on('error', () => resolve(false));
+    req.on('timeout', () => { req.destroy(); resolve(false); });
+  });
+}
+
+/** Wait for server to become healthy, polling at intervals. */
+function waitForHealthy(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const startTime = Date.now();
+
+    const poll = async (): Promise<void> => {
+      if (currentStatus === 'stopped' || isShuttingDown) {
+        resolve(false);
+        return;
+      }
+
+      const healthy = await checkHealth(port);
+      if (healthy) {
+        resolve(true);
+        return;
+      }
+
+      if (Date.now() - startTime > HEALTH_POLL_TIMEOUT_MS) {
+        resolve(false);
+        return;
+      }
+
+      setTimeout(poll, HEALTH_POLL_INTERVAL_MS);
+    };
+
+    poll();
+  });
+}
+
+/** Start periodic health monitoring once server is ready. */
+function startHealthMonitor(port: number): void {
+  stopHealthMonitor();
+  healthPollTimer = setInterval(async () => {
+    if (currentStatus !== 'ready') return;
+
+    const healthy = await checkHealth(port);
+    if (!healthy && currentStatus === 'ready' && !isShuttingDown) {
+      console.warn('[aiInferenceService] Health check failed, server may have crashed');
+      handleServerCrash();
+    }
+  }, HEALTH_POLL_INTERVAL_MS * 4); // Less frequent once running
+}
+
+function stopHealthMonitor(): void {
+  if (healthPollTimer) {
+    clearInterval(healthPollTimer);
+    healthPollTimer = null;
+  }
+}
+
+/** Handle unexpected server exit. */
+function handleServerCrash(): void {
+  stopHealthMonitor();
+  serverProcess = null;
+
+  if (isShuttingDown) {
+    pushStatus('stopped');
+    return;
+  }
+
+  if (restartCount < MAX_RESTART_ATTEMPTS) {
+    restartCount++;
+    const delay = RESTART_BACKOFF_BASE_MS * Math.pow(2, restartCount - 1);
+    console.log(`[aiInferenceService] Auto-restart attempt ${restartCount}/${MAX_RESTART_ATTEMPTS} in ${delay}ms`);
+    pushStatus('starting', `Restarting (attempt ${restartCount}/${MAX_RESTART_ATTEMPTS})...`);
+    setTimeout(() => {
+      aiInferenceService.start().catch((err) => {
+        console.error('[aiInferenceService] Auto-restart failed:', err);
+      });
+    }, delay);
+  } else {
+    pushStatus('error', 'Server crashed repeatedly. Please check model files and restart manually.');
+  }
+}
+
+// ─── HTTP Request Helper ────────────────────────────────────────
+
+/** Image entry for llama-server /completion endpoint. */
+interface ImageDataEntry {
+  data: string;  // raw base64 (no data:image prefix)
+  id: number;    // matches [img-N] placeholder in prompt
+}
+
+/** Response shape from llama-server /completion endpoint. */
+interface CompletionResponse {
+  content: string;
+  stop: boolean;
+  model?: string;
+  tokens_predicted?: number;
+  tokens_evaluated?: number;
+}
+
+/**
+ * Send a completion request to the local llama-server using the /completion endpoint.
+ *
+ * Unlike /v1/chat/completions, the /completion endpoint gives us full control
+ * over the prompt format. This is critical for LLaVA-Med because the chat
+ * completions endpoint doesn't apply the Mistral [INST] template correctly
+ * for multimodal content (logs show "Chat format: Content-only").
+ *
+ * The prompt must include [img-N] placeholders that match the image_data ids.
+ */
+function completionRequest(
+  port: number,
+  prompt: string,
+  imageData: ImageDataEntry[],
+  signal?: AbortSignal,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const requestBody: Record<string, any> = {
+      prompt,
+      temperature: 0.2,
+      n_predict: 1024,
+      repeat_penalty: 1.1,
+      repeat_last_n: 128,
+      stop: ['</s>', '[INST]'],  // Stop at end-of-sequence or next instruction
+    };
+
+    // Attach images if present
+    if (imageData.length > 0) {
+      requestBody.image_data = imageData;
+    }
+
+    const body = JSON.stringify(requestBody);
+
+    console.log(`[aiInferenceService] POST /completion — prompt ${prompt.length} chars, ${imageData.length} image(s), body ${body.length} bytes`);
+
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path: '/completion',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+        },
+        timeout: REQUEST_TIMEOUT_MS,
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
+        res.on('end', () => {
+          if (res.statusCode && res.statusCode >= 400) {
+            reject(new Error(`llama-server returned HTTP ${res.statusCode}: ${data.slice(0, 500)}`));
+            return;
+          }
+          try {
+            const json = JSON.parse(data) as CompletionResponse;
+            const content = json.content;
+            if (!content) {
+              reject(new Error('Empty response from llama-server'));
+              return;
+            }
+            console.log(
+              `[aiInferenceService] Response: ${content.length} chars, ` +
+              `predicted=${json.tokens_predicted}, evaluated=${json.tokens_evaluated}, ` +
+              `starts: ${content.slice(0, 200).replace(/\n/g, ' ')}...`,
+            );
+            resolve(content);
+          } catch (err) {
+            reject(new Error(`Failed to parse llama-server response: ${data.slice(0, 500)}`));
+          }
+        });
+      },
+    );
+
+    req.on('error', (err) => {
+      reject(new Error(`llama-server request failed: ${err.message}`));
+    });
+
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error(`llama-server request timed out (${REQUEST_TIMEOUT_MS / 1000}s)`));
+    });
+
+    // Abort support
+    if (signal) {
+      const onAbort = (): void => {
+        req.destroy();
+        reject(new Error('Analysis cancelled'));
+      };
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+
+    req.write(body);
+    req.end();
+  });
+}
+
+// ─── Public API ─────────────────────────────────────────────────
+
+export const aiInferenceService = {
+  /** Start the llama-server child process. */
+  async start(): Promise<void> {
+    if (serverProcess) {
+      console.log('[aiInferenceService] Server already running');
+      return;
+    }
+
+    const config = aiConfigStore.load();
+
+    // Auto-resolve model paths from models dir if not explicitly configured
+    const modelsDir = aiConfigStore.getModelsDir();
+    if (!config.modelPath) {
+      const defaultModel = path.join(modelsDir, 'llava-med-v1.5-mistral-7b.Q4_K_M.gguf');
+      if (fs.existsSync(defaultModel)) {
+        config.modelPath = defaultModel;
+        console.log('[aiInferenceService] Auto-resolved model path:', defaultModel);
+      }
+    }
+    if (!config.mmProjPath) {
+      const defaultMmproj = path.join(modelsDir, 'mmproj-model-f16.gguf');
+      if (fs.existsSync(defaultMmproj)) {
+        config.mmProjPath = defaultMmproj;
+        console.log('[aiInferenceService] Auto-resolved mmproj path:', defaultMmproj);
+      }
+    }
+
+    // Validate model files exist
+    if (!config.modelPath || !fs.existsSync(config.modelPath)) {
+      pushStatus('model-missing', 'Model file not found. Please configure the model path in settings.');
+      return;
+    }
+
+    if (config.backend === 'llava-med' && config.mmProjPath && !fs.existsSync(config.mmProjPath)) {
+      pushStatus('model-missing', 'Multimodal projector file not found. Please configure the mmproj path in settings.');
+      return;
+    }
+
+    const binaryPath = resolveBinaryPath(config);
+    if (!binaryPath) {
+      pushStatus('error', 'llama-server binary not found. Please install llama.cpp or configure the path.');
+      return;
+    }
+
+    const args = buildArgs(config);
+    console.log('[aiInferenceService] Starting:', binaryPath, args.join(' '));
+    pushStatus('starting');
+
+    try {
+      serverProcess = spawn(binaryPath, args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        detached: false,
+      });
+
+      // Log stdout/stderr
+      serverProcess.stdout?.on('data', (data: Buffer) => {
+        const line = data.toString().trim();
+        if (line) console.log('[llama-server]', line);
+      });
+
+      const stderrLines: string[] = [];
+      serverProcess.stderr?.on('data', (data: Buffer) => {
+        const line = data.toString().trim();
+        if (line) {
+          console.log('[llama-server:err]', line);
+          stderrLines.push(line);
+          if (stderrLines.length > 20) stderrLines.shift(); // keep last 20
+        }
+      });
+
+      serverProcess.on('error', (err) => {
+        console.error('[aiInferenceService] Failed to spawn llama-server:', err.message);
+        serverProcess = null;
+
+        if (err.message.includes('ENOENT')) {
+          pushStatus('error', 'llama-server binary not found. Please install llama.cpp or configure the path in settings.');
+        } else if (err.message.includes('EACCES')) {
+          pushStatus('error', 'llama-server binary is not executable. Check file permissions.');
+        } else {
+          pushStatus('error', `Failed to start server: ${err.message}`);
+        }
+      });
+
+      serverProcess.on('exit', (code, signal) => {
+        console.log(`[aiInferenceService] llama-server exited (code=${code}, signal=${signal})`);
+        const wasRunning = currentStatus === 'ready';
+        serverProcess = null;
+
+        if (isShuttingDown || currentStatus === 'stopped') {
+          pushStatus('stopped');
+          return;
+        }
+
+        if (wasRunning) {
+          handleServerCrash();
+        } else if (signal) {
+          // Process was killed by a signal during startup
+          const hint = signal === 'SIGKILL' ? ' (out of memory — try reducing context size or using GPU offloading)'
+                     : signal === 'SIGSEGV' ? ' (segmentation fault — check model file integrity)'
+                     : '';
+          const stderrTail = stderrLines.slice(-5).join('\n');
+          const detail = stderrTail ? `\n${stderrTail}` : '';
+          pushStatus('error', `Server killed by ${signal}${hint}${detail}`);
+        } else if (code !== null && code !== 0) {
+          // Failed during startup with an exit code
+          const stderrTail = stderrLines.slice(-5).join('\n');
+          const stderrAll = stderrLines.join('\n');
+          const detail = stderrTail ? `\n${stderrTail}` : '';
+
+          // Check stderr for actual port conflict evidence (not just exit code)
+          const portConflict = /address already in use|EADDRINUSE|bind failed/i.test(stderrAll);
+          if (portConflict) {
+            pushStatus('error', `Port ${config.port} is already in use. Change the port in settings.`);
+          } else {
+            pushStatus('error', `Server exited with code ${code}.${detail}`);
+          }
+        }
+      });
+
+      // Wait for health endpoint
+      const healthy = await waitForHealthy(config.port);
+      if (healthy) {
+        restartCount = 0; // Reset on successful start
+        pushStatus('ready');
+        startHealthMonitor(config.port);
+        console.log('[aiInferenceService] Server ready on port', config.port);
+      } else if (currentStatus !== 'error' && currentStatus !== 'stopped') {
+        pushStatus('error', 'Server failed to become ready within 60 seconds. Check model files and logs.');
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error('[aiInferenceService] start() error:', msg);
+      pushStatus('error', msg);
+    }
+  },
+
+  /** Stop the llama-server child process. */
+  async stop(): Promise<void> {
+    isShuttingDown = true;
+    stopHealthMonitor();
+
+    // Cancel any in-flight analysis
+    if (activeAbortController) {
+      activeAbortController.abort();
+      activeAbortController = null;
+    }
+
+    if (serverProcess) {
+      console.log('[aiInferenceService] Stopping server...');
+      const proc = serverProcess;
+      serverProcess = null;
+
+      // Try graceful SIGTERM first
+      proc.kill('SIGTERM');
+
+      // Force kill after grace period
+      await new Promise<void>((resolve) => {
+        const timeout = setTimeout(() => {
+          try {
+            proc.kill('SIGKILL');
+          } catch {
+            // Already dead
+          }
+          resolve();
+        }, ABORT_GRACE_MS);
+
+        proc.on('exit', () => {
+          clearTimeout(timeout);
+          resolve();
+        });
+      });
+    }
+
+    pushStatus('stopped');
+    restartCount = 0;
+    isShuttingDown = false;
+    console.log('[aiInferenceService] Server stopped');
+  },
+
+  /** Get current server status. */
+  getStatus(): { status: AiServerStatus; error?: string } {
+    return { status: currentStatus, error: currentError };
+  },
+
+  /**
+   * Send a completion request to the running server.
+   * Uses the /completion endpoint with a pre-formatted prompt and image data.
+   */
+  async completion(
+    prompt: string,
+    imageData: ImageDataEntry[],
+  ): Promise<string> {
+    if (currentStatus !== 'ready') {
+      throw new Error('Server is not ready. Current status: ' + currentStatus);
+    }
+
+    const config = aiConfigStore.load();
+    activeAbortController = new AbortController();
+
+    try {
+      const result = await completionRequest(
+        config.port,
+        prompt,
+        imageData,
+        activeAbortController.signal,
+      );
+      return result;
+    } finally {
+      activeAbortController = null;
+    }
+  },
+
+  /** Cancel an in-flight analysis request. */
+  cancel(): void {
+    if (activeAbortController) {
+      activeAbortController.abort();
+      activeAbortController = null;
+      console.log('[aiInferenceService] Analysis cancelled');
+    }
+  },
+
+  /** Check if the server process is running. */
+  isRunning(): boolean {
+    return serverProcess !== null && currentStatus === 'ready';
+  },
+};

--- a/src/main/services/promptTemplates.ts
+++ b/src/main/services/promptTemplates.ts
@@ -1,0 +1,100 @@
+/**
+ * Prompt Templates — optimized for LLaVA-Med v1.5 (7B Mistral-based VQA model).
+ *
+ * LLaVA-Med is based on Mistral 7B and uses the [INST]...[/INST] chat template.
+ * The /v1/chat/completions endpoint often fails to apply the correct template
+ * for multimodal models (logs show "Chat format: Content-only"), so we format
+ * the prompt ourselves and use the raw /completion endpoint instead.
+ *
+ * The [IMG] placeholder is where llama-server inserts the image embedding
+ * when using the `image_data` parameter on the /completion endpoint.
+ *
+ * Output format: structured JSON with findings[], impression, and limitations.
+ * Falls back gracefully to free-text parsing if the model doesn't produce JSON.
+ */
+import type { AiAnalysisRequest } from '../../shared/types/ai';
+
+// ─── Prompt Construction ────────────────────────────────────────
+
+/**
+ * Build the complete prompt string using Mistral [INST] template.
+ *
+ * LLaVA-Med expects:
+ *   <s>[INST] <image>\n{question} [/INST]
+ *
+ * Where <image> is replaced internally by the vision encoder's output.
+ * For llama-server's /completion endpoint, we use [img-N] placeholders
+ * that get replaced by the corresponding image_data entries.
+ */
+export function buildPrompt(request: AiAnalysisRequest): string {
+  const parts: string[] = [];
+
+  // Direct question — matches LLaVA-Med's VQA training style
+  parts.push(`Describe the findings in this ${request.modality || 'medical'} image. Note the severity of each finding.`);
+
+  // Brief metadata for clinical context
+  if (request.seriesDescription) {
+    parts.push(`Series: ${request.seriesDescription}`);
+  }
+  if (request.bodyPart) {
+    parts.push(`Body part: ${request.bodyPart}`);
+  }
+  if (request.patientAge || request.patientSex) {
+    const demo: string[] = [];
+    if (request.patientAge) demo.push(request.patientAge);
+    if (request.patientSex) demo.push(request.patientSex);
+    parts.push(`Patient: ${demo.join(', ')}`);
+  }
+
+  const question = parts.join('\n');
+
+  // Mistral [INST] template with image placeholder.
+  // [img-10] is the placeholder for the first image (id=10).
+  // Additional window images get sequential ids.
+  let prompt = `[INST] [img-10]\n${question} [/INST]`;
+
+  return prompt;
+}
+
+/**
+ * Extract image data from the request as an array of {id, data} objects
+ * for llama-server's /completion endpoint `image_data` parameter.
+ *
+ * The `data` field must be raw base64 (no data:image/... prefix).
+ * Each image gets an integer `id` that matches [img-N] in the prompt.
+ */
+export function extractImageData(
+  request: AiAnalysisRequest,
+): Array<{ data: string; id: number }> {
+  const images: Array<{ data: string; id: number }> = [];
+
+  // Primary image — id matches [img-10] in prompt
+  images.push({
+    data: stripDataUrlPrefix(request.imageDataUrl),
+    id: 10,
+  });
+
+  // Additional window images (CT multi-window) — sequential ids
+  if (request.additionalWindows) {
+    request.additionalWindows.forEach((win, idx) => {
+      images.push({
+        data: stripDataUrlPrefix(win.dataUrl),
+        id: 11 + idx,
+      });
+    });
+  }
+
+  return images;
+}
+
+/**
+ * Strip the "data:image/...;base64," prefix from a data URL.
+ * llama-server's image_data expects raw base64 only.
+ */
+function stripDataUrlPrefix(dataUrl: string): string {
+  const commaIdx = dataUrl.indexOf(',');
+  if (commaIdx !== -1) {
+    return dataUrl.slice(commaIdx + 1);
+  }
+  return dataUrl;
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -68,6 +68,41 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke(IPC.XNAT_DOWNLOAD_TEMP_FILE, sessionId, filename),
   },
 
+  ai: {
+    getConfig: () =>
+      ipcRenderer.invoke(IPC.AI_GET_CONFIG),
+    setConfig: (config: Record<string, unknown>) =>
+      ipcRenderer.invoke(IPC.AI_SET_CONFIG, config),
+    startServer: () =>
+      ipcRenderer.invoke(IPC.AI_START_SERVER),
+    stopServer: () =>
+      ipcRenderer.invoke(IPC.AI_STOP_SERVER),
+    getStatus: () =>
+      ipcRenderer.invoke(IPC.AI_GET_STATUS),
+    analyzeImage: (request: {
+      imageDataUrl: string;
+      modality: string;
+      seriesDescription?: string;
+      bodyPart?: string;
+      sliceInfo?: string;
+      studyDescription?: string;
+      patientAge?: string;
+      patientSex?: string;
+      additionalWindows?: Array<{ name: string; dataUrl: string }>;
+    }) =>
+      ipcRenderer.invoke(IPC.AI_ANALYZE_IMAGE, request),
+    checkModels: () =>
+      ipcRenderer.invoke(IPC.AI_CHECK_MODELS),
+    cancelAnalysis: () =>
+      ipcRenderer.invoke(IPC.AI_CANCEL_ANALYSIS),
+    openModelsDir: () =>
+      ipcRenderer.invoke(IPC.AI_OPEN_MODELS_DIR),
+    browseFile: (title: string, filters?: Array<{ name: string; extensions: string[] }>) =>
+      ipcRenderer.invoke(IPC.AI_BROWSE_FILE, title, filters),
+    scanModels: () =>
+      ipcRenderer.invoke(IPC.AI_SCAN_MODELS),
+  },
+
   export: {
     saveScreenshot: (dataUrl: string, defaultName?: string) =>
       ipcRenderer.invoke(IPC.EXPORT_SAVE_SCREENSHOT, dataUrl, defaultName),

--- a/src/renderer/components/icons.tsx
+++ b/src/renderer/components/icons.tsx
@@ -562,3 +562,15 @@ export function IconRedo(props: IconProps) {
     </svg>
   );
 }
+
+/** AI Sparkle — 4-point sparkle for AI features */
+export function IconAiSparkle(props: IconProps) {
+  return (
+    <svg {...defaults(props)}>
+      {/* Large 4-point sparkle */}
+      <path d="M8 1.5 L9.5 6 L14.5 8 L9.5 10 L8 14.5 L6.5 10 L1.5 8 L6.5 6 Z" fill="none" />
+      {/* Small accent sparkle */}
+      <path d="M12.5 2 L13 3.5 L14.5 4 L13 4.5 L12.5 6 L12 4.5 L10.5 4 L12 3.5 Z" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}

--- a/src/renderer/components/viewer/AiFindingsPanel.tsx
+++ b/src/renderer/components/viewer/AiFindingsPanel.tsx
@@ -1,0 +1,871 @@
+/**
+ * AiFindingsPanel — right-side panel for AI-powered finding extraction.
+ *
+ * Layout:
+ * ┌─ Header: "AI Findings" + close (X) ─────────────┐
+ * │ ⚠ AI-Generated — Not a Clinical Diagnosis        │ ← amber bg, always visible
+ * ├──────────────────────────────────────────────────┤
+ * │ ● Ready  |  LLaVA-Med 7B                        │ ← server status
+ * │ [  Analyze Current Slice  ]                       │ ← blue button
+ * ├──────────────────────────────────────────────────┤
+ * │ Finding 1: Right upper lobe nodule               │ ← severity badge, location
+ * │   Location: RUL, posterior segment               │
+ * │   Severity: moderate  Confidence: 82%            │
+ * │   [✓ Accept] [✎ Edit] [✗ Reject]                │
+ * ├──────────────────────────────────────────────────┤
+ * │ ▸ Impression                                      │ ← collapsible
+ * │ ▸ Limitations                                     │ ← collapsible
+ * │ ▸ Settings                                        │ ← collapsible inline
+ * ├──────────────────────────────────────────────────┤
+ * │ Generated in 12.3s • LLaVA-Med 7B               │ ← footer
+ * └──────────────────────────────────────────────────┘
+ */
+import { useState, useEffect, useCallback } from 'react';
+import { useAiFindingsStore } from '../../stores/aiFindingsStore';
+import { useViewerStore } from '../../stores/viewerStore';
+import { buildAnalysisRequest } from '../../lib/aiImageCapture';
+import { IconClose, IconChevronDown, IconAiSparkle } from '../icons';
+import { IPC } from '../../../shared/ipcChannels';
+import type {
+  AiFinding,
+  AiFindingSeverity,
+  AiModelConfig,
+  ModelFileStatus,
+  ModelPreset,
+} from '../../../shared/types/ai';
+
+// ─── Constants ──────────────────────────────────────────────────
+
+const SEVERITY_COLORS: Record<AiFindingSeverity, string> = {
+  normal: 'bg-emerald-900/50 text-emerald-300 border-emerald-700',
+  mild: 'bg-yellow-900/50 text-yellow-300 border-yellow-700',
+  moderate: 'bg-orange-900/50 text-orange-300 border-orange-700',
+  severe: 'bg-red-900/50 text-red-300 border-red-700',
+};
+
+const SEVERITY_BADGE: Record<AiFindingSeverity, string> = {
+  normal: 'bg-emerald-800 text-emerald-200',
+  mild: 'bg-yellow-800 text-yellow-200',
+  moderate: 'bg-orange-800 text-orange-200',
+  severe: 'bg-red-800 text-red-200',
+};
+
+const STATUS_DOT: Record<string, string> = {
+  stopped: 'bg-zinc-500',
+  starting: 'bg-yellow-400 animate-pulse',
+  ready: 'bg-emerald-400',
+  error: 'bg-red-400',
+  'model-missing': 'bg-orange-400',
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  stopped: 'Stopped',
+  starting: 'Starting...',
+  ready: 'Ready',
+  error: 'Error',
+  'model-missing': 'Model Missing',
+};
+
+// ─── Props ──────────────────────────────────────────────────────
+
+interface AiFindingsPanelProps {
+  sourceImageIds: string[];
+}
+
+// ─── Sub-Components ─────────────────────────────────────────────
+
+/** Collapsible section with chevron indicator */
+function CollapsibleSection({
+  title,
+  defaultOpen = false,
+  children,
+}: {
+  title: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="border-t border-zinc-800">
+      <button
+        onClick={() => setOpen(!open)}
+        className="w-full flex items-center gap-1.5 px-3 py-2 text-xs font-medium text-zinc-400 hover:text-zinc-200 transition-colors"
+      >
+        <IconChevronDown
+          className={`w-3 h-3 transition-transform ${open ? '' : '-rotate-90'}`}
+        />
+        {title}
+      </button>
+      {open && <div className="px-3 pb-2">{children}</div>}
+    </div>
+  );
+}
+
+/** Single finding card */
+function FindingCard({
+  finding,
+  onUpdateStatus,
+}: {
+  finding: AiFinding;
+  onUpdateStatus: (
+    id: string,
+    status: AiFinding['status'],
+    editedDescription?: string,
+  ) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [editText, setEditText] = useState(finding.editedDescription ?? finding.description);
+
+  const handleSaveEdit = useCallback(() => {
+    onUpdateStatus(finding.id, 'edited', editText);
+    setEditing(false);
+  }, [finding.id, editText, onUpdateStatus]);
+
+  const confidencePct = Math.round(finding.confidence * 100);
+
+  return (
+    <div
+      className={`rounded-lg border p-2.5 mb-2 ${SEVERITY_COLORS[finding.severity]} ${
+        finding.status === 'rejected' ? 'opacity-40' : ''
+      }`}
+    >
+      {/* Description */}
+      <div className="flex items-start justify-between gap-2 mb-1.5">
+        <div className="flex-1 min-w-0">
+          {editing ? (
+            <textarea
+              value={editText}
+              onChange={(e) => setEditText(e.target.value)}
+              className="w-full bg-zinc-900 text-zinc-200 text-xs rounded px-2 py-1 border border-zinc-600 resize-none"
+              rows={2}
+              autoFocus
+            />
+          ) : (
+            <p className="text-xs leading-relaxed">
+              {finding.status === 'edited' && finding.editedDescription
+                ? finding.editedDescription
+                : finding.description}
+            </p>
+          )}
+        </div>
+        <span
+          className={`shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded ${SEVERITY_BADGE[finding.severity]}`}
+        >
+          {finding.severity}
+        </span>
+      </div>
+
+      {/* Location + metadata */}
+      <div className="flex items-center gap-2 text-[10px] text-zinc-400 mb-2">
+        <span>{finding.location}</span>
+        <span>•</span>
+        <span>{finding.category}</span>
+        <span>•</span>
+        <span>{confidencePct}%</span>
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex items-center gap-1.5">
+        {editing ? (
+          <>
+            <button
+              onClick={handleSaveEdit}
+              className="text-[10px] px-2 py-0.5 rounded bg-blue-600 text-white hover:bg-blue-500 transition-colors"
+            >
+              Save
+            </button>
+            <button
+              onClick={() => setEditing(false)}
+              className="text-[10px] px-2 py-0.5 rounded bg-zinc-700 text-zinc-300 hover:bg-zinc-600 transition-colors"
+            >
+              Cancel
+            </button>
+          </>
+        ) : (
+          <>
+            <button
+              onClick={() => onUpdateStatus(finding.id, 'accepted')}
+              className={`text-[10px] px-2 py-0.5 rounded transition-colors ${
+                finding.status === 'accepted'
+                  ? 'bg-emerald-600 text-white'
+                  : 'bg-zinc-700/50 text-zinc-400 hover:bg-zinc-600 hover:text-zinc-200'
+              }`}
+            >
+              {'\u2713'} Accept
+            </button>
+            <button
+              onClick={() => setEditing(true)}
+              className={`text-[10px] px-2 py-0.5 rounded transition-colors ${
+                finding.status === 'edited'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-zinc-700/50 text-zinc-400 hover:bg-zinc-600 hover:text-zinc-200'
+              }`}
+            >
+              {'\u270E'} Edit
+            </button>
+            <button
+              onClick={() => onUpdateStatus(finding.id, 'rejected')}
+              className={`text-[10px] px-2 py-0.5 rounded transition-colors ${
+                finding.status === 'rejected'
+                  ? 'bg-red-600 text-white'
+                  : 'bg-zinc-700/50 text-zinc-400 hover:bg-zinc-600 hover:text-zinc-200'
+              }`}
+            >
+              {'\u2717'} Reject
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Model Setup Guide (Prominent) ──────────────────────────────
+
+/** Prominent model setup guide shown when models are missing */
+function ModelSetupGuide({
+  modelStatus,
+  onRefresh,
+}: {
+  modelStatus: ModelFileStatus[];
+  onRefresh: () => void;
+}) {
+  const missingFiles = modelStatus.filter((f) => !f.exists);
+
+  if (missingFiles.length === 0) return null;
+
+  return (
+    <div className="mx-2 mt-2 rounded-lg border border-orange-700/50 bg-orange-950/30 overflow-hidden">
+      {/* Banner */}
+      <div className="px-3 py-2 bg-orange-900/40 border-b border-orange-700/50">
+        <h3 className="text-[11px] font-bold text-orange-300">Model Setup Required</h3>
+        <p className="text-[10px] text-orange-400/80 mt-0.5">
+          Download the AI model files to enable analysis
+        </p>
+      </div>
+
+      <div className="px-3 py-2.5 space-y-3">
+        {/* Step 1: Download */}
+        <div>
+          <p className="text-[10px] font-semibold text-zinc-300 mb-1.5">
+            <span className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-blue-600 text-white text-[9px] font-bold mr-1.5">1</span>
+            Download model files
+          </p>
+          <div className="space-y-1.5 ml-5">
+            {missingFiles.map((file) => (
+              <a
+                key={file.role}
+                href={file.downloadUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-between bg-blue-600 hover:bg-blue-500 text-white rounded px-3 py-1.5 transition-colors group"
+              >
+                <span className="text-[10px] font-medium truncate mr-2">{file.filename}</span>
+                <span className="text-[9px] shrink-0 opacity-80 group-hover:opacity-100">
+                  {file.expectedSizeMB.toLocaleString()} MB
+                </span>
+              </a>
+            ))}
+          </div>
+        </div>
+
+        {/* Step 2: Save to directory */}
+        <div>
+          <p className="text-[10px] font-semibold text-zinc-300 mb-1.5">
+            <span className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-blue-600 text-white text-[9px] font-bold mr-1.5">2</span>
+            Save to models directory
+          </p>
+          <div className="ml-5">
+            <button
+              onClick={() => window.electronAPI.ai.openModelsDir()}
+              className="text-[10px] px-3 py-1.5 bg-zinc-700 text-zinc-200 rounded hover:bg-zinc-600 transition-colors font-medium"
+            >
+              Open Models Folder
+            </button>
+            <p className="text-[9px] text-zinc-500 mt-1">
+              Move downloaded .gguf files into this folder
+            </p>
+          </div>
+        </div>
+
+        {/* Step 3: Refresh */}
+        <div>
+          <p className="text-[10px] font-semibold text-zinc-300 mb-1.5">
+            <span className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-blue-600 text-white text-[9px] font-bold mr-1.5">3</span>
+            Verify setup
+          </p>
+          <div className="ml-5">
+            <button
+              onClick={onRefresh}
+              className="text-[10px] px-3 py-1.5 bg-zinc-700 text-zinc-200 rounded hover:bg-zinc-600 transition-colors font-medium"
+            >
+              Refresh Status
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Settings Section ───────────────────────────────────────────
+
+const CUSTOM_PRESET_ID = '__custom__';
+
+function SettingsSection() {
+  const [config, setConfig] = useState<AiModelConfig | null>(null);
+  const [presets, setPresets] = useState<ModelPreset[]>([]);
+  const [modelStatus, setModelStatus] = useState<ModelFileStatus[]>([]);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [showDownloadGuide, setShowDownloadGuide] = useState(false);
+
+  // Load config + presets on mount
+  useEffect(() => {
+    window.electronAPI.ai.getConfig().then(setConfig);
+    window.electronAPI.ai.scanModels().then(setPresets);
+    window.electronAPI.ai.checkModels().then(setModelStatus);
+  }, []);
+
+  const updateConfig = useCallback(
+    async (partial: Partial<AiModelConfig>) => {
+      await window.electronAPI.ai.setConfig(partial);
+      const updated = await window.electronAPI.ai.getConfig();
+      setConfig(updated);
+    },
+    [],
+  );
+
+  const refreshPresets = useCallback(async () => {
+    const updated = await window.electronAPI.ai.scanModels();
+    setPresets(updated);
+    const status = await window.electronAPI.ai.checkModels();
+    setModelStatus(status);
+  }, []);
+
+  const browseFile = useCallback(
+    async (field: 'modelPath' | 'mmProjPath' | 'llamaServerPath', title: string) => {
+      const result = await window.electronAPI.ai.browseFile(title);
+      if (result.ok && result.path) {
+        await updateConfig({ [field]: result.path });
+        await refreshPresets();
+      }
+    },
+    [updateConfig, refreshPresets],
+  );
+
+  const handlePresetChange = useCallback(
+    async (presetId: string) => {
+      if (presetId === CUSTOM_PRESET_ID) {
+        await updateConfig({ selectedPresetId: CUSTOM_PRESET_ID });
+        setShowAdvanced(true);
+        return;
+      }
+
+      const preset = presets.find((p) => p.id === presetId);
+      if (!preset) return;
+
+      // Auto-resolve paths from models dir
+      await updateConfig({
+        selectedPresetId: presetId,
+        backend: preset.backend,
+        // Clear explicit paths so auto-resolve from models dir kicks in
+        modelPath: '',
+        mmProjPath: '',
+      });
+    },
+    [presets, updateConfig],
+  );
+
+  if (!config) return null;
+
+  // Determine which preset is selected
+  const selectedId = config.selectedPresetId || (presets.length > 0 ? presets[0].id : '');
+  const selectedPreset = presets.find((p) => p.id === selectedId);
+  const isCustom = selectedId === CUSTOM_PRESET_ID;
+
+  return (
+    <div className="space-y-3">
+      {/* Model Preset Dropdown */}
+      <div>
+        <label className="text-[10px] text-zinc-500 uppercase tracking-wide">Model</label>
+        <select
+          value={selectedId}
+          onChange={(e) => handlePresetChange(e.target.value)}
+          className="w-full mt-0.5 bg-zinc-900 text-zinc-300 text-[11px] rounded px-2 py-1.5 border border-zinc-700 cursor-pointer appearance-none"
+          style={{
+            backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2371717a' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E")`,
+            backgroundRepeat: 'no-repeat',
+            backgroundPosition: 'right 8px center',
+            paddingRight: '28px',
+          }}
+        >
+          {presets.map((preset) => (
+            <option key={preset.id} value={preset.id}>
+              {preset.isComplete ? '\u2713' : '\u26A0'} {preset.displayName}
+            </option>
+          ))}
+          <option value={CUSTOM_PRESET_ID}>Custom (manual paths)</option>
+        </select>
+
+        {/* Status indicator below dropdown */}
+        {!isCustom && selectedPreset && (
+          <p className={`text-[10px] mt-1 ${selectedPreset.isComplete ? 'text-emerald-400' : 'text-orange-400'}`}>
+            {selectedPreset.isComplete
+              ? '\u2713 Model files found'
+              : '\u26A0 Missing files \u2014 see download guide below'}
+          </p>
+        )}
+      </div>
+
+      {/* GPU Layers */}
+      <div>
+        <div className="flex items-center justify-between mb-0.5">
+          <label className="text-[10px] text-zinc-500 uppercase tracking-wide">GPU Layers</label>
+          <span className="text-[11px] text-zinc-400 tabular-nums">{config.gpuLayers}</span>
+        </div>
+        <input
+          type="range"
+          min={0}
+          max={99}
+          value={config.gpuLayers}
+          onChange={(e) => updateConfig({ gpuLayers: parseInt(e.target.value, 10) })}
+          className="w-full h-1 accent-blue-500 cursor-pointer"
+        />
+        <div className="flex justify-between text-[9px] text-zinc-600 mt-0.5">
+          <span>CPU only</span>
+          <span>Full GPU</span>
+        </div>
+      </div>
+
+      {/* Context Size */}
+      <div>
+        <div className="flex items-center justify-between mb-0.5">
+          <label className="text-[10px] text-zinc-500 uppercase tracking-wide">Context Size</label>
+          <span className="text-[11px] text-zinc-400 tabular-nums">{config.contextSize}</span>
+        </div>
+        <input
+          type="range"
+          min={2048}
+          max={8192}
+          step={512}
+          value={config.contextSize}
+          onChange={(e) => updateConfig({ contextSize: parseInt(e.target.value, 10) })}
+          className="w-full h-1 accent-blue-500 cursor-pointer"
+        />
+      </div>
+
+      {/* Port */}
+      <div>
+        <div className="flex items-center justify-between mb-0.5">
+          <label className="text-[10px] text-zinc-500 uppercase tracking-wide">Port</label>
+          <span className="text-[11px] text-zinc-400 tabular-nums">{config.port}</span>
+        </div>
+        <input
+          type="number"
+          min={1024}
+          max={65535}
+          value={config.port}
+          onChange={(e) => {
+            const v = parseInt(e.target.value, 10);
+            if (v >= 1024 && v <= 65535) updateConfig({ port: v });
+          }}
+          className="w-full bg-zinc-900 text-zinc-300 text-[11px] rounded px-2 py-1 border border-zinc-700"
+        />
+      </div>
+
+      {/* Advanced (collapsible) — Browse fields for power users */}
+      <div className="border-t border-zinc-800 pt-2">
+        <button
+          onClick={() => setShowAdvanced(!showAdvanced)}
+          className="w-full flex items-center gap-1.5 text-[10px] font-medium text-zinc-400 hover:text-zinc-200 transition-colors"
+        >
+          <IconChevronDown
+            className={`w-3 h-3 transition-transform ${showAdvanced ? '' : '-rotate-90'}`}
+          />
+          Advanced
+        </button>
+
+        {showAdvanced && (
+          <div className="mt-2 space-y-2.5">
+            {/* Model Path */}
+            <div>
+              <label className="text-[10px] text-zinc-500 uppercase tracking-wide">Model Path</label>
+              <div className="flex items-center gap-1 mt-0.5">
+                <input
+                  type="text"
+                  value={config.modelPath}
+                  readOnly
+                  className="flex-1 min-w-0 bg-zinc-900 text-zinc-300 text-[11px] rounded px-2 py-1 border border-zinc-700 truncate"
+                  placeholder={isCustom ? 'Not configured' : 'Auto-detect from models dir'}
+                />
+                <button
+                  onClick={() => browseFile('modelPath', 'Select GGUF model file')}
+                  className="shrink-0 text-[10px] px-2 py-1 bg-zinc-700 text-zinc-300 rounded hover:bg-zinc-600 transition-colors"
+                >
+                  Browse
+                </button>
+              </div>
+            </div>
+
+            {/* mmproj Path */}
+            <div>
+              <label className="text-[10px] text-zinc-500 uppercase tracking-wide">mmproj Path</label>
+              <div className="flex items-center gap-1 mt-0.5">
+                <input
+                  type="text"
+                  value={config.mmProjPath}
+                  readOnly
+                  className="flex-1 min-w-0 bg-zinc-900 text-zinc-300 text-[11px] rounded px-2 py-1 border border-zinc-700 truncate"
+                  placeholder={isCustom ? 'Not configured' : 'Auto-detect from models dir'}
+                />
+                <button
+                  onClick={() => browseFile('mmProjPath', 'Select mmproj projector file')}
+                  className="shrink-0 text-[10px] px-2 py-1 bg-zinc-700 text-zinc-300 rounded hover:bg-zinc-600 transition-colors"
+                >
+                  Browse
+                </button>
+              </div>
+            </div>
+
+            {/* llama-server Path */}
+            <div>
+              <label className="text-[10px] text-zinc-500 uppercase tracking-wide">
+                llama-server binary <span className="text-zinc-600">(bundled)</span>
+              </label>
+              <div className="flex items-center gap-1 mt-0.5">
+                <input
+                  type="text"
+                  value={config.llamaServerPath}
+                  readOnly
+                  className="flex-1 min-w-0 bg-zinc-900 text-zinc-300 text-[11px] rounded px-2 py-1 border border-zinc-700 truncate"
+                  placeholder="Auto-detect (bundled or PATH)"
+                />
+                <button
+                  onClick={() => browseFile('llamaServerPath', 'Select llama-server binary')}
+                  className="shrink-0 text-[10px] px-2 py-1 bg-zinc-700 text-zinc-300 rounded hover:bg-zinc-600 transition-colors"
+                >
+                  Browse
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Open models directory */}
+      <button
+        onClick={() => window.electronAPI.ai.openModelsDir()}
+        className="w-full text-[10px] px-2 py-1.5 bg-zinc-800 text-zinc-400 rounded hover:bg-zinc-700 hover:text-zinc-200 transition-colors"
+      >
+        Open Models Directory
+      </button>
+
+      {/* Download Guide (compact, for when models are already configured) */}
+      <div className="border-t border-zinc-800 pt-2">
+        <button
+          onClick={() => {
+            setShowDownloadGuide(!showDownloadGuide);
+            if (!showDownloadGuide) refreshPresets();
+          }}
+          className="w-full flex items-center gap-1.5 text-[10px] font-medium text-zinc-400 hover:text-zinc-200 transition-colors"
+        >
+          <IconChevronDown
+            className={`w-3 h-3 transition-transform ${showDownloadGuide ? '' : '-rotate-90'}`}
+          />
+          Download Guide
+        </button>
+
+        {showDownloadGuide && (
+          <div className="mt-2 space-y-2">
+            {modelStatus.map((file) => (
+              <div key={file.role} className="bg-zinc-900 rounded p-2">
+                <div className="flex items-center justify-between mb-1">
+                  <span className="text-[10px] font-medium text-zinc-300">{file.filename}</span>
+                  {file.exists ? (
+                    <span className="text-[9px] text-emerald-400">Found</span>
+                  ) : (
+                    <span className="text-[9px] text-red-400">Missing</span>
+                  )}
+                </div>
+                <p className="text-[9px] text-zinc-500 mb-1">{file.description}</p>
+                <p className="text-[9px] text-zinc-500 mb-1">
+                  Size: ~{file.expectedSizeMB.toLocaleString()} MB
+                  {file.sizeBytes && ` (${(file.sizeBytes / 1024 / 1024).toFixed(0)} MB on disk)`}
+                </p>
+                {!file.exists && (
+                  <a
+                    href={file.downloadUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-block bg-blue-600 hover:bg-blue-500 text-white text-[10px] px-3 py-1 rounded font-medium transition-colors mt-1"
+                  >
+                    Download ({file.expectedSizeMB.toLocaleString()} MB)
+                  </a>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Main Panel Component ───────────────────────────────────────
+
+export default function AiFindingsPanel({ sourceImageIds }: AiFindingsPanelProps) {
+  const togglePanel = useAiFindingsStore((s) => s.togglePanel);
+  const serverStatus = useAiFindingsStore((s) => s.serverStatus);
+  const serverError = useAiFindingsStore((s) => s.serverError);
+  const isAnalyzing = useAiFindingsStore((s) => s.isAnalyzing);
+  const analysisProgress = useAiFindingsStore((s) => s.analysisProgress);
+  const currentResult = useAiFindingsStore((s) => s.currentResult);
+  const analysisError = useAiFindingsStore((s) => s.analysisError);
+  const setServerStatus = useAiFindingsStore((s) => s.setServerStatus);
+  const setAnalyzing = useAiFindingsStore((s) => s.setAnalyzing);
+  const setResult = useAiFindingsStore((s) => s.setResult);
+  const setAnalysisError = useAiFindingsStore((s) => s.setAnalysisError);
+  const updateFindingStatus = useAiFindingsStore((s) => s.updateFindingStatus);
+
+  const activeViewportId = useViewerStore((s) => s.activeViewportId);
+
+  // Track model file status for the prominent setup guide
+  const [modelStatus, setModelStatus] = useState<ModelFileStatus[]>([]);
+
+  const refreshModelStatus = useCallback(async () => {
+    const status = await window.electronAPI.ai.checkModels();
+    setModelStatus(status);
+  }, []);
+
+  // Wire up status push events from main process
+  useEffect(() => {
+    const handler = (update: { status: string; error?: string }) => {
+      setServerStatus(
+        update.status as Parameters<typeof setServerStatus>[0],
+        update.error,
+      );
+      // Refresh model status when server reports model-missing
+      if (update.status === 'model-missing') {
+        refreshModelStatus();
+      }
+    };
+    window.electronAPI.on(IPC.AI_STATUS_UPDATE, handler as (...args: unknown[]) => void);
+
+    // Fetch initial status + model status
+    window.electronAPI.ai.getStatus().then((s) => {
+      setServerStatus(s.status as Parameters<typeof setServerStatus>[0], s.error);
+    });
+    refreshModelStatus();
+  }, [setServerStatus, refreshModelStatus]);
+
+  // ─── Server Control ─────────────────────────────────────────
+  const handleStartServer = useCallback(async () => {
+    const result = await window.electronAPI.ai.startServer();
+    if (!result.ok && result.error) {
+      setServerStatus('error', result.error);
+    }
+  }, [setServerStatus]);
+
+  const handleStopServer = useCallback(async () => {
+    await window.electronAPI.ai.stopServer();
+  }, []);
+
+  // ─── Analysis ─────────────────────────────────────────────
+  const handleAnalyze = useCallback(async () => {
+    if (isAnalyzing) return;
+
+    setAnalyzing(true, 'Capturing image...');
+
+    // Build request from viewport
+    const request = buildAnalysisRequest(activeViewportId);
+    if (!request) {
+      setAnalysisError('Failed to capture viewport image');
+      return;
+    }
+
+    setAnalyzing(true, 'Running AI analysis...');
+
+    const result = await window.electronAPI.ai.analyzeImage(request);
+    if (result.ok && result.result) {
+      setResult(result.result);
+    } else {
+      setAnalysisError(result.error ?? 'Analysis failed');
+    }
+  }, [isAnalyzing, activeViewportId, setAnalyzing, setResult, setAnalysisError]);
+
+  const handleCancel = useCallback(async () => {
+    await window.electronAPI.ai.cancelAnalysis();
+    setAnalyzing(false);
+  }, [setAnalyzing]);
+
+  // ─── Render ─────────────────────────────────────────────────
+  const hasImages = sourceImageIds.length > 0;
+  const canAnalyze = serverStatus === 'ready' && !isAnalyzing && hasImages;
+
+  return (
+    <div className="w-80 shrink-0 border-l border-zinc-800 bg-zinc-950 flex flex-col overflow-hidden">
+      {/* ─── Header ───────────────────────────────────── */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-zinc-800">
+        <div className="flex items-center gap-1.5">
+          <IconAiSparkle className="w-4 h-4 text-blue-400" />
+          <h2 className="text-sm font-semibold text-zinc-200">AI Findings</h2>
+        </div>
+        <button
+          onClick={togglePanel}
+          title="Close AI panel"
+          className="p-0.5 rounded hover:bg-zinc-800 text-zinc-500 hover:text-zinc-300 transition-colors"
+        >
+          <IconClose className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      {/* ─── Disclaimer ───────────────────────────────── */}
+      <div className="mx-2 mt-2 px-2.5 py-2 bg-amber-900/30 border border-amber-700/50 rounded-lg">
+        <p className="text-[10px] text-amber-300 leading-relaxed font-medium">
+          AI-Generated — Not a Clinical Diagnosis. All findings must be reviewed by a qualified radiologist.
+        </p>
+      </div>
+
+      {/* ─── Scrollable Content ───────────────────────── */}
+      <div className="flex-1 overflow-y-auto">
+        {/* Server Status + Controls */}
+        <div className="px-3 py-2.5">
+          <div className="flex items-center justify-between mb-2">
+            <div className="flex items-center gap-1.5">
+              <span
+                className={`w-2 h-2 rounded-full ${STATUS_DOT[serverStatus] ?? 'bg-zinc-500'}`}
+              />
+              <span className="text-xs text-zinc-300">{STATUS_LABEL[serverStatus] ?? serverStatus}</span>
+            </div>
+            {(serverStatus === 'stopped' || serverStatus === 'error' || serverStatus === 'model-missing') && (
+              <button
+                onClick={handleStartServer}
+                className="text-[10px] px-2 py-0.5 bg-zinc-700 text-zinc-300 rounded hover:bg-zinc-600 transition-colors"
+              >
+                Start
+              </button>
+            )}
+            {(serverStatus === 'ready' || serverStatus === 'starting') && (
+              <button
+                onClick={handleStopServer}
+                className="text-[10px] px-2 py-0.5 bg-zinc-700 text-zinc-300 rounded hover:bg-zinc-600 transition-colors"
+              >
+                Stop
+              </button>
+            )}
+          </div>
+
+          {/* Server Error */}
+          {serverError && (
+            <p className="text-[10px] text-red-400 mb-2 leading-relaxed">{serverError}</p>
+          )}
+        </div>
+
+        {/* Prominent Model Setup Guide — shown when models are missing */}
+        {(serverStatus === 'model-missing' || serverStatus === 'stopped') && modelStatus.length > 0 && (
+          <ModelSetupGuide modelStatus={modelStatus} onRefresh={refreshModelStatus} />
+        )}
+
+        <div className="px-3 py-2.5 pt-0">
+          {/* Analyze Button */}
+          <button
+            onClick={isAnalyzing ? handleCancel : handleAnalyze}
+            disabled={!isAnalyzing && !canAnalyze}
+            className={`w-full py-2 rounded-lg text-xs font-semibold transition-colors ${
+              isAnalyzing
+                ? 'bg-red-600 text-white hover:bg-red-500'
+                : canAnalyze
+                  ? 'bg-blue-600 text-white hover:bg-blue-500'
+                  : 'bg-zinc-800 text-zinc-600 cursor-not-allowed'
+            }`}
+          >
+            {isAnalyzing ? (
+              <span className="flex items-center justify-center gap-2">
+                <svg className="w-3.5 h-3.5 animate-spin" viewBox="0 0 16 16" fill="none">
+                  <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="2" opacity="0.3" />
+                  <path d="M14 8a6 6 0 0 0-6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                </svg>
+                {analysisProgress || 'Analyzing...'}
+              </span>
+            ) : (
+              'Analyze Current Slice'
+            )}
+          </button>
+
+          {/* Analysis Error */}
+          {analysisError && !isAnalyzing && (
+            <p className="text-[10px] text-red-400 mt-2 leading-relaxed">{analysisError}</p>
+          )}
+        </div>
+
+        {/* ─── Findings ─────────────────────────────────── */}
+        {currentResult && currentResult.findings.length > 0 && (
+          <div className="px-3 pb-2">
+            <h3 className="text-[10px] font-semibold text-zinc-500 uppercase tracking-wide mb-2">
+              Findings ({currentResult.findings.length})
+            </h3>
+            {currentResult.findings.map((finding) => (
+              <FindingCard
+                key={finding.id}
+                finding={finding}
+                onUpdateStatus={updateFindingStatus}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* No findings message */}
+        {currentResult && currentResult.findings.length === 0 && (
+          <div className="px-3 py-4 text-center">
+            <p className="text-xs text-zinc-500">No findings identified</p>
+          </div>
+        )}
+
+        {/* ─── Impression ────────────────────────────────── */}
+        {currentResult && currentResult.impression && (
+          <CollapsibleSection title="Impression" defaultOpen>
+            <p className="text-xs text-zinc-300 leading-relaxed">{currentResult.impression}</p>
+          </CollapsibleSection>
+        )}
+
+        {/* ─── Limitations ───────────────────────────────── */}
+        {currentResult && currentResult.limitations.length > 0 && (
+          <CollapsibleSection title="Limitations">
+            <ul className="space-y-1">
+              {currentResult.limitations.map((lim, i) => (
+                <li key={i} className="text-[10px] text-zinc-500 leading-relaxed">
+                  • {lim}
+                </li>
+              ))}
+            </ul>
+          </CollapsibleSection>
+        )}
+
+        {/* ─── Raw Output (debug, shown only on parse issues) ─── */}
+        {currentResult?.rawOutput && (
+          <CollapsibleSection title="Debug: Raw Output">
+            <pre className="text-[9px] text-zinc-500 bg-zinc-900 rounded p-2 overflow-x-auto whitespace-pre-wrap max-h-40">
+              {currentResult.rawOutput}
+            </pre>
+          </CollapsibleSection>
+        )}
+
+        {/* ─── Settings ──────────────────────────────────── */}
+        <CollapsibleSection title="Settings">
+          <SettingsSection />
+        </CollapsibleSection>
+      </div>
+
+      {/* ─── Footer ──────────────────────────────────── */}
+      {currentResult && (
+        <div className="px-3 py-1.5 border-t border-zinc-800 text-[9px] text-zinc-600">
+          Generated in {(currentResult.processingTimeMs / 1000).toFixed(1)}s
+          {' • '}
+          {currentResult.modelBackend === 'llava-med' ? 'LLaVA-Med' : 'BiomedCLIP+Mistral'}
+          {' • '}
+          {currentResult.modality}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/components/viewer/Toolbar.tsx
+++ b/src/renderer/components/viewer/Toolbar.tsx
@@ -30,7 +30,9 @@ import {
   IconProtocol,
   IconUndo,
   IconRedo,
+  IconAiSparkle,
 } from '../icons';
+import { useAiFindingsStore } from '../../stores/aiFindingsStore';
 import { segmentationService } from '../../lib/cornerstone/segmentationService';
 
 // ─── Shared Button Components ─────────────────────────────────────
@@ -224,6 +226,38 @@ function DicomTagsToggle({
     >
       <IconDocument className="w-3.5 h-3.5" />
       <span>Tags</span>
+    </button>
+  );
+}
+
+/** Toggle button for the AI findings panel */
+function AiFindingsPanelToggle() {
+  const showPanel = useAiFindingsStore((s) => s.showPanel);
+  const togglePanel = useAiFindingsStore((s) => s.togglePanel);
+  const serverStatus = useAiFindingsStore((s) => s.serverStatus);
+  const isAnalyzing = useAiFindingsStore((s) => s.isAnalyzing);
+
+  return (
+    <button
+      onClick={togglePanel}
+      title={showPanel ? 'Hide AI findings' : 'Show AI findings'}
+      className={`flex items-center gap-1.5 px-2 py-1.5 text-xs font-medium rounded transition-colors ${
+        showPanel
+          ? 'bg-blue-600 text-white'
+          : 'bg-zinc-800 text-zinc-300 hover:bg-zinc-700 hover:text-white'
+      }`}
+    >
+      <span className="relative">
+        <IconAiSparkle className="w-3.5 h-3.5" />
+        {/* Status dot indicator */}
+        {serverStatus === 'ready' && !isAnalyzing && (
+          <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 bg-emerald-400 rounded-full" />
+        )}
+        {isAnalyzing && (
+          <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 bg-blue-400 rounded-full animate-pulse" />
+        )}
+      </span>
+      <span>AI</span>
     </button>
   );
 }
@@ -589,6 +623,7 @@ export default function Toolbar({ showDicomPanel = false, onToggleDicomPanel, on
       {onToggleDicomPanel && (
         <DicomTagsToggle active={showDicomPanel} onToggle={onToggleDicomPanel} />
       )}
+      {!mprActive && <AiFindingsPanelToggle />}
     </div>
   );
 }

--- a/src/renderer/lib/aiImageCapture.ts
+++ b/src/renderer/lib/aiImageCapture.ts
@@ -1,0 +1,222 @@
+/**
+ * AI Image Capture — captures viewport canvas + DICOM metadata for AI analysis.
+ *
+ * Provides functions to capture the current viewport as a PNG data URL,
+ * extract DICOM metadata (modality, series description, body part, patient info),
+ * and build a complete AiAnalysisRequest ready for IPC to the main process.
+ *
+ * For CT modality, supports multi-window capture: temporarily applies standard
+ * W/L presets (soft tissue, lung, bone), captures each, then restores original.
+ */
+import { metaData } from '@cornerstonejs/core';
+import { viewportService } from './cornerstone/viewportService';
+import type { AiAnalysisRequest } from '../../shared/types/ai';
+
+// ─── CT Window Presets ──────────────────────────────────────────
+
+const CT_WINDOWS = [
+  { name: 'Soft Tissue', ww: 400, wc: 40 },
+  { name: 'Lung', ww: 1500, wc: -600 },
+  { name: 'Bone', ww: 2000, wc: 400 },
+] as const;
+
+// ─── Internal Helpers ───────────────────────────────────────────
+
+/**
+ * Safely read a string from a metadata field.
+ * Handles the common Cornerstone3D pattern where values may be
+ * undefined, null, objects, or strings.
+ */
+function toStr(val: unknown): string {
+  if (val === undefined || val === null) return '';
+  if (typeof val === 'string') return val;
+  // Cornerstone sometimes wraps names in { Alphabetic: "..." }
+  if (typeof val === 'object' && val !== null && 'Alphabetic' in val) {
+    return String((val as Record<string, unknown>).Alphabetic ?? '');
+  }
+  return String(val);
+}
+
+/**
+ * Capture the canvas of a given viewport as a PNG data URL.
+ */
+function captureCanvas(viewportId: string): string | null {
+  const viewport = viewportService.getViewport(viewportId);
+  if (!viewport) return null;
+
+  try {
+    const canvas = viewport.getCanvas();
+    return canvas.toDataURL('image/png');
+  } catch (err) {
+    console.error('[aiImageCapture] Canvas capture failed:', err);
+    return null;
+  }
+}
+
+/**
+ * Get the current image ID from a viewport.
+ */
+function getCurrentImageId(viewportId: string): string | null {
+  const viewport = viewportService.getViewport(viewportId);
+  if (!viewport) return null;
+
+  try {
+    return viewport.getCurrentImageId() ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Public API ─────────────────────────────────────────────────
+
+/**
+ * Capture the current viewport as a PNG data URL.
+ * Returns null if the viewport is not found or capture fails.
+ */
+export function captureCurrentView(viewportId: string): string | null {
+  return captureCanvas(viewportId);
+}
+
+/**
+ * For CT scans, capture additional window/level presets.
+ * Temporarily applies each W/L preset, captures, then restores original.
+ * Returns an array of { name, dataUrl } for each window preset.
+ */
+export function captureMultiWindow(
+  viewportId: string,
+): Array<{ name: string; dataUrl: string }> {
+  const viewport = viewportService.getViewport(viewportId);
+  if (!viewport) return [];
+
+  const results: Array<{ name: string; dataUrl: string }> = [];
+
+  try {
+    // Save current VOI state
+    const props = viewport.getProperties();
+    const originalVoi = props.voiRange;
+
+    for (const preset of CT_WINDOWS) {
+      // Apply preset W/L
+      const lower = preset.wc - preset.ww / 2;
+      const upper = preset.wc + preset.ww / 2;
+      viewport.setProperties({ voiRange: { lower, upper } });
+      viewport.render();
+
+      // Capture
+      const canvas = viewport.getCanvas();
+      const dataUrl = canvas.toDataURL('image/png');
+      results.push({ name: preset.name, dataUrl });
+    }
+
+    // Restore original VOI
+    if (originalVoi) {
+      viewport.setProperties({ voiRange: originalVoi });
+      viewport.render();
+    }
+  } catch (err) {
+    console.error('[aiImageCapture] Multi-window capture failed:', err);
+  }
+
+  return results;
+}
+
+/**
+ * Extract DICOM metadata from the current image for clinical context.
+ * Uses Cornerstone3D's metadata providers (patientModule, generalSeriesModule, etc.)
+ */
+export function getImageMetadata(viewportId: string): {
+  modality: string;
+  seriesDescription: string;
+  bodyPart: string;
+  sliceInfo: string;
+  studyDescription: string;
+  patientAge: string;
+  patientSex: string;
+} {
+  const imageId = getCurrentImageId(viewportId);
+  const defaults = {
+    modality: '',
+    seriesDescription: '',
+    bodyPart: '',
+    sliceInfo: '',
+    studyDescription: '',
+    patientAge: '',
+    patientSex: '',
+  };
+
+  if (!imageId) return defaults;
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const series: any = metaData.get('generalSeriesModule', imageId) ?? {};
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const patient: any = metaData.get('patientModule', imageId) ?? {};
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const study: any = metaData.get('generalStudyModule', imageId) ?? {};
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const imagePlane: any = metaData.get('imagePlaneModule', imageId) ?? {};
+
+    // Slice info
+    const viewport = viewportService.getViewport(viewportId);
+    let sliceInfo = '';
+    if (viewport) {
+      const currentIdx = viewport.getCurrentImageIdIndex();
+      const total = viewport.getImageIds().length;
+      sliceInfo = `Slice ${currentIdx + 1} of ${total}`;
+      if (imagePlane.sliceLocation) {
+        sliceInfo += ` (location: ${imagePlane.sliceLocation})`;
+      }
+    }
+
+    return {
+      modality: toStr(series.modality),
+      seriesDescription: toStr(series.seriesDescription),
+      bodyPart: toStr(series.bodyPartExamined),
+      sliceInfo,
+      studyDescription: toStr(study.studyDescription),
+      patientAge: toStr(patient.patientAge),
+      patientSex: toStr(patient.patientSex),
+    };
+  } catch (err) {
+    console.warn('[aiImageCapture] Error reading metadata:', err);
+    return defaults;
+  }
+}
+
+/**
+ * Build a complete AiAnalysisRequest from the current viewport.
+ * Captures the image, extracts metadata, and for CT adds multi-window views.
+ */
+export function buildAnalysisRequest(viewportId: string): AiAnalysisRequest | null {
+  // Capture primary image
+  const imageDataUrl = captureCurrentView(viewportId);
+  if (!imageDataUrl) {
+    console.error('[aiImageCapture] Failed to capture viewport');
+    return null;
+  }
+
+  // Get metadata
+  const meta = getImageMetadata(viewportId);
+  const modality = meta.modality || 'UNKNOWN';
+
+  // For CT, capture additional window views
+  let additionalWindows: Array<{ name: string; dataUrl: string }> | undefined;
+  if (modality.toUpperCase() === 'CT') {
+    additionalWindows = captureMultiWindow(viewportId);
+    if (additionalWindows.length === 0) {
+      additionalWindows = undefined;
+    }
+  }
+
+  return {
+    imageDataUrl,
+    modality,
+    seriesDescription: meta.seriesDescription || undefined,
+    bodyPart: meta.bodyPart || undefined,
+    sliceInfo: meta.sliceInfo || undefined,
+    studyDescription: meta.studyDescription || undefined,
+    patientAge: meta.patientAge || undefined,
+    patientSex: meta.patientSex || undefined,
+    additionalWindows,
+  };
+}

--- a/src/renderer/pages/ViewerPage.tsx
+++ b/src/renderer/pages/ViewerPage.tsx
@@ -11,12 +11,14 @@ import MPRViewportGrid from '../components/viewer/MPRViewportGrid';
 import AnnotationListPanel from '../components/viewer/AnnotationListPanel';
 import SegmentationPanel from '../components/viewer/SegmentationPanel';
 import DicomHeaderPanel from '../components/viewer/DicomHeaderPanel';
+import AiFindingsPanel from '../components/viewer/AiFindingsPanel';
 import { toolService } from '../lib/cornerstone/toolService';
 import { annotationService } from '../lib/cornerstone/annotationService';
 import { segmentationService } from '../lib/cornerstone/segmentationService';
 import { useHotkeys } from '../hooks/useHotkeys';
 import { useAnnotationStore } from '../stores/annotationStore';
 import { useSegmentationStore } from '../stores/segmentationStore';
+import { useAiFindingsStore } from '../stores/aiFindingsStore';
 import { useViewerStore } from '../stores/viewerStore';
 
 interface ViewerPageProps {
@@ -33,6 +35,7 @@ interface ViewerPageProps {
 export default function ViewerPage({ panelImageIds, onApplyProtocol, onToggleMPR, mprSourceImageIds, leftSlot, browserSlot }: ViewerPageProps) {
   const showAnnotationPanel = useAnnotationStore((s) => s.showPanel);
   const showSegPanel = useSegmentationStore((s) => s.showPanel);
+  const showAiPanel = useAiFindingsStore((s) => s.showPanel);
   const [showDicomPanel, setShowDicomPanel] = useState(false);
 
   const mprActive = useViewerStore((s) => s.mprActive);
@@ -92,6 +95,11 @@ export default function ViewerPage({ panelImageIds, onApplyProtocol, onToggleMPR
             />
           )}
           {!mprActive && showDicomPanel && <DicomHeaderPanel onClose={closeDicomPanel} />}
+          {!mprActive && showAiPanel && (
+            <AiFindingsPanel
+              sourceImageIds={panelImageIds[activeViewportId] ?? []}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/src/renderer/stores/aiFindingsStore.ts
+++ b/src/renderer/stores/aiFindingsStore.ts
@@ -1,0 +1,145 @@
+/**
+ * AI Findings Store — reactive UI state for AI-powered finding extraction.
+ *
+ * Tracks server lifecycle, analysis progress, structured findings,
+ * and panel visibility. Components subscribe to individual slices
+ * via Zustand selectors for fine-grained re-rendering.
+ *
+ * Status push events from the main process are wired in the panel's
+ * useEffect, calling setServerStatus() when AI_STATUS_UPDATE fires.
+ */
+import { create } from 'zustand';
+import type {
+  AiServerStatus,
+  AiAnalysisResult,
+  AiFinding,
+} from '../../shared/types/ai';
+
+// ─── Store Interface ────────────────────────────────────────────
+
+interface AiFindingsStore {
+  /** Whether the AI findings panel is visible */
+  showPanel: boolean;
+
+  /** Whether the settings section is expanded */
+  showSettings: boolean;
+
+  /** Current llama-server lifecycle status */
+  serverStatus: AiServerStatus;
+
+  /** Error message from server (if status is 'error') */
+  serverError: string | undefined;
+
+  /** Whether an analysis is currently in progress */
+  isAnalyzing: boolean;
+
+  /** Progress message shown during analysis */
+  analysisProgress: string;
+
+  /** Most recent analysis result (null if no analysis run yet) */
+  currentResult: AiAnalysisResult | null;
+
+  /** Error from most recent analysis attempt */
+  analysisError: string | undefined;
+
+  // ─── Actions ────────────────────────────────────────────────
+
+  /** Toggle panel visibility */
+  togglePanel: () => void;
+
+  /** Toggle settings section visibility */
+  toggleSettings: () => void;
+
+  /** Update server status (called from AI_STATUS_UPDATE push event) */
+  setServerStatus: (status: AiServerStatus, error?: string) => void;
+
+  /** Set analyzing state with progress message */
+  setAnalyzing: (analyzing: boolean, progress?: string) => void;
+
+  /** Set analysis result */
+  setResult: (result: AiAnalysisResult) => void;
+
+  /** Set analysis error */
+  setAnalysisError: (error: string) => void;
+
+  /** Update a single finding's review status */
+  updateFindingStatus: (
+    findingId: string,
+    status: AiFinding['status'],
+    editedDescription?: string,
+  ) => void;
+
+  /** Reset store to initial state (e.g., when leaving viewer) */
+  reset: () => void;
+}
+
+// ─── Store Creation ─────────────────────────────────────────────
+
+export const useAiFindingsStore = create<AiFindingsStore>((set) => ({
+  // Initial state
+  showPanel: false,
+  showSettings: false,
+  serverStatus: 'stopped',
+  serverError: undefined,
+  isAnalyzing: false,
+  analysisProgress: '',
+  currentResult: null,
+  analysisError: undefined,
+
+  // Actions
+  togglePanel: () => set((s) => ({ showPanel: !s.showPanel })),
+
+  toggleSettings: () => set((s) => ({ showSettings: !s.showSettings })),
+
+  setServerStatus: (status, error) =>
+    set({ serverStatus: status, serverError: error }),
+
+  setAnalyzing: (analyzing, progress) =>
+    set({
+      isAnalyzing: analyzing,
+      analysisProgress: progress ?? '',
+      ...(analyzing ? { analysisError: undefined } : {}),
+    }),
+
+  setResult: (result) =>
+    set({
+      currentResult: result,
+      isAnalyzing: false,
+      analysisProgress: '',
+      analysisError: undefined,
+    }),
+
+  setAnalysisError: (error) =>
+    set({
+      isAnalyzing: false,
+      analysisProgress: '',
+      analysisError: error,
+    }),
+
+  updateFindingStatus: (findingId, status, editedDescription) =>
+    set((s) => {
+      if (!s.currentResult) return s;
+
+      const findings = s.currentResult.findings.map((f) =>
+        f.id === findingId
+          ? { ...f, status, ...(editedDescription !== undefined ? { editedDescription } : {}) }
+          : f,
+      );
+
+      return {
+        currentResult: { ...s.currentResult, findings },
+      };
+    }),
+
+  reset: () =>
+    set({
+      showPanel: false,
+      showSettings: false,
+      serverStatus: 'stopped',
+      serverError: undefined,
+      isAnalyzing: false,
+      analysisProgress: '',
+      currentResult: null,
+      analysisError: undefined,
+    }),
+}));

--- a/src/shared/ipcChannels.ts
+++ b/src/shared/ipcChannels.ts
@@ -6,9 +6,12 @@
  *   XNAT_GET_PROJECT_SESSIONS,
  *   XNAT_UPLOAD_DICOM_SEG, XNAT_UPLOAD_DICOM_RTSTRUCT, XNAT_OVERWRITE_DICOM_SEG,
  *   XNAT_AUTOSAVE_TEMP, XNAT_LIST_TEMP_FILES, XNAT_DELETE_TEMP_FILE, XNAT_DOWNLOAD_TEMP_FILE
+ *   AI_GET_CONFIG, AI_SET_CONFIG, AI_START_SERVER, AI_STOP_SERVER, AI_GET_STATUS,
+ *   AI_ANALYZE_IMAGE, AI_CHECK_MODELS, AI_CANCEL_ANALYSIS, AI_OPEN_MODELS_DIR, AI_BROWSE_FILE,
+ *   AI_SCAN_MODELS
  *
  * main → renderer (send/on):
- *   XNAT_SESSION_EXPIRED
+ *   XNAT_SESSION_EXPIRED, AI_STATUS_UPDATE
  */
 export const IPC = {
   // Auth (renderer → main)
@@ -53,6 +56,22 @@ export const IPC = {
   EXPORT_SAVE_ALL_SLICES: 'export:save-all-slices',
   EXPORT_SAVE_REPORT: 'export:save-report',
   EXPORT_SAVE_DICOM_RTSTRUCT: 'export:save-dicom-rtstruct',
+
+  // AI Findings (renderer → main, invoke/handle)
+  AI_GET_CONFIG: 'ai:get-config',
+  AI_SET_CONFIG: 'ai:set-config',
+  AI_START_SERVER: 'ai:start-server',
+  AI_STOP_SERVER: 'ai:stop-server',
+  AI_GET_STATUS: 'ai:get-status',
+  AI_ANALYZE_IMAGE: 'ai:analyze-image',
+  AI_CHECK_MODELS: 'ai:check-models',
+  AI_CANCEL_ANALYSIS: 'ai:cancel-analysis',
+  AI_OPEN_MODELS_DIR: 'ai:open-models-dir',
+  AI_BROWSE_FILE: 'ai:browse-file',
+  AI_SCAN_MODELS: 'ai:scan-models',
+
+  // AI Findings (main → renderer, send/on)
+  AI_STATUS_UPDATE: 'ai:status-update',
 } as const;
 
 export type IpcChannel = (typeof IPC)[keyof typeof IPC];

--- a/src/shared/types/ai.ts
+++ b/src/shared/types/ai.ts
@@ -1,0 +1,165 @@
+/**
+ * Shared AI type definitions between main and renderer processes.
+ *
+ * Covers model configuration, server lifecycle, image analysis requests,
+ * structured finding results, and model file status for the download guide.
+ */
+
+// ─── Model & Server ──────────────────────────────────────────────
+
+/** Supported AI model backends. LLaVA-Med is the primary (multimodal single-model).
+ *  BiomedCLIP+Mistral is a future two-stage pipeline (stubbed for now). */
+export type AiModelBackend = 'llava-med' | 'biomedclip-mistral';
+
+/** llama-server child process lifecycle states. */
+export type AiServerStatus =
+  | 'stopped'
+  | 'starting'
+  | 'ready'
+  | 'error'
+  | 'model-missing';
+
+/** Persisted AI configuration stored in {userData}/ai-config.json. */
+export interface AiModelConfig {
+  /** Active model backend */
+  backend: AiModelBackend;
+  /** Path to llama-server binary (empty = auto-detect bundled or PATH) */
+  llamaServerPath: string;
+  /** Path to the main GGUF model file */
+  modelPath: string;
+  /** Path to multimodal projector (LLaVA-Med only) */
+  mmProjPath: string;
+  /** Number of layers offloaded to GPU (0 = CPU only) */
+  gpuLayers: number;
+  /** Context window size in tokens */
+  contextSize: number;
+  /** HTTP port for llama-server */
+  port: number;
+  /** Selected model preset ID (empty = auto-detect) */
+  selectedPresetId: string;
+}
+
+/** Status update pushed from main → renderer when server state changes. */
+export interface AiServerStatusUpdate {
+  status: AiServerStatus;
+  error?: string;
+  modelLoaded?: string;
+}
+
+// ─── Analysis Request & Result ───────────────────────────────────
+
+/** Image + metadata sent from renderer to main for AI analysis. */
+export interface AiAnalysisRequest {
+  /** PNG data URL of the current viewport (data:image/png;base64,...) */
+  imageDataUrl: string;
+  /** DICOM modality (CT, MR, CR, DX, US, PT, NM, etc.) */
+  modality: string;
+  /** DICOM SeriesDescription */
+  seriesDescription?: string;
+  /** DICOM BodyPartExamined */
+  bodyPart?: string;
+  /** Current slice info (e.g., "Slice 45 of 120") */
+  sliceInfo?: string;
+  /** Study description */
+  studyDescription?: string;
+  /** Patient demographics for clinical context */
+  patientAge?: string;
+  patientSex?: string;
+  /** Additional windowed captures (CT multi-window) */
+  additionalWindows?: Array<{ name: string; dataUrl: string }>;
+}
+
+/** Severity of an individual AI finding. */
+export type AiFindingSeverity = 'normal' | 'mild' | 'moderate' | 'severe';
+
+/** Anatomical/pathological category for a finding. */
+export type AiFindingCategory =
+  | 'airspace'
+  | 'vascular'
+  | 'cardiac'
+  | 'skeletal'
+  | 'soft_tissue'
+  | 'device'
+  | 'other';
+
+/** A single structured finding extracted by the AI model. */
+export interface AiFinding {
+  /** Unique ID (UUID assigned client-side) */
+  id: string;
+  /** Description of the finding */
+  description: string;
+  /** Anatomic location */
+  location: string;
+  /** Severity classification */
+  severity: AiFindingSeverity;
+  /** Model confidence (0-1) */
+  confidence: number;
+  /** Pathological category */
+  category: AiFindingCategory;
+  /** User review status */
+  status: 'pending' | 'accepted' | 'rejected' | 'edited';
+  /** User-edited description (when status is 'edited') */
+  editedDescription?: string;
+}
+
+/** Complete result of an AI image analysis. */
+export interface AiAnalysisResult {
+  /** Structured findings extracted from the image */
+  findings: AiFinding[];
+  /** Overall clinical impression */
+  impression: string;
+  /** Analysis limitations noted by the model */
+  limitations: string[];
+  /** Which model backend produced this result */
+  modelBackend: AiModelBackend;
+  /** Unix timestamp of result */
+  timestamp: number;
+  /** Image modality that was analyzed */
+  modality: string;
+  /** Wall-clock inference time in milliseconds */
+  processingTimeMs: number;
+  /** Raw model output (for debugging parse failures) */
+  rawOutput?: string;
+}
+
+// ─── Model Preset (dropdown selector) ────────────────────────────
+
+/** A recognized model configuration shown in the Settings dropdown. */
+export interface ModelPreset {
+  /** Unique preset ID, e.g. 'llava-med-7b-q4km' */
+  id: string;
+  /** Human-readable name, e.g. 'LLaVA-Med 7B (Q4_K_M)' */
+  displayName: string;
+  /** Which backend this preset uses */
+  backend: AiModelBackend;
+  /** Expected GGUF filename in the models directory */
+  modelFilename: string;
+  /** Expected mmproj filename (LLaVA-Med only) */
+  mmProjFilename?: string;
+  /** Whether all required files are present on disk */
+  isComplete: boolean;
+  /** Combined download size in MB */
+  totalSizeMB: number;
+}
+
+// ─── Model File Status (download guide) ──────────────────────────
+
+/** Status of a single model file on disk. Used by the download guide UI. */
+export interface ModelFileStatus {
+  /** Display filename */
+  filename: string;
+  /** Role of this file (model, projector, clip encoder) */
+  role: 'model' | 'mmproj' | 'clip-vision' | 'clip-text';
+  /** Absolute path where the file should be / is located */
+  path: string;
+  /** Whether the file exists at the path */
+  exists: boolean;
+  /** File size in bytes (if exists) */
+  sizeBytes?: number;
+  /** Expected file size in MB (for download guide) */
+  expectedSizeMB: number;
+  /** HuggingFace download URL */
+  downloadUrl: string;
+  /** Human-readable description */
+  description: string;
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -2,6 +2,7 @@
 export * from './viewer';
 export * from './dicom';
 export * from './xnat';
+export * from './ai';
 
 import type {
   XnatLoginCredentials,
@@ -15,6 +16,16 @@ import type {
   XnatScan,
   XnatUploadResult,
 } from './xnat';
+
+import type {
+  AiModelConfig,
+  AiServerStatus,
+  AiAnalysisRequest,
+  AiAnalysisResult,
+  AiServerStatusUpdate,
+  ModelFileStatus,
+  ModelPreset,
+} from './ai';
 
 export interface ElectronAPI {
   platform: string;
@@ -106,6 +117,21 @@ export interface ElectronAPI {
       dicomBase64: string,
       defaultName?: string,
     ): Promise<{ ok: boolean; path?: string; error?: string }>;
+  };
+  ai: {
+    getConfig(): Promise<AiModelConfig>;
+    setConfig(config: Partial<AiModelConfig>): Promise<{ ok: boolean; error?: string }>;
+    startServer(): Promise<{ ok: boolean; error?: string }>;
+    stopServer(): Promise<{ ok: boolean }>;
+    getStatus(): Promise<{ status: AiServerStatus; error?: string }>;
+    analyzeImage(
+      request: AiAnalysisRequest,
+    ): Promise<{ ok: boolean; result?: AiAnalysisResult; error?: string }>;
+    checkModels(): Promise<ModelFileStatus[]>;
+    cancelAnalysis(): Promise<{ ok: boolean }>;
+    openModelsDir(): Promise<{ ok: boolean }>;
+    browseFile(title: string, filters?: Array<{ name: string; extensions: string[] }>): Promise<{ ok: boolean; path?: string }>;
+    scanModels(): Promise<ModelPreset[]>;
   };
   on(channel: string, callback: (...args: unknown[]) => void): void;
 }


### PR DESCRIPTION
Integrate llama-server (llama.cpp) as a child process to run LLaVA-Med v1.5 locally for medical image analysis. The system captures viewport images, sends them to the local model via the /completion endpoint with Mistral [INST] template formatting, and parses the free-text response into structured findings with keyword-inferred severity and category.

Key components:
- aiInferenceService: llama-server lifecycle management (spawn, health polling, auto-restart, graceful shutdown)
- aiConfigStore: JSON config persistence for model paths, GPU layers, port
- promptTemplates: Mistral [INST] template with [img-N] placeholders for the /completion endpoint (avoids chat template issues)
- aiHandlers: IPC handlers with free-text parser, keyword-based severity inference (normal/mild/moderate/severe), and category classification
- AiFindingsPanel: React UI with color-coded severity badges, settings panel, and model download guide
- download-llama-server.sh: script to fetch pre-built binaries with companion shared libraries (libmtmd, libllama, libggml, etc.)