### PR TITLE
Refactor CSRF token handling

### DIFF
--- a/src/main/xnat/browserLogin.ts
+++ b/src/main/xnat/browserLogin.ts
@@ -42,6 +42,7 @@ async function exchangeCredentials(
   loginSession: Electron.Session,
   serverUrl: string,
   jsessionId: string,
+  csrfToken: string | null,
 ): Promise<BrowserLoginResult> {
   let username = '';
 
@@ -93,7 +94,7 @@ async function exchangeCredentials(
     // Use original JSESSIONID if cookie read fails
   }
 
-  return { jsessionId: currentJsessionId, username, serverCookies };
+  return { jsessionId: currentJsessionId, username, serverCookies, csrfToken };
 }
 
 /** A server cookie to transfer between sessions. */
@@ -112,6 +113,8 @@ export interface BrowserLoginResult {
   username: string;
   /** All server cookies (JSESSIONID, ALB sticky-session cookies, etc.) */
   serverCookies: ServerCookie[];
+  /** CSRF token extracted from XNAT's rendered pages (session attribute XNAT_CSRF). */
+  csrfToken: string | null;
 }
 
 /**
@@ -245,10 +248,34 @@ export async function openBrowserLogin(
 
         console.log(`[browserLogin] Authenticated session detected (JSESSIONID=${jsessionId.slice(0, 8)}...)`);
 
+        // ── Extract CSRF token from the rendered XNAT page ──
+        // XNAT sets `var csrfToken = '<uuid>'` via server-side template rendering
+        // on every authenticated page. Extract it before destroying the window.
+        let csrfToken: string | null = null;
+        try {
+          csrfToken = await loginWindow.webContents.executeJavaScript('window.csrfToken || ""') || null;
+        } catch {
+          // Window may have navigated away — try loading the root page
+        }
+        if (!csrfToken) {
+          try {
+            const baseUrl = serverUrl.replace(/\/+$/, '');
+            await loginWindow.loadURL(`${baseUrl}/`);
+            csrfToken = await loginWindow.webContents.executeJavaScript('window.csrfToken || ""') || null;
+          } catch {
+            // Non-fatal — CSRF token will be missing but GETs still work
+          }
+        }
+        if (csrfToken) {
+          console.log(`[browserLogin] CSRF token extracted: ${csrfToken.slice(0, 8)}...`);
+        } else {
+          console.warn('[browserLogin] Could not extract CSRF token from login window');
+        }
+
         // ── Get username & collect all cookies ──
         // Must happen now, while the login session is still alive.
         // After finish() the session is destroyed and cookies are gone.
-        const authData = await exchangeCredentials(loginSession, serverUrl, jsessionId);
+        const authData = await exchangeCredentials(loginSession, serverUrl, jsessionId, csrfToken);
         finish(authData);
         return;
       } catch (err) {

--- a/src/main/xnat/browserLogin.ts
+++ b/src/main/xnat/browserLogin.ts
@@ -249,6 +249,13 @@ export async function openBrowserLogin(
 
         console.log(`[browserLogin] Authenticated session detected (JSESSIONID=${jsessionId.slice(0, 8)}...)`);
 
+        // Hide and stop loading immediately so XNAT's post-login
+        // redirect to the homepage doesn't flash in the window.
+        if (!loginWindow.isDestroyed()) {
+          loginWindow.webContents.stop();
+          loginWindow.hide();
+        }
+
         // ── Extract CSRF token from the rendered XNAT page ──
         // XNAT sets `var csrfToken = '<uuid>'` via server-side template rendering
         // on every authenticated page. First try the current page in the login
@@ -312,11 +319,6 @@ export async function openBrowserLogin(
       if (value === firstJsessionId) return; // same cookie, no change
 
       console.log(`[browserLogin] JSESSIONID regenerated (${value.slice(0, 8)}...), checking auth`);
-      // Hide immediately — XNAT's login JS will redirect to the homepage
-      // and we don't want that to flash while we validate asynchronously.
-      if (!loginWindow.isDestroyed()) {
-        loginWindow.hide();
-      }
       checkForAuthenticatedSession();
     }
     loginSession.cookies.on('changed', onCookieChanged);

--- a/src/main/xnat/browserLogin.ts
+++ b/src/main/xnat/browserLogin.ts
@@ -150,6 +150,7 @@ export async function openBrowserLogin(
       width: 900,
       height: 700,
       show: false,
+      useContentSize: true,
       title: 'Sign in — XNAT',
       webPreferences: {
         nodeIntegration: false,
@@ -250,18 +251,24 @@ export async function openBrowserLogin(
 
         // ── Extract CSRF token from the rendered XNAT page ──
         // XNAT sets `var csrfToken = '<uuid>'` via server-side template rendering
-        // on every authenticated page. Extract it before destroying the window.
+        // on every authenticated page. First try the current page in the login
+        // window; if that fails, fetch the root page via session.fetch() (invisible
+        // HTTP request) to avoid flashing the XNAT homepage in the visible window.
         let csrfToken: string | null = null;
         try {
           csrfToken = await loginWindow.webContents.executeJavaScript('window.csrfToken || ""') || null;
         } catch {
-          // Window may have navigated away — try loading the root page
+          // Window may have navigated away — fall through to fetch
         }
         if (!csrfToken) {
           try {
             const baseUrl = serverUrl.replace(/\/+$/, '');
-            await loginWindow.loadURL(`${baseUrl}/`);
-            csrfToken = await loginWindow.webContents.executeJavaScript('window.csrfToken || ""') || null;
+            const resp = await loginSession.fetch(`${baseUrl}/`);
+            if (resp.ok) {
+              const html = await resp.text();
+              const match = html.match(/var\s+csrfToken\s*=\s*['"]([^'"]+)['"]/);
+              csrfToken = match?.[1] || null;
+            }
           } catch {
             // Non-fatal — CSRF token will be missing but GETs still work
           }
@@ -305,6 +312,11 @@ export async function openBrowserLogin(
       if (value === firstJsessionId) return; // same cookie, no change
 
       console.log(`[browserLogin] JSESSIONID regenerated (${value.slice(0, 8)}...), checking auth`);
+      // Hide immediately — XNAT's login JS will redirect to the homepage
+      // and we don't want that to flash while we validate asynchronously.
+      if (!loginWindow.isDestroyed()) {
+        loginWindow.hide();
+      }
       checkForAuthenticatedSession();
     }
     loginSession.cookies.on('changed', onCookieChanged);
@@ -319,7 +331,25 @@ export async function openBrowserLogin(
     const loginUrl = `${baseUrl}/app/template/Login.vm`;
     console.log(`[browserLogin] Opening login window: ${loginUrl}`);
 
-    loginWindow.loadURL(loginUrl).then(() => {
+    loginWindow.loadURL(loginUrl).then(async () => {
+      if (resolved) return;
+
+      // Resize the window to fit the page content before showing
+      try {
+        const [w, h] = await loginWindow.webContents.executeJavaScript(
+          '[document.documentElement.scrollWidth, document.documentElement.scrollHeight]',
+        );
+        if (w > 0 && h > 0) {
+          loginWindow.setContentSize(
+            Math.max(w, 480),
+            Math.max(h, 360),
+          );
+          loginWindow.center();
+        }
+      } catch {
+        // Use default size if measurement fails
+      }
+
       if (!resolved) {
         loginWindow.show();
       }

--- a/src/main/xnat/sessionManager.ts
+++ b/src/main/xnat/sessionManager.ts
@@ -227,7 +227,8 @@ function setupWebRequestInterceptor(): void {
   const serverUrl = client.serverUrl;
   const filter = { urls: [`${serverUrl}/*`] };
 
-  // Inject auth headers on outgoing requests
+  // Inject auth cookie on outgoing requests from the renderer (Cornerstone
+  // wadouri GETs). Main-process fetches already have cookies via session.fetch().
   electronSession.defaultSession.webRequest.onBeforeSendHeaders(
     filter,
     (details, callback) => {
@@ -239,35 +240,14 @@ function setupWebRequestInterceptor(): void {
       try {
         const authHeaders = client.buildAuthHeaders();
         const requestHeaders = { ...details.requestHeaders } as Record<string, string | string[]>;
-        const method = String(details.method || 'GET').toUpperCase();
-        const isMutating = method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE';
         const hasHeader = (name: string): boolean =>
           Object.keys(requestHeaders).some((k) => k.toLowerCase() === name.toLowerCase());
 
-        // Preserve cookie jar-managed headers when already present (main-process
-        // fetches). Only inject auth cookie for requests that have none.
         if (!hasHeader('cookie') && authHeaders.Cookie) {
           requestHeaders.Cookie = authHeaders.Cookie;
         }
 
-        // Do not overwrite existing CSRF headers set by the caller.
-        for (const [name, value] of Object.entries(authHeaders)) {
-          if (name.toLowerCase() === 'cookie') continue;
-          if (!hasHeader(name)) {
-            requestHeaders[name] = value;
-          }
-        }
-
-        // XNAT can require CSRF token only for "interactive" user-agents
-        // (browser regexes like Mozilla/AppleWebKit). Main-process API writes
-        // should present a non-interactive agent string.
-        if (isMutating) {
-          requestHeaders['User-Agent'] = 'XNAT-Viewer-API/0.4.1';
-        }
-
-        callback({
-          requestHeaders,
-        });
+        callback({ requestHeaders });
       } catch {
         callback({ requestHeaders: details.requestHeaders });
       }

--- a/src/main/xnat/xnatClient.ts
+++ b/src/main/xnat/xnatClient.ts
@@ -193,19 +193,26 @@ export class XnatClient {
     const isMutating = method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE';
 
     let fetchUrl = url;
-    if (isMutating && this.csrfToken) {
-      const separator = url.includes('?') ? '&' : '?';
-      fetchUrl = `${url}${separator}XNAT_CSRF=${encodeURIComponent(this.csrfToken)}`;
-    } else if (isMutating) {
-      console.warn(`[xnatClient] No CSRF token for ${method} ${url}`);
-    }
-
-    return electronSession.defaultSession.fetch(fetchUrl, {
+    const fetchOptions: RequestInit = {
       credentials: 'include',
       cache: 'no-store',
       redirect: 'follow',
       ...(options ?? {}),
-    });
+    };
+
+    if (isMutating && this.csrfToken) {
+      const separator = url.includes('?') ? '&' : '?';
+      fetchUrl = `${url}${separator}XNAT_CSRF=${encodeURIComponent(this.csrfToken)}`;
+    } else if (isMutating) {
+      // Fallback: XNAT's XnatSecureGuard skips CSRF validation for
+      // non-browser User-Agent strings. Use the XNATDesktopClient UA
+      // so mutating requests still succeed without a token.
+      const headers = new Headers(fetchOptions.headers as HeadersInit ?? {});
+      headers.set('User-Agent', 'XNATDesktopClient');
+      fetchOptions.headers = headers;
+    }
+
+    return electronSession.defaultSession.fetch(fetchUrl, fetchOptions);
   }
 
   /**

--- a/src/main/xnat/xnatClient.ts
+++ b/src/main/xnat/xnatClient.ts
@@ -33,33 +33,8 @@ export class XnatClient {
   /** Set by markDisconnected() to stop concurrent in-flight requests from retrying */
   private _disconnected = false;
   private scanSopClassUidCache = new Map<string, string | null>();
-  /** Cached CSRF token used for mutating requests (PUT/POST/PATCH/DELETE). */
+  /** CSRF token extracted at login — appended as ?XNAT_CSRF= on mutating requests. */
   private csrfToken: string | null = null;
-  private loggedCsrfMissingWarning = false;
-  /** Candidate cookie names used by XNAT/Spring deployments for CSRF token transport. */
-  private static readonly CSRF_COOKIE_NAMES = [
-    'XNAT_CSRF',
-    'XSRF-TOKEN',
-    'CSRF-TOKEN',
-    '_csrf',
-    'CSRF',
-  ];
-  /** Candidate endpoints that may return/refresh CSRF token material on different XNAT versions. */
-  private static readonly CSRF_TOKEN_ENDPOINTS = [
-    '/data/services/tokens/XSRF',
-    '/data/services/tokens/CSRF',
-    '/data/services/tokens/xsrf',
-    '/data/services/tokens/csrf',
-    '/xapi/auth/csrf',
-    '/xapi/auth/CSRF',
-    '/xapi/auth/xsrf',
-    '/xapi/auth/XSRF',
-  ];
-  private static readonly CSRF_TOKEN_METHODS: ReadonlyArray<'GET' | 'POST' | 'PUT'> = [
-    'GET',
-    'POST',
-    'PUT',
-  ];
 
   constructor(baseUrl: string) {
     // Normalize base URL (remove trailing slash)
@@ -76,12 +51,16 @@ export class XnatClient {
     jsessionId: string;
     username: string;
     serverCookies?: ServerCookie[];
+    csrfToken?: string | null;
   }): Promise<void> {
     this.username = opts.username;
     this.serverCookies = opts.serverCookies ?? [];
-    this.csrfToken = this.extractCsrfFromServerCookies(this.serverCookies);
+    this.csrfToken = opts.csrfToken ?? null;
     await this.setAllCookies(opts.jsessionId, this.serverCookies);
-    console.log(`[xnatClient] Browser login complete: user=${this.username}`);
+    console.log(
+      `[xnatClient] Browser login complete: user=${this.username}`,
+      this.csrfToken ? `csrf=${this.csrfToken.slice(0, 8)}...` : '(no CSRF token)',
+    );
   }
 
   /**
@@ -201,316 +180,32 @@ export class XnatClient {
       if (c.name === 'JSESSIONID') continue;
       parts.push(`${c.name}=${c.value}`);
     }
-    const headers: Record<string, string> = { Cookie: parts.join('; ') };
-    if (this.csrfToken) {
-      headers['X-XSRF-TOKEN'] = this.csrfToken;
-      headers['X-CSRF-TOKEN'] = this.csrfToken;
-      headers.XNAT_CSRF = this.csrfToken;
-      headers['X-Requested-With'] = 'XMLHttpRequest';
-    }
-    return headers;
+    return { Cookie: parts.join('; ') };
   }
 
   /**
-   * Wrapper around session.fetch that uses the default session's
-   * cookie jar. session.fetch() automatically sends cookies for the
-   * matching domain.
+   * Authenticated fetch via Electron's default session cookie jar.
+   * For mutating requests (POST/PUT/PATCH/DELETE), appends the CSRF
+   * token as an XNAT_CSRF query parameter.
    */
-  private rawFetch(url: string, options?: RequestInit): Promise<Response> {
-    // Explicitly set fetch mode/credentials for non-renderer requests so
-    // Chromium does not downgrade to no-cors semantics (which can strip
-    // custom CSRF headers on mutating requests).
-    const normalized: RequestInit = {
+  private async xfetch(url: string, options?: RequestInit): Promise<Response> {
+    const method = (options?.method ?? 'GET').toUpperCase();
+    const isMutating = method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE';
+
+    let fetchUrl = url;
+    if (isMutating && this.csrfToken) {
+      const separator = url.includes('?') ? '&' : '?';
+      fetchUrl = `${url}${separator}XNAT_CSRF=${encodeURIComponent(this.csrfToken)}`;
+    } else if (isMutating) {
+      console.warn(`[xnatClient] No CSRF token for ${method} ${url}`);
+    }
+
+    return electronSession.defaultSession.fetch(fetchUrl, {
       credentials: 'include',
       cache: 'no-store',
       redirect: 'follow',
       ...(options ?? {}),
-    };
-    if (!normalized.mode) {
-      normalized.mode = 'cors';
-    }
-    return electronSession.defaultSession.fetch(url, normalized);
-  }
-
-  private extractCsrfFromServerCookies(cookies: ServerCookie[]): string | null {
-    for (const name of XnatClient.CSRF_COOKIE_NAMES) {
-      const hit = cookies.find((c) => c.name.toLowerCase() === name.toLowerCase() && c.value);
-      if (hit?.value) return hit.value;
-    }
-    return null;
-  }
-
-  private async readCsrfFromDefaultSessionCookies(): Promise<string | null> {
-    try {
-      const cookies = await electronSession.defaultSession.cookies.get({ url: this.baseUrl });
-      for (const name of XnatClient.CSRF_COOKIE_NAMES) {
-        const hit = cookies.find((c) => c.name.toLowerCase() === name.toLowerCase() && c.value);
-        if (hit?.value) {
-          return hit.value;
-        }
-      }
-      const heuristic = cookies.find((c) => /csrf|xsrf/i.test(c.name) && c.value);
-      if (heuristic?.value) {
-        return heuristic.value;
-      }
-    } catch {
-      // Ignore cookie-read failures and continue with endpoint probing.
-    }
-    return null;
-  }
-
-  private async getDefaultSessionCookieNames(): Promise<string[]> {
-    try {
-      const cookies = await electronSession.defaultSession.cookies.get({ url: this.baseUrl });
-      return cookies.map((c) => c.name);
-    } catch {
-      return [];
-    }
-  }
-
-  private extractCsrfFromResponse(resp: Response, bodyText: string): string | null {
-    const headerCandidates = ['x-xsrf-token', 'x-csrf-token', 'xnat_csrf'];
-    for (const name of headerCandidates) {
-      const value = resp.headers.get(name);
-      if (value && value.trim()) return value.trim();
-    }
-
-    const text = (bodyText || '').trim();
-    if (!text) return null;
-    if (text.startsWith('<')) return null; // HTML status/login pages are not token payloads
-
-    // Plain text token.
-    if (!text.startsWith('{') && !text.startsWith('[')) {
-      const normalized = text.replace(/^"+|"+$/g, '').trim();
-      return normalized || null;
-    }
-
-    // JSON payload token.
-    try {
-      const parsed = JSON.parse(text) as Record<string, unknown>;
-      const candidates = ['token', 'csrfToken', 'csrf', '_csrf', 'value'];
-      for (const key of candidates) {
-        const raw = parsed[key];
-        if (typeof raw === 'string' && raw.trim()) return raw.trim();
-      }
-    } catch {
-      // Not parseable JSON — ignore.
-    }
-    return null;
-  }
-
-  private extractCsrfFromHtml(htmlText: string): string | null {
-    const text = htmlText || '';
-    if (!text) return null;
-    const patterns = [
-      /name=["']_csrf["'][^>]*value=["']([^"']+)["']/i,
-      /name=["']csrf-token["'][^>]*content=["']([^"']+)["']/i,
-      /name=["']x-csrf-token["'][^>]*content=["']([^"']+)["']/i,
-      /"_csrf"\s*:\s*"([^"]+)"/i,
-      /"csrfToken"\s*:\s*"([^"]+)"/i,
-      /window\._csrf\s*=\s*["']([^"']+)["']/i,
-    ];
-    for (const pattern of patterns) {
-      const match = text.match(pattern);
-      const value = match?.[1]?.trim();
-      if (value) return value;
-    }
-    return null;
-  }
-
-  private async ensureCsrfToken(): Promise<string | null> {
-    if (this.csrfToken) return this.csrfToken;
-
-    const cookieToken = await this.readCsrfFromDefaultSessionCookies();
-    if (cookieToken) {
-      this.csrfToken = cookieToken;
-      console.log('[xnatClient] CSRF token resolved from cookie jar');
-      return cookieToken;
-    }
-
-    // Prime server session state first. Some deployments only mint CSRF
-    // after a normal authenticated API request.
-    try {
-      await this.rawFetch(`${this.baseUrl}/data/JSESSION`, {
-        method: 'GET',
-        headers: {
-          Accept: 'application/json, text/plain, */*',
-          'X-Requested-With': 'XMLHttpRequest',
-        },
-      });
-      const tokenAfterPrime = await this.readCsrfFromDefaultSessionCookies();
-      if (tokenAfterPrime) {
-        this.csrfToken = tokenAfterPrime;
-        console.log('[xnatClient] CSRF token resolved from cookie jar after JSESSION prime');
-        return tokenAfterPrime;
-      }
-    } catch {
-      // Continue with endpoint probing.
-    }
-
-    const probeResults: string[] = [];
-    for (const endpoint of XnatClient.CSRF_TOKEN_ENDPOINTS) {
-      for (const method of XnatClient.CSRF_TOKEN_METHODS) {
-        try {
-          const headers = new Headers({
-            Accept: 'application/json, text/plain, */*',
-            'X-Requested-With': 'XMLHttpRequest',
-            'X-XSRF-TOKEN': 'Fetch',
-            'X-CSRF-TOKEN': 'Fetch',
-          });
-          let body: string | undefined;
-          if (method !== 'GET') {
-            headers.set('Content-Type', 'application/json');
-            body = '{}';
-          }
-          const resp = await this.rawFetch(`${this.baseUrl}${endpoint}`, {
-            method,
-            headers,
-            body,
-          });
-          const text = await resp.text().catch(() => '');
-          const extracted = this.extractCsrfFromResponse(resp, text);
-          if (extracted) {
-            this.csrfToken = extracted;
-            console.log(`[xnatClient] CSRF token resolved from endpoint ${method} ${endpoint}`);
-            return extracted;
-          }
-          const refreshedCookieToken = await this.readCsrfFromDefaultSessionCookies();
-          if (refreshedCookieToken) {
-            this.csrfToken = refreshedCookieToken;
-            console.log(`[xnatClient] CSRF token refreshed in cookie jar via ${method} ${endpoint}`);
-            return refreshedCookieToken;
-          }
-          const snippet = text.replace(/\s+/g, ' ').slice(0, 120);
-          probeResults.push(`${method} ${endpoint}:${resp.status}${snippet ? `:${snippet}` : ''}`);
-        } catch {
-          probeResults.push(`${method} ${endpoint}:error`);
-          // Try next method/endpoint variant.
-        }
-      }
-    }
-
-    // Fallback: some deployments only expose CSRF token in authenticated HTML pages.
-    const htmlFallbacks = [
-      '/app/template/Login.vm',
-      '/app/',
-      '/',
-    ];
-    for (const endpoint of htmlFallbacks) {
-      try {
-        const resp = await this.rawFetch(`${this.baseUrl}${endpoint}`, {
-          method: 'GET',
-          headers: {
-            Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-            'X-Requested-With': 'XMLHttpRequest',
-          },
-        });
-        const text = await resp.text().catch(() => '');
-        const htmlToken = this.extractCsrfFromHtml(text);
-        if (htmlToken) {
-          this.csrfToken = htmlToken;
-          console.log(`[xnatClient] CSRF token resolved from HTML fallback ${endpoint}`);
-          return htmlToken;
-        }
-        probeResults.push(`GET ${endpoint}:${resp.status}:html-no-token`);
-      } catch {
-        probeResults.push(`GET ${endpoint}:error`);
-      }
-    }
-
-    const names = await this.getDefaultSessionCookieNames();
-    console.warn(
-      '[xnatClient] Failed to resolve CSRF token.',
-      `probes=${probeResults.join(', ') || '<none>'}`,
-      `cookies=${names.join(', ') || '<none>'}`,
-    );
-
-    return null;
-  }
-
-  private isInvalidCsrfResponse(resp: Response, bodyText: string): boolean {
-    const text = bodyText.toLowerCase();
-    const csrfText = (
-      text.includes('invalid csrf')
-      || text.includes('invalidcsrf')
-      || text.includes('invalidcsrfexception')
-      || text.includes('csrftoken')
-      || text.includes('csrf')
-    );
-    if (!csrfText) return false;
-    return (
-      resp.status === 403
-      || resp.status === 400
-      || resp.status === 412
-      || resp.status === 500
-      || text.includes('forbidden')
-    );
-  }
-
-  private async xfetch(url: string, options?: RequestInit): Promise<Response> {
-    const method = (options?.method ?? 'GET').toUpperCase();
-    const isMutating = method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE';
-    if (!isMutating) {
-      return this.rawFetch(url, options);
-    }
-
-    const attachCsrfHeaders = (token: string | null): Headers => {
-      const headers = new Headers(options?.headers ?? {});
-      headers.set('X-Requested-With', 'XMLHttpRequest');
-      if (token) {
-        headers.set('X-XSRF-TOKEN', token);
-        headers.set('X-CSRF-TOKEN', token);
-        headers.set('XNAT_CSRF', token);
-        headers.set('XSRF-TOKEN', token);
-      }
-      return headers;
-    };
-
-    const csrfToken = await this.ensureCsrfToken();
-    if (csrfToken) {
-      this.loggedCsrfMissingWarning = false;
-    } else if (!this.loggedCsrfMissingWarning) {
-      this.loggedCsrfMissingWarning = true;
-      console.warn(`[xnatClient] No CSRF token resolved for ${method} ${url}`);
-    }
-
-    let response = await this.rawFetch(url, {
-      ...(options ?? {}),
-      headers: attachCsrfHeaders(csrfToken),
     });
-
-    // Some XNAT deployments rotate CSRF tokens server-side and may return
-    // either 403 or 500 InvalidCsrfException. Retry once on CSRF failures.
-    if (!response.ok) {
-      const firstBody = await response.text().catch(() => '');
-      if (this.isInvalidCsrfResponse(response, firstBody)) {
-        this.csrfToken = null;
-        const refreshedToken = await this.ensureCsrfToken();
-        if (refreshedToken) {
-          console.warn('[xnatClient] Retrying mutating request after CSRF token refresh');
-          response = await this.rawFetch(url, {
-            ...(options ?? {}),
-            headers: attachCsrfHeaders(refreshedToken),
-          });
-        } else {
-          // Recreate the consumed response body so callers receive the original detail.
-          response = new Response(firstBody, {
-            status: response.status,
-            statusText: response.statusText,
-            headers: response.headers,
-          });
-        }
-      } else {
-        // Recreate the consumed body for non-CSRF callers too.
-        response = new Response(firstBody, {
-          status: response.status,
-          statusText: response.statusText,
-          headers: response.headers,
-        });
-      }
-    }
-
-    return response;
   }
 
   /**


### PR DESCRIPTION
## Summary      
- Extract the CSRF token directly from XNAT's rendered page at login time (`window.csrfToken`) instead of probing multiple cookie names and API endpoints at request time
- Append the token as an `XNAT_CSRF` query parameter on mutating requests, matching XNAT's expected format
- Fall back to `XNATDesktopClient` User-Agent when no CSRF token is available, which bypasses XNAT's browser-agent CSRF guard
- Remove ~300 lines of speculative CSRF machinery (cookie scanning, endpoint probing, HTML scraping, retry-on-403 logic)

## Changes
- **`browserLogin.ts`** — After detecting an authenticated session, execute JS in the login window to read `window.csrfToken` and pass it through to the session setup
- **`xnatClient.ts`** — Replace `ensureCsrfToken()` and all CSRF discovery/retry infrastructure with a single `csrfToken` field set at login; `xfetch()` appends it as a query param or falls back to a non-browser User-Agent
- **`sessionManager.ts`** — Simplify the `onBeforeSendHeaders` interceptor to only inject the auth cookie (no CSRF headers or User-Agent overrides needed)

## Test plan
- [x] Log in via browser login flow and verify CSRF token appears in console logs
- [x] Perform mutating operations (upload SEG, create assessor) and confirm they succeed

I can't think of how to verify that the fallback User-Agent allows writes, but based on the XNAT code, it should.