### PR TITLE
Add per-viewport orientation selection, crosshair sync, and multi-pan…

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -568,13 +568,27 @@ export default function App() {
     // Compute the next value eagerly so we can bump epochs synchronously.
     const prev = panelImageIdsRef.current;
     const next = typeof updater === 'function' ? updater(prev) : updater;
-    // Bump epoch for every panel in the new map (synchronous — no batching delay)
-    for (const pid of Object.keys(next)) {
-      panelEpochRef.current[pid] = viewportReadyService.bumpEpoch(pid);
+    // Bump epoch only for panels whose image stack actually changed.
+    // Bumping unchanged panels causes whenReady() waits to target epochs that
+    // will never be marked ready (no viewport recreate), leading to timeouts.
+    const allPanelIds = new Set([...Object.keys(prev), ...Object.keys(next)]);
+    for (const pid of allPanelIds) {
+      const prevIds = prev[pid] ?? [];
+      const nextIds = next[pid] ?? [];
+      const changed =
+        prevIds.length !== nextIds.length ||
+        prevIds.some((id, idx) => id !== nextIds[idx]);
+      if (changed) {
+        panelEpochRef.current[pid] = viewportReadyService.bumpEpoch(pid);
+      }
     }
     // Eagerly update the ref so that back-to-back calls before React re-renders
     // still see the correct "previous" value.
     panelImageIdsRef.current = next;
+    const viewer = useViewerStore.getState();
+    for (const pid of allPanelIds) {
+      viewer.setPanelImageIds(pid, next[pid] ?? []);
+    }
     setPanelImageIdsRaw(next);
   }, []);
 
@@ -753,6 +767,9 @@ export default function App() {
         panelXnatContextMap: {},
         panelScanMap: {},
         panelSessionLabelMap: {},
+        panelSubjectLabelMap: {},
+        crosshairWorldPoint: null,
+        crosshairSourcePanelId: null,
       });
     }
     wasConnectedRef.current = isConnected;
@@ -975,7 +992,7 @@ export default function App() {
 
     // Load regular DICOM image files into the active panel
     let newImageIds: string[] = [];
-    const targetPanel = useViewerStore.getState().activeViewportId;
+    let targetPanel = useViewerStore.getState().activeViewportId;
 
     if (regularFiles.length > 0) {
       for (const file of regularFiles) {
@@ -995,6 +1012,7 @@ export default function App() {
       console.log(`Loaded ${newImageIds.length} DICOM image files into ${targetPanel}`);
       setPanelImageIds((prev) => ({ ...prev, [targetPanel]: newImageIds }));
       useViewerStore.getState().setPanelSessionLabel(targetPanel, '');
+      useViewerStore.getState().setPanelSubjectLabel(targetPanel, '');
       setBrowserStatusMessage(
         'Loaded local image stack',
         'success',
@@ -1245,6 +1263,7 @@ export default function App() {
     scanId: string,
     scan: XnatScan,
     context: { projectId: string; subjectId: string; sessionLabel: string; projectName?: string; subjectLabel?: string },
+    options?: { openInMpr?: boolean },
   ) => {
     if (!isConnected) return;
 
@@ -1263,7 +1282,7 @@ export default function App() {
       dicomwebLoader.clearScanImageIdsCache(currentSessionId);
     }
 
-    const targetPanel = useViewerStore.getState().activeViewportId;
+    let targetPanel = useViewerStore.getState().activeViewportId;
     const ensureSourceScanOnPanel = async (panelId: string, sourceScanId: string): Promise<string[]> => {
       segmentationManager.removeSegmentationsFromViewport(panelId);
       const ids = await dicomwebLoader.getScanImageIds(sessionId, sourceScanId, {
@@ -1279,6 +1298,7 @@ export default function App() {
       });
       useViewerStore.getState().setPanelScan(panelId, sourceScanId);
       useViewerStore.getState().setPanelSessionLabel(panelId, context.sessionLabel);
+      useViewerStore.getState().setPanelSubjectLabel(panelId, context.subjectLabel ?? context.subjectId);
       segmentationManager.onPanelImagesChanged(
         panelId, sourceScanId, panelEpochRef.current[panelId] ?? 0,
       );
@@ -1315,6 +1335,7 @@ export default function App() {
       sessionLabel: context.sessionLabel,
       scanId: contextScanId,
     });
+    useViewerStore.getState().setPanelSubjectLabel(targetPanel, context.subjectLabel ?? context.subjectId);
 
     // Remember this session for "Load Recent" on next visit
     const serverUrl = useConnectionStore.getState().connection?.serverUrl;
@@ -1565,6 +1586,7 @@ export default function App() {
           );
           useViewerStore.getState().setPanelScan(segTargetPanel, resolvedScanId);
           useViewerStore.getState().setPanelSessionLabel(segTargetPanel, context.sessionLabel);
+          useViewerStore.getState().setPanelSubjectLabel(segTargetPanel, context.subjectLabel ?? context.subjectId);
           segmentationManager.onPanelImagesChanged(
             segTargetPanel, resolvedScanId, panelEpochRef.current[segTargetPanel] ?? 0,
           );
@@ -1822,6 +1844,11 @@ export default function App() {
 
         if (stackUnchanged) {
           console.log(`[App] Scan #${scanId} already loaded in ${targetPanel}; skipping viewport reload`);
+          // This path does not recreate the viewport; ensure readiness is marked
+          // for the current epoch so overlay attach paths cannot stall.
+          const currentEpoch =
+            panelEpochRef.current[targetPanel] ?? viewportReadyService.getEpoch(targetPanel);
+          viewportReadyService.markReady(targetPanel, currentEpoch);
           setBrowserStatusMessage('Scan already loaded', 'info', `Scan #${scanId} is already visible in ${targetPanel}.`);
         } else {
           // Clean up stale segmentations before replacing the stack
@@ -1832,6 +1859,7 @@ export default function App() {
           setBrowserStatusMessage('Image stack loaded', 'success', `${ids.length} image(s) in ${targetPanel}.`);
         }
         useViewerStore.getState().setPanelSessionLabel(targetPanel, context.sessionLabel);
+        useViewerStore.getState().setPanelSubjectLabel(targetPanel, context.subjectLabel ?? context.subjectId);
 
         // Notify SegmentationManager about the new source scan
         segmentationManager.onPanelImagesChanged(
@@ -1839,6 +1867,70 @@ export default function App() {
           scanId,
           panelEpochRef.current[targetPanel] ?? viewportReadyService.getEpoch(targetPanel),
         );
+
+        if (options?.openInMpr && isPrimaryImageScan(effectiveScan)) {
+          const viewerStore = useViewerStore.getState();
+          if (viewerStore.mprActive) {
+            viewerStore.exitMPR();
+          }
+
+          setBrowserStatusMessage(
+            'Opening 2x2 orientation view...',
+            'loading',
+            `Scan #${scanId} in axial/sagittal/coronal views.`,
+          );
+
+          viewerStore.setLayout('2x2');
+          const p0 = panelId(0); // top-left
+          const p1 = panelId(1); // top-right
+          const p2 = panelId(2); // bottom-left
+          const p3 = panelId(3); // bottom-right
+          const targetPanels = [p0, p1, p2, p3];
+
+          for (const pid of targetPanels) {
+            segmentationManager.removeSegmentationsFromViewport(pid);
+          }
+
+          setPanelImageIds((prev) => ({
+            ...prev,
+            [p0]: ids,
+            [p1]: ids,
+            [p2]: ids,
+            [p3]: ids,
+          }));
+
+          viewerStore.setPanelOrientation(p0, 'AXIAL');
+          viewerStore.setPanelOrientation(p1, 'SAGITTAL');
+          viewerStore.setPanelOrientation(p2, 'CORONAL');
+          viewerStore.setPanelOrientation(p3, 'STACK');
+
+          for (const pid of targetPanels) {
+            viewerStore.setPanelXnatContext(pid, {
+              projectId: context.projectId,
+              subjectId: context.subjectId,
+              sessionId,
+              sessionLabel: context.sessionLabel,
+              scanId,
+            });
+            viewerStore.setPanelScan(pid, scanId);
+            viewerStore.setPanelSessionLabel(pid, context.sessionLabel);
+            viewerStore.setPanelSubjectLabel(pid, context.subjectLabel ?? context.subjectId);
+            segmentationManager.onPanelImagesChanged(
+              pid,
+              scanId,
+              panelEpochRef.current[pid] ?? viewportReadyService.getEpoch(pid),
+            );
+          }
+
+          targetPanel = p0;
+          viewerStore.setActiveViewport(targetPanel);
+
+          setBrowserStatusMessage(
+            '2x2 orientation view ready',
+            'success',
+            `Axial / Sagittal / Coronal loaded for scan #${scanId}.`,
+          );
+        }
 
         // Start SEG/RTSTRUCT UID association resolution in the background so
         // the stack appears immediately, then await only if auto-display is enabled.
@@ -2092,6 +2184,7 @@ export default function App() {
           });
           store.setPanelScan(pid, scanId);
           store.setPanelSessionLabel(pid, context.sessionLabel);
+          store.setPanelSubjectLabel(pid, context.subjectLabel ?? context.subjectId);
           console.log(`  Panel ${panelIdx} (${pid}): scan #${scanId} → ${ids.length} images`);
         }
 
@@ -2274,6 +2367,44 @@ export default function App() {
     [setBrowserStatusMessage],
   );
 
+  const enterMprForPanel = useCallback(async (sourcePanelId: string, sourceImageIds: string[]) => {
+    const store = useViewerStore.getState();
+    if (sourceImageIds.length < 2) {
+      console.warn('[App] Need at least 2 slices for MPR');
+      return false;
+    }
+
+    if (store.mprActive) {
+      store.exitMPR();
+    }
+
+    const volumeId = volumeService.generateId();
+    try {
+      await volumeService.create(volumeId, sourceImageIds);
+      console.log('[App] Volume created in cache:', volumeId);
+    } catch (err) {
+      console.error('[App] Volume creation failed:', err);
+      return false;
+    }
+
+    useViewerStore.getState().setActiveViewport(sourcePanelId);
+    useViewerStore.getState().enterMPR(sourcePanelId, volumeId);
+
+    try {
+      await volumeService.load(volumeId, (p) => {
+        const percent = p.total > 0 ? Math.round((p.loaded / p.total) * 100) : 0;
+        useViewerStore.getState()._updateMPRVolumeProgress({ ...p, percent });
+      });
+      useViewerStore.getState()._updateMPRVolumeProgress(null);
+      console.log('[App] Volume loaded for MPR');
+      return true;
+    } catch (err) {
+      console.error('[App] Volume loading failed:', err);
+      useViewerStore.getState().exitMPR();
+      return false;
+    }
+  }, []);
+
   /**
    * Toggle MPR mode on the active panel's image stack.
    * Enters MPR: creates a 3D volume and shows 2×2 orthogonal views.
@@ -2283,48 +2414,13 @@ export default function App() {
     const store = useViewerStore.getState();
 
     if (store.mprActive) {
-      // Exit MPR
       store.exitMPR();
       return;
     }
 
-    // Enter MPR — need images from the active panel
     const activeImageIds = panelImageIds[store.activeViewportId] ?? [];
-    if (activeImageIds.length < 2) {
-      console.warn('[App] Need at least 2 slices for MPR');
-      return;
-    }
-
-    // Step 1: Generate volume ID and create the volume in cache FIRST
-    // This must complete before viewports mount and try to call setVolume
-    const volumeId = volumeService.generateId();
-
-    try {
-      await volumeService.create(volumeId, activeImageIds);
-      console.log('[App] Volume created in cache:', volumeId);
-    } catch (err) {
-      console.error('[App] Volume creation failed:', err);
-      return;
-    }
-
-    // Step 2: Now enter MPR mode (sets mprActive=true, renders viewports)
-    // The volume exists in cache so viewports can successfully call setVolume
-    store.enterMPR(store.activeViewportId, volumeId);
-
-    // Step 3: Start loading the volume data (streaming, progressive)
-    try {
-      await volumeService.load(volumeId, (p) => {
-        const percent = p.total > 0 ? Math.round((p.loaded / p.total) * 100) : 0;
-        useViewerStore.getState()._updateMPRVolumeProgress({ ...p, percent });
-      });
-      // Clear progress when done
-      useViewerStore.getState()._updateMPRVolumeProgress(null);
-      console.log('[App] Volume loaded for MPR');
-    } catch (err) {
-      console.error('[App] Volume loading failed:', err);
-      useViewerStore.getState().exitMPR();
-    }
-  }, [panelImageIds]);
+    await enterMprForPanel(store.activeViewportId, activeImageIds);
+  }, [panelImageIds, enterMprForPanel]);
 
   // Derive sourceImageIds for MPR mode (from the panel that launched MPR)
   const mprSourcePanelId = useViewerStore((s) => s.mprSourcePanelId);

--- a/src/renderer/components/connection/XnatBrowser.tsx
+++ b/src/renderer/components/connection/XnatBrowser.tsx
@@ -43,7 +43,7 @@ interface XnatBrowserProps {
     sessionLabel: string;
     projectName?: string;
     subjectLabel?: string;
-  }) => void;
+  }, options?: { openInMpr?: boolean }) => void;
   onLoadSession?: (sessionId: string, scans: XnatScan[], context: {
     projectId: string;
     subjectId: string;
@@ -907,7 +907,7 @@ export default function XnatBrowser({
   }, [maybeResolveSessionAssociations]);
 
   const loadScanForSession = useCallback(
-    (session: XnatSession, scan: XnatScan) => {
+    (session: XnatSession, scan: XnatScan, options?: { openInMpr?: boolean }) => {
       if (!selectedProject || !selectedSubject) return;
       onLoadScan(session.id, scan.id, scan, {
         projectId: selectedProject.id,
@@ -915,7 +915,7 @@ export default function XnatBrowser({
         sessionLabel: session.label,
         projectName: selectedProject.name,
         subjectLabel: selectedSubject.label,
-      });
+      }, options);
     },
     [selectedProject, selectedSubject, onLoadScan],
   );
@@ -950,9 +950,9 @@ export default function XnatBrowser({
   );
 
   const selectScan = useCallback(
-    (scan: XnatScan) => {
+    (scan: XnatScan, e?: React.MouseEvent) => {
       if (!selectedSession) return;
-      loadScanForSession(selectedSession, scan);
+      loadScanForSession(selectedSession, scan, { openInMpr: !!e?.shiftKey });
     },
     [selectedSession, loadScanForSession],
   );
@@ -1374,7 +1374,7 @@ export default function XnatBrowser({
                                         <button
                                           key={scan.id}
                                           ref={registerThumbVisibilityTarget(`${session.id}/${scan.id}`)}
-                                          onClick={() => loadScanForSession(session, scan)}
+                                          onClick={(e) => loadScanForSession(session, scan, { openInMpr: e.shiftKey })}
                                           draggable
                                           onDragStart={(e) => handleScanDragStart(e, session, scan)}
                                           className="text-left border border-zinc-800 rounded-md overflow-hidden hover:border-zinc-600 hover:bg-zinc-800/30 transition-colors"
@@ -1426,7 +1426,7 @@ export default function XnatBrowser({
                                       return (
                                         <button
                                           key={scan.id}
-                                          onClick={() => loadScanForSession(session, scan)}
+                                          onClick={(e) => loadScanForSession(session, scan, { openInMpr: e.shiftKey })}
                                           draggable
                                           onDragStart={(e) => handleScanDragStart(e, session, scan)}
                                           className="w-full text-left px-2.5 py-2 hover:bg-zinc-800/40 transition-colors"
@@ -1487,7 +1487,7 @@ export default function XnatBrowser({
                         <button
                           key={s.id}
                           ref={selectedSession ? registerThumbVisibilityTarget(`${selectedSession.id}/${s.id}`) : undefined}
-                          onClick={() => selectScan(s)}
+                          onClick={(e) => selectScan(s, e)}
                           draggable
                           onDragStart={(e) => {
                             if (!selectedSession) return;
@@ -1597,7 +1597,7 @@ interface ItemListProps<T> {
   items: T[];
   renderItem: (item: T) => React.ReactNode;
   renderAction?: (item: T) => React.ReactNode;
-  onSelect: (item: T) => void;
+  onSelect: (item: T, e?: React.MouseEvent<HTMLDivElement>) => void;
   onItemDragStart?: (item: T, e: React.DragEvent<HTMLDivElement>) => void;
   emptyMessage: string;
 }
@@ -1616,7 +1616,7 @@ function ItemList<T>({ items, renderItem, renderAction, onSelect, onItemDragStar
       {items.map((item, i) => (
         <div
           key={i}
-          onClick={() => onSelect(item)}
+          onClick={(e) => onSelect(item, e)}
           draggable={Boolean(onItemDragStart)}
           onDragStart={onItemDragStart ? (e) => onItemDragStart(item, e) : undefined}
           className="w-full text-left px-3 py-2.5 hover:bg-zinc-800/50 transition-colors cursor-pointer flex items-center group"

--- a/src/renderer/components/icons.tsx
+++ b/src/renderer/components/icons.tsx
@@ -67,6 +67,20 @@ export function IconZoom(props: IconProps) {
   );
 }
 
+/** Crosshairs — targeting reticle */
+export function IconCrosshairs(props: IconProps) {
+  return (
+    <svg {...defaults(props)}>
+      <circle cx="8" cy="8" r="3.25" />
+      <line x1="8" y1="1.5" x2="8" y2="4" />
+      <line x1="8" y1="12" x2="8" y2="14.5" />
+      <line x1="1.5" y1="8" x2="4" y2="8" />
+      <line x1="12" y1="8" x2="14.5" y2="8" />
+      <circle cx="8" cy="8" r="0.8" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
 // ─── Action Icons ─────────────────────────────────────────────────
 
 /** Reset — counterclockwise arrow */

--- a/src/renderer/components/viewer/CornerstoneViewport.tsx
+++ b/src/renderer/components/viewer/CornerstoneViewport.tsx
@@ -18,8 +18,12 @@ import { viewportService } from '../../lib/cornerstone/viewportService';
 import { toolService } from '../../lib/cornerstone/toolService';
 import { metadataService } from '../../lib/cornerstone/metadataService';
 import { viewportReadyService } from '../../lib/cornerstone/viewportReadyService';
+import { crosshairSyncService } from '../../lib/cornerstone/crosshairSyncService';
+import { wireCrosshairPointerHandlers } from '../../lib/cornerstone/crosshairGeometry';
+import { segmentationManager } from '../../lib/segmentation/segmentationManagerSingleton';
 import { useViewerStore } from '../../stores/viewerStore';
 import { useMetadataStore } from '../../stores/metadataStore';
+import { ToolName } from '@shared/types/viewer';
 
 interface CornerstoneViewportProps {
   panelId: string;
@@ -30,8 +34,21 @@ export default function CornerstoneViewport({ panelId, imageIds }: CornerstoneVi
   const containerRef = useRef<HTMLDivElement>(null);
   const [status, setStatus] = useState<string>('Initializing...');
   const [error, setError] = useState<string | null>(null);
+  const activeTool = useViewerStore((s) => s.activeTool);
   const renderedImageIndex = useViewerStore((s) => s.viewports[panelId]?.imageIndex ?? 0);
   const requestedImageIndex = useViewerStore((s) => s.viewports[panelId]?.requestedImageIndex ?? null);
+  const cursorClass = activeTool === ToolName.Crosshairs ? 'cursor-crosshair' : '';
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+    const cursor = activeTool === ToolName.Crosshairs ? 'crosshair' : '';
+    element.style.cursor = cursor;
+    const canvas = element.querySelector('canvas') as HTMLCanvasElement | null;
+    if (canvas) {
+      canvas.style.cursor = cursor;
+    }
+  }, [activeTool]);
 
   // ─── Setup / Teardown ──────────────────────────────────────
   useEffect(() => {
@@ -111,6 +128,10 @@ export default function CornerstoneViewport({ panelId, imageIds }: CornerstoneVi
           if (currentImageId) {
             const overlay = metadataService.getOverlayData(currentImageId);
             useMetadataStore.getState()._updateOverlay(panelId, overlay);
+            const nativeOrientation = metadataService.getNativeOrientation(currentImageId);
+            if (nativeOrientation) {
+              useViewerStore.getState().setPanelNativeOrientation(panelId, nativeOrientation);
+            }
 
             // Image dimensions
             const imageData = viewport.getImageData();
@@ -131,6 +152,13 @@ export default function CornerstoneViewport({ panelId, imageIds }: CornerstoneVi
         // no more polling for viewport existence.
         if (!cancelled) {
           viewportReadyService.markReady(panelId, epochAtSetup);
+        }
+
+        // Ensure overlays are re-attached after viewport recreation (e.g. when
+        // changing orientation/layout without changing source imageIds).
+        if (!cancelled) {
+          segmentationManager.removeSegmentationsFromViewport(panelId);
+          await segmentationManager.attachVisibleSegmentationsToViewport(panelId);
         }
       } catch (err) {
         console.error(`[CornerstoneViewport:${panelId}] Setup error:`, err);
@@ -167,10 +195,10 @@ export default function CornerstoneViewport({ panelId, imageIds }: CornerstoneVi
   }, [panelId, imageIds]);
 
   return (
-    <div className="relative w-full h-full bg-black">
+    <div className={`relative w-full h-full bg-black ${cursorClass}`}>
       <div
         ref={containerRef}
-        className="w-full h-full"
+        className={`w-full h-full ${cursorClass}`}
         onContextMenu={(e) => e.preventDefault()}
       />
       {/* Status overlay — only shown when no images or loading */}
@@ -237,6 +265,10 @@ function wireEvents(element: HTMLDivElement, panelId: string): void {
     if (imageId) {
       const overlay = metadataService.getOverlayData(imageId);
       useMetadataStore.getState()._updateOverlay(panelId, overlay);
+      const nativeOrientation = metadataService.getNativeOrientation(imageId);
+      if (nativeOrientation) {
+        useViewerStore.getState().setPanelNativeOrientation(panelId, nativeOrientation);
+      }
     }
   }) as EventListener);
 
@@ -284,4 +316,11 @@ function wireEvents(element: HTMLDivElement, panelId: string): void {
       }
     }
   }, { passive: false });
+
+  wireCrosshairPointerHandlers({
+    element,
+    panelId,
+    isCrosshairActive: () => useViewerStore.getState().activeTool === ToolName.Crosshairs,
+    onWorldPoint: (point) => crosshairSyncService.syncFromViewport(panelId, point),
+  });
 }

--- a/src/renderer/components/viewer/MPRViewport.tsx
+++ b/src/renderer/components/viewer/MPRViewport.tsx
@@ -13,8 +13,10 @@ import { Enums } from '@cornerstonejs/core';
 import { mprService } from '../../lib/cornerstone/mprService';
 import { mprToolService } from '../../lib/cornerstone/mprToolService';
 import { viewportService } from '../../lib/cornerstone/viewportService';
+import { crosshairSyncService } from '../../lib/cornerstone/crosshairSyncService';
+import { wireCrosshairPointerHandlers } from '../../lib/cornerstone/crosshairGeometry';
 import { useViewerStore } from '../../stores/viewerStore';
-import type { MPRPlane } from '@shared/types/viewer';
+import { ToolName, type MPRPlane } from '@shared/types/viewer';
 
 interface MPRViewportProps {
   panelId: string;
@@ -39,10 +41,23 @@ const PLANE_LABELS: Record<MPRPlane, string> = {
 export default function MPRViewport({ panelId, volumeId, plane }: MPRViewportProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
+  const activeTool = useViewerStore((s) => s.activeTool);
+  const cursorClass = activeTool === ToolName.Crosshairs ? 'cursor-crosshair' : '';
 
   // Read MPR slice state from store
   const mprState = useViewerStore((s) => s.mprViewports[panelId]);
   const voiState = useViewerStore((s) => s.viewports[panelId]);
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+    const cursor = activeTool === ToolName.Crosshairs ? 'crosshair' : '';
+    element.style.cursor = cursor;
+    const canvas = element.querySelector('canvas') as HTMLCanvasElement | null;
+    if (canvas) {
+      canvas.style.cursor = cursor;
+    }
+  }, [activeTool]);
 
   // ─── Setup / Teardown ──────────────────────────────────────
   useEffect(() => {
@@ -88,6 +103,7 @@ export default function MPRViewport({ panelId, volumeId, plane }: MPRViewportPro
         // Initialize slice info in store
         const sliceInfo = mprService.getSliceInfo(panelId);
         useViewerStore.getState()._updateMPRSlice(panelId, sliceInfo.sliceIndex, sliceInfo.totalSlices);
+        useViewerStore.getState()._updateImageIndex(panelId, sliceInfo.sliceIndex, sliceInfo.totalSlices);
 
         // Initialize zoom
         useViewerStore.getState()._updateZoom(panelId, mprService.getZoom(panelId));
@@ -138,10 +154,10 @@ export default function MPRViewport({ panelId, volumeId, plane }: MPRViewportPro
   const wc = voiState?.windowCenter ?? 0;
 
   return (
-    <div className="relative w-full h-full bg-black">
+    <div className={`relative w-full h-full bg-black ${cursorClass}`}>
       <div
         ref={containerRef}
-        className="w-full h-full"
+        className={`w-full h-full ${cursorClass}`}
         onContextMenu={(e) => e.preventDefault()}
       />
 
@@ -213,6 +229,7 @@ function wireEvents(element: HTMLDivElement, panelId: string): void {
     // Update slice info
     const sliceInfo = mprService.getSliceInfo(panelId);
     useViewerStore.getState()._updateMPRSlice(panelId, sliceInfo.sliceIndex, sliceInfo.totalSlices);
+    useViewerStore.getState()._updateImageIndex(panelId, sliceInfo.sliceIndex, sliceInfo.totalSlices);
 
     // Update zoom
     useViewerStore.getState()._updateZoom(panelId, mprService.getZoom(panelId));
@@ -234,4 +251,11 @@ function wireEvents(element: HTMLDivElement, panelId: string): void {
       mprService.scroll(panelId, steps);
     }
   }, { passive: false });
+
+  wireCrosshairPointerHandlers({
+    element,
+    panelId,
+    isCrosshairActive: () => useViewerStore.getState().activeTool === ToolName.Crosshairs,
+    onWorldPoint: (point) => crosshairSyncService.syncFromViewport(panelId, point),
+  });
 }

--- a/src/renderer/components/viewer/MPRViewportGrid.tsx
+++ b/src/renderer/components/viewer/MPRViewportGrid.tsx
@@ -18,9 +18,9 @@
  * Keyboard shortcuts (including MPR slice navigation) are handled globally
  * by hotkeyService — see src/renderer/lib/hotkeys/hotkeyService.ts.
  */
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useViewerStore } from '../../stores/viewerStore';
-import { mprPanelId, MPR_PANELS } from '@shared/types/viewer';
+import { ToolName, mprPanelId, MPR_PANELS } from '@shared/types/viewer';
 import { mprService } from '../../lib/cornerstone/mprService';
 import MPRViewport from './MPRViewport';
 import CornerstoneViewport from './CornerstoneViewport';
@@ -37,7 +37,13 @@ const MPR_STACK_PANEL_ID = 'mpr_stack';
 export default function MPRViewportGrid({ volumeId, sourceImageIds }: MPRViewportGridProps) {
   const activeViewportId = useViewerStore((s) => s.activeViewportId);
   const setActiveViewport = useViewerStore((s) => s.setActiveViewport);
+  const activeTool = useViewerStore((s) => s.activeTool);
   const mprVolumeProgress = useViewerStore((s) => s.mprVolumeProgress);
+
+  useEffect(() => {
+    const el = document.querySelector(`[data-panel-id="${activeViewportId}"]`) as HTMLElement | null;
+    el?.focus?.();
+  }, [activeViewportId]);
 
   // Is volume still loading?
   const isLoading = mprVolumeProgress !== null && mprVolumeProgress.percent < 100;
@@ -46,7 +52,7 @@ export default function MPRViewportGrid({ volumeId, sourceImageIds }: MPRViewpor
     <div className="relative w-full h-full">
       {/* 2×2 grid */}
       <div
-        className="w-full h-full"
+        className={`w-full h-full ${activeTool === ToolName.Crosshairs ? 'crosshair-mode' : ''}`}
         style={{
           display: 'grid',
           gridTemplateRows: 'repeat(2, 1fr)',
@@ -64,12 +70,15 @@ export default function MPRViewportGrid({ volumeId, sourceImageIds }: MPRViewpor
             <div
               key={pid}
               data-panel-id={pid}
-              className={`relative min-w-0 min-h-0 cursor-pointer ${
-                isActive ? 'ring-2 ring-blue-500 ring-inset' : ''
-              }`}
+              tabIndex={-1}
+              className="relative min-w-0 min-h-0 cursor-pointer"
               onClick={() => setActiveViewport(pid)}
             >
+              {isActive && (
+                <div className="absolute inset-0 border border-zinc-500/80 pointer-events-none z-40" />
+              )}
               <MPRViewport panelId={pid} volumeId={volumeId} plane={plane} />
+              <ViewportOverlay panelId={pid} />
               <MPRScrollSlider panelId={pid} />
             </div>
           );
@@ -78,11 +87,13 @@ export default function MPRViewportGrid({ volumeId, sourceImageIds }: MPRViewpor
         {/* Panel 3: Original stack viewport for reference */}
         <div
           data-panel-id={MPR_STACK_PANEL_ID}
-          className={`relative min-w-0 min-h-0 cursor-pointer ${
-            MPR_STACK_PANEL_ID === activeViewportId ? 'ring-2 ring-blue-500 ring-inset' : ''
-          }`}
+          tabIndex={-1}
+          className="relative min-w-0 min-h-0 cursor-pointer"
           onClick={() => setActiveViewport(MPR_STACK_PANEL_ID)}
         >
+          {MPR_STACK_PANEL_ID === activeViewportId && (
+            <div className="absolute inset-0 border border-zinc-500/80 pointer-events-none z-40" />
+          )}
           {sourceImageIds.length > 0 ? (
             <>
               <CornerstoneViewport panelId={MPR_STACK_PANEL_ID} imageIds={sourceImageIds} />

--- a/src/renderer/components/viewer/OrientedViewport.tsx
+++ b/src/renderer/components/viewer/OrientedViewport.tsx
@@ -1,0 +1,211 @@
+/**
+ * OrientedViewport — per-panel orthographic volume viewport used by the
+ * regular ViewportGrid when a panel orientation is set to Axial/Sagittal/Coronal.
+ *
+ * Unlike global MPR mode, this component uses the primary tool group so users
+ * can draw/edit annotations directly in any selected viewing plane.
+ */
+import { useEffect, useRef, useState } from 'react';
+import { Enums } from '@cornerstonejs/core';
+import { mprService } from '../../lib/cornerstone/mprService';
+import { volumeService } from '../../lib/cornerstone/volumeService';
+import { viewportService } from '../../lib/cornerstone/viewportService';
+import { toolService } from '../../lib/cornerstone/toolService';
+import { crosshairSyncService } from '../../lib/cornerstone/crosshairSyncService';
+import { wireCrosshairPointerHandlers } from '../../lib/cornerstone/crosshairGeometry';
+import { segmentationManager } from '../../lib/segmentation/segmentationManagerSingleton';
+import { viewportReadyService } from '../../lib/cornerstone/viewportReadyService';
+import { useViewerStore } from '../../stores/viewerStore';
+import { ToolName, type MPRPlane } from '@shared/types/viewer';
+
+interface OrientedViewportProps {
+  panelId: string;
+  imageIds: string[];
+  plane: MPRPlane;
+}
+
+export default function OrientedViewport({ panelId, imageIds, plane }: OrientedViewportProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const volumeIdRef = useRef<string | null>(null);
+  const [status, setStatus] = useState('Initializing...');
+  const [error, setError] = useState<string | null>(null);
+  const activeTool = useViewerStore((s) => s.activeTool);
+  const cursorClass = activeTool === ToolName.Crosshairs ? 'cursor-crosshair' : '';
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+    const cursor = activeTool === ToolName.Crosshairs ? 'crosshair' : '';
+    element.style.cursor = cursor;
+    const canvas = element.querySelector('canvas') as HTMLCanvasElement | null;
+    if (canvas) {
+      canvas.style.cursor = cursor;
+    }
+  }, [activeTool]);
+
+  useEffect(() => {
+    if (!containerRef.current || imageIds.length === 0) return;
+
+    let cancelled = false;
+    const element = containerRef.current;
+
+    async function setup() {
+      try {
+        setStatus('Creating oriented viewport...');
+        setError(null);
+        const epochAtSetup = viewportReadyService.getEpoch(panelId);
+
+        for (let i = 0; i < 20; i++) {
+          if (element.clientWidth > 0 && element.clientHeight > 0) break;
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+        if (cancelled) return;
+
+        useViewerStore.getState()._initPanel(panelId);
+
+        const volumeId = volumeService.generateId();
+        volumeIdRef.current = volumeId;
+        await volumeService.create(volumeId, imageIds);
+        if (cancelled) return;
+
+        mprService.createViewport(panelId, element, plane);
+        toolService.addViewport(panelId);
+        wireEvents(element, panelId);
+
+        setStatus(`Loading ${imageIds.length} images...`);
+        await mprService.setVolume(panelId, volumeId);
+        if (cancelled) return;
+
+        // Load volume progressively in the background.
+        void volumeService.load(volumeId).catch((err) => {
+          console.warn(`[OrientedViewport:${panelId}] Volume streaming load warning:`, err);
+        });
+
+        viewportService.resize();
+        mprService.resetCamera(panelId);
+        syncSliceState(panelId);
+        setStatus(`Loaded ${imageIds.length} images`);
+
+        // Signal readiness as soon as viewport + stack are usable.
+        // Re-attaching overlays happens after this and should not block
+        // other async flows waiting on panel readiness.
+        if (!cancelled) {
+          viewportReadyService.markReady(panelId, epochAtSetup);
+        }
+
+        // Switching STACK <-> ORTHOGRAPHIC can leave stale representation state
+        // on the reused viewportId. Detach first, then re-attach deterministically.
+        segmentationManager.removeSegmentationsFromViewport(panelId);
+
+        // Re-attach overlays that belong on this panel/source scan.
+        await segmentationManager.attachVisibleSegmentationsToViewport(panelId);
+      } catch (err) {
+        console.error(`[OrientedViewport:${panelId}] Setup error:`, err);
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+          setStatus('Error');
+        }
+      }
+    }
+
+    setup();
+
+    const resizeObserver = new ResizeObserver(() => {
+      viewportService.resize();
+    });
+    resizeObserver.observe(element);
+
+    return () => {
+      cancelled = true;
+      resizeObserver.disconnect();
+
+      useViewerStore.getState().stopCine(panelId);
+      toolService.removeViewport(panelId);
+      mprService.destroyViewport(panelId);
+
+      if (volumeIdRef.current) {
+        volumeService.destroy(volumeIdRef.current);
+        volumeIdRef.current = null;
+      }
+
+      useViewerStore.getState()._destroyPanel(panelId);
+    };
+  }, [imageIds, panelId, plane]);
+
+  return (
+    <div className={`relative w-full h-full bg-black ${cursorClass}`}>
+      <div
+        ref={containerRef}
+        className={`w-full h-full ${cursorClass}`}
+        onContextMenu={(e) => e.preventDefault()}
+      />
+      {(imageIds.length === 0 || status === 'Error') && (
+        <div className="absolute bottom-2 left-2 text-xs text-zinc-400">
+          {status}
+        </div>
+      )}
+      {error && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/80">
+          <div className="bg-red-950 border border-red-800 text-red-200 px-4 py-3 rounded max-w-md">
+            <p className="font-semibold text-sm">Viewport Error</p>
+            <p className="text-xs mt-1">{error}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function syncSliceState(panelId: string): void {
+  const sliceInfo = mprService.getSliceInfo(panelId);
+  useViewerStore.getState()._updateMPRSlice(panelId, sliceInfo.sliceIndex, sliceInfo.totalSlices);
+  useViewerStore.getState()._updateImageIndex(panelId, sliceInfo.sliceIndex, sliceInfo.totalSlices);
+  useViewerStore.getState()._updateZoom(panelId, mprService.getZoom(panelId));
+
+  const viewport = mprService.getViewport(panelId) as any;
+  const imageData = viewport?.getImageData?.();
+  const dims = imageData?.dimensions;
+  if (Array.isArray(dims) && dims.length >= 2) {
+    useViewerStore.getState()._updateImageDimensions(panelId, Number(dims[0]) || 0, Number(dims[1]) || 0);
+  }
+}
+
+function wireEvents(element: HTMLDivElement, panelId: string): void {
+  const Events = Enums.Events;
+
+  element.addEventListener(Events.VOI_MODIFIED, ((e: Event) => {
+    const detail = (e as CustomEvent).detail;
+    if (detail?.range) {
+      const { lower, upper } = detail.range;
+      const ww = upper - lower;
+      const wc = lower + ww / 2;
+      useViewerStore.getState()._updateVOI(panelId, ww, wc);
+    }
+  }) as EventListener);
+
+  element.addEventListener(Events.CAMERA_MODIFIED, (() => {
+    syncSliceState(panelId);
+  }) as EventListener);
+
+  let wheelAccum = 0;
+  const WHEEL_THRESHOLD = 50;
+
+  element.addEventListener('wheel', (e: WheelEvent) => {
+    if (e.ctrlKey || e.metaKey) return;
+    e.preventDefault();
+    wheelAccum += e.deltaY;
+
+    if (Math.abs(wheelAccum) >= WHEEL_THRESHOLD) {
+      const steps = Math.trunc(wheelAccum / WHEEL_THRESHOLD);
+      wheelAccum -= steps * WHEEL_THRESHOLD;
+      mprService.scroll(panelId, steps);
+    }
+  }, { passive: false });
+
+  wireCrosshairPointerHandlers({
+    element,
+    panelId,
+    isCrosshairActive: () => useViewerStore.getState().activeTool === ToolName.Crosshairs,
+    onWorldPoint: (point) => crosshairSyncService.syncFromViewport(panelId, point),
+  });
+}

--- a/src/renderer/components/viewer/ScrollSlider.tsx
+++ b/src/renderer/components/viewer/ScrollSlider.tsx
@@ -13,38 +13,49 @@
 import { useCallback, useRef, useState } from 'react';
 import { useViewerStore } from '../../stores/viewerStore';
 import { viewportService } from '../../lib/cornerstone/viewportService';
+import { mprService } from '../../lib/cornerstone/mprService';
 
 interface ScrollSliderProps {
   panelId: string;
 }
 
 export default function ScrollSlider({ panelId }: ScrollSliderProps) {
+  const orientation = useViewerStore((s) => s.panelOrientationMap[panelId] ?? 'STACK');
   // Use separate primitive selectors to avoid creating new objects (infinite re-render pitfall)
   const imageIndex = useViewerStore((s) => s.viewports[panelId]?.imageIndex ?? 0);
   const requestedImageIndex = useViewerStore((s) => s.viewports[panelId]?.requestedImageIndex ?? null);
   const totalImages = useViewerStore((s) => s.viewports[panelId]?.totalImages ?? 0);
+  const mprSliceIndex = useViewerStore((s) => s.mprViewports[panelId]?.sliceIndex ?? 0);
+  const mprTotalSlices = useViewerStore((s) => s.mprViewports[panelId]?.totalSlices ?? 0);
   const requestImageIndex = useViewerStore((s) => s._requestImageIndex);
   const [isDragging, setIsDragging] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const trackRef = useRef<HTMLDivElement>(null);
   const draggingRef = useRef(false); // Non-reactive ref for pointer events
 
-  const displayIndex = requestedImageIndex ?? imageIndex;
-  const thumbPercent = totalImages > 1 ? (displayIndex / (totalImages - 1)) * 100 : 0;
+  const isOriented = orientation !== 'STACK';
+  const total = isOriented ? mprTotalSlices : totalImages;
+  const currentIndex = isOriented ? mprSliceIndex : imageIndex;
+  const displayIndex = isOriented ? currentIndex : (requestedImageIndex ?? currentIndex);
+  const thumbPercent = total > 1 ? (displayIndex / (total - 1)) * 100 : 0;
 
   // All hooks must be declared before any early return (Rules of Hooks)
   const scrollToY = useCallback(
     (clientY: number) => {
       const track = trackRef.current;
-      if (!track || totalImages <= 1) return;
+      if (!track || total <= 1) return;
       const rect = track.getBoundingClientRect();
       const percent = Math.max(0, Math.min(1, (clientY - rect.top) / rect.height));
-      const index = Math.round(percent * (totalImages - 1));
+      const index = Math.round(percent * (total - 1));
       if (index === displayIndex) return;
-      requestImageIndex(panelId, index, totalImages);
-      viewportService.scrollToIndex(panelId, index);
+      if (isOriented) {
+        mprService.scrollToIndex(panelId, index);
+      } else {
+        requestImageIndex(panelId, index, total);
+        viewportService.scrollToIndex(panelId, index);
+      }
     },
-    [displayIndex, panelId, totalImages, requestImageIndex],
+    [displayIndex, isOriented, panelId, requestImageIndex, total],
   );
 
   const handlePointerDown = useCallback(
@@ -85,7 +96,7 @@ export default function ScrollSlider({ panelId }: ScrollSliderProps) {
   );
 
   // Don't show slider for single-slice or empty stacks
-  if (totalImages <= 1) return null;
+  if (total <= 1) return null;
 
   const isVisible = isDragging || isHovered;
 
@@ -113,7 +124,7 @@ export default function ScrollSlider({ panelId }: ScrollSliderProps) {
             isDragging ? 'bg-blue-400' : 'bg-white'
           }`}
           style={{
-            height: `${Math.max(8, 100 / totalImages)}%`,
+            height: `${Math.max(8, 100 / total)}%`,
             minHeight: '8px',
             maxHeight: '24px',
             top: `${thumbPercent}%`,
@@ -128,7 +139,7 @@ export default function ScrollSlider({ panelId }: ScrollSliderProps) {
           className="absolute right-8 bg-black/80 text-white text-[10px] font-mono px-1.5 py-0.5 rounded whitespace-nowrap pointer-events-none"
           style={{ top: `${Math.max(5, Math.min(95, thumbPercent))}%`, transform: 'translateY(-50%)' }}
         >
-          {displayIndex + 1}/{totalImages}
+          {displayIndex + 1}/{total}
         </div>
       )}
     </div>

--- a/src/renderer/components/viewer/SegmentationPanel.tsx
+++ b/src/renderer/components/viewer/SegmentationPanel.tsx
@@ -271,6 +271,7 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
   const localOriginBySegId = useSegmentationManagerStore((s) => s.localOriginBySegId);
   const loadStatusByDerivedScan = useSegmentationManagerStore((s) => s.loadStatus);
   const dirtySegIds = useSegmentationManagerStore((s) => s.dirtySegIds);
+  const presentation = useSegmentationManagerStore((s) => s.presentation);
 
   const activeSourceScanId = panelScanMap[activeViewportId] ?? null;
   const activePanelXnatContext = panelXnatContextMap[activeViewportId] ?? xnatContext;
@@ -1241,6 +1242,31 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
     }
   }, [activeSourceCompositeKey]);
 
+  // Keep the currently selected annotation activated when viewport focus changes.
+  // Avoid depending on full segmentation summaries: they change on every
+  // segmentation event and can cause activation loops.
+  const lastViewportActivationRef = useRef<string>('');
+  useEffect(() => {
+    if (!activeSegId) {
+      lastViewportActivationRef.current = '';
+      return;
+    }
+
+    const segStore = useSegmentationStore.getState();
+    const targetIndex =
+      Number.isFinite(segStore.activeSegmentIndex) &&
+      Number.isInteger(segStore.activeSegmentIndex) &&
+      segStore.activeSegmentIndex > 0
+        ? segStore.activeSegmentIndex
+        : 1;
+
+    const activationKey = `${activeViewportId}|${activeSegId}|${targetIndex}`;
+    if (lastViewportActivationRef.current === activationKey) return;
+    lastViewportActivationRef.current = activationKey;
+
+    segmentationManager.userSelectedSegmentation(activeViewportId, activeSegId, targetIndex);
+  }, [activeViewportId, activeSegId]);
+
   const activeAnnotationType = useMemo<SegmentationDicomType | null>(() => {
     if (!activeSegId) return null;
     return (
@@ -1497,10 +1523,14 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
                       {seg.segments.map((segment) => {
                         const isActiveSegment =
                           isActiveSeg && activeSegIndex === segment.segmentIndex;
+                        const cachedVisible =
+                          presentation[seg.segmentationId]?.visibility?.[segment.segmentIndex];
+                        const isVisible =
+                          typeof cachedVisible === 'boolean' ? cachedVisible : segment.visible;
 
                         return (
                           <div
-                            key={segment.segmentIndex}
+                            key={`${seg.segmentationId}:${segment.segmentIndex}`}
                             className={`group flex items-center gap-1.5 px-2 py-1 rounded cursor-pointer transition-colors ${
                               isActiveSegment
                                 ? 'bg-blue-900/25 border-l-2 border-blue-500'
@@ -1567,9 +1597,9 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
                                 );
                               }}
                               className="text-zinc-500 hover:text-zinc-300 transition-colors p-0.5 shrink-0"
-                              title={segment.visible ? 'Hide segment' : 'Show segment'}
+                              title={isVisible ? 'Hide segment' : 'Show segment'}
                             >
-                              {segment.visible ? (
+                              {isVisible ? (
                                 <IconEye className="w-3 h-3" />
                               ) : (
                                 <IconEyeOff className="w-3 h-3" />

--- a/src/renderer/components/viewer/Toolbar.tsx
+++ b/src/renderer/components/viewer/Toolbar.tsx
@@ -11,6 +11,7 @@ import { BUILT_IN_PROTOCOLS } from '@shared/types/hangingProtocol';
 import AnnotationToolDropdown from './AnnotationToolDropdown';
 import {
   IconWindowLevel,
+  IconCrosshairs,
   IconPan,
   IconZoom,
   IconReset,
@@ -555,6 +556,13 @@ export default function Toolbar({ showDicomPanel = false, onToggleDicomPanel, on
       {/* ─── Interaction Tools ──────────────────────────── */}
       {!mprActive && (
         <>
+          <ToolButton
+            icon={<IconCrosshairs className="w-3.5 h-3.5" />}
+            label="Cross"
+            active={activeTool === ToolName.Crosshairs}
+            onClick={() => setActiveTool(ToolName.Crosshairs)}
+            title="Crosshairs (left-click to sync; hold Shift+move for dynamic sync; left-drag W/L)"
+          />
           <ToolButton
             icon={<IconWindowLevel className="w-3.5 h-3.5" />}
             label="W/L"

--- a/src/renderer/components/viewer/ViewportGrid.tsx
+++ b/src/renderer/components/viewer/ViewportGrid.tsx
@@ -11,8 +11,11 @@
 import { useViewerStore } from '../../stores/viewerStore';
 import { panelId } from '@shared/types/viewer';
 import CornerstoneViewport from './CornerstoneViewport';
+import OrientedViewport from './OrientedViewport';
 import ViewportOverlay from './ViewportOverlay';
 import ScrollSlider from './ScrollSlider';
+import { ToolName } from '@shared/types/viewer';
+import { useEffect } from 'react';
 
 interface ViewportGridProps {
   panelImageIds: Record<string, string[]>;
@@ -22,13 +25,20 @@ export default function ViewportGrid({ panelImageIds }: ViewportGridProps) {
   const layoutConfig = useViewerStore((s) => s.layoutConfig);
   const activeViewportId = useViewerStore((s) => s.activeViewportId);
   const setActiveViewport = useViewerStore((s) => s.setActiveViewport);
+  const panelOrientationMap = useViewerStore((s) => s.panelOrientationMap);
+  const activeTool = useViewerStore((s) => s.activeTool);
   const sessionScans = useViewerStore((s) => s.sessionScans);
   const panelXnatContextMap = useViewerStore((s) => s.panelXnatContextMap);
   const panelScanMap = useViewerStore((s) => s.panelScanMap);
 
+  useEffect(() => {
+    const el = document.querySelector(`[data-panel-id="${activeViewportId}"]`) as HTMLElement | null;
+    el?.focus?.();
+  }, [activeViewportId]);
+
   return (
     <div
-      className="w-full h-full"
+      className={`w-full h-full ${activeTool === ToolName.Crosshairs ? 'crosshair-mode' : ''}`}
       style={{
         display: 'grid',
         gridTemplateRows: `repeat(${layoutConfig.rows}, 1fr)`,
@@ -41,6 +51,9 @@ export default function ViewportGrid({ panelImageIds }: ViewportGridProps) {
         const pid = panelId(i);
         const imageIds = panelImageIds[pid] ?? [];
         const isActive = pid === activeViewportId;
+        const orientation = panelOrientationMap[pid] ?? 'STACK';
+        const canUseOrientedView = imageIds.length > 1;
+        const shouldUseOrientedView = canUseOrientedView && orientation !== 'STACK';
         const loadingScanId = panelXnatContextMap[pid]?.scanId || panelScanMap[pid] || '';
         const loadingScanLabel = sessionScans?.find((scan) => scan.id === loadingScanId)?.seriesDescription?.trim() ?? '';
         const loadingMessage = loadingScanId
@@ -51,14 +64,20 @@ export default function ViewportGrid({ panelImageIds }: ViewportGridProps) {
           <div
             key={pid}
             data-panel-id={pid}
-            className={`relative min-w-0 min-h-0 cursor-pointer ${
-              isActive ? 'ring-2 ring-blue-500 ring-inset' : ''
-            }`}
+            tabIndex={-1}
+            className="relative min-w-0 min-h-0 cursor-pointer"
             onClick={() => setActiveViewport(pid)}
           >
+            {isActive && (
+              <div className="absolute inset-0 border border-zinc-500/80 pointer-events-none z-40" />
+            )}
             {imageIds.length > 0 ? (
               <>
-                <CornerstoneViewport panelId={pid} imageIds={imageIds} />
+                {shouldUseOrientedView ? (
+                  <OrientedViewport panelId={pid} imageIds={imageIds} plane={orientation} />
+                ) : (
+                  <CornerstoneViewport panelId={pid} imageIds={imageIds} />
+                )}
                 <ViewportOverlay panelId={pid} />
                 <ScrollSlider panelId={pid} />
               </>

--- a/src/renderer/components/viewer/ViewportOverlay.tsx
+++ b/src/renderer/components/viewer/ViewportOverlay.tsx
@@ -1,5 +1,5 @@
 /**
- * ViewportOverlay — four-corner DICOM metadata overlay.
+ * ViewportOverlay — four-corner DICOM metadata overlay plus crosshair guides.
  *
  * Absolute-positioned over the viewport with pointer-events: none
  * so it doesn't interfere with mouse interactions. Reads per-panel state
@@ -9,6 +9,9 @@ import { useViewerStore } from '../../stores/viewerStore';
 import { useMetadataStore } from '../../stores/metadataStore';
 import { useSegmentationStore } from '../../stores/segmentationStore';
 import { EMPTY_OVERLAY } from '@shared/types/dicom';
+import type { MPRPlane } from '@shared/types/viewer';
+import { ToolName } from '@shared/types/viewer';
+import { getPanelDisplayPointForWorld } from '../../lib/cornerstone/crosshairGeometry';
 
 interface ViewportOverlayProps {
   panelId: string;
@@ -29,93 +32,197 @@ const EMPTY_VP = {
   imageHeight: 0,
 };
 
+function getCrosshairDisplayPoint(
+  panelId: string,
+  worldPoint: [number, number, number],
+): { x: number; y: number; width: number; height: number } | null {
+  return getPanelDisplayPointForWorld(panelId, worldPoint);
+}
+
 export default function ViewportOverlay({ panelId }: ViewportOverlayProps) {
   const showContextOverlay = useSegmentationStore((s) => s.showViewportContextOverlay);
   const viewport = useViewerStore((s) => s.viewports[panelId] ?? EMPTY_VP);
+  const panelOrientation = useViewerStore((s) => s.panelOrientationMap[panelId] ?? 'STACK');
+  const nativeOrientation = useViewerStore((s) => s.panelNativeOrientationMap[panelId] ?? 'AXIAL');
+  const setPanelOrientation = useViewerStore((s) => s.setPanelOrientation);
+  const subjectLabel = useViewerStore(
+    (s) =>
+      s.panelSubjectLabelMap[panelId]
+      ?? s.panelXnatContextMap[panelId]?.subjectId
+      ?? s.xnatContext?.subjectId
+      ?? '',
+  );
   const sessionLabel = useViewerStore(
     (s) => s.panelSessionLabelMap[panelId] ?? s.xnatContext?.sessionLabel ?? '',
   );
+  const panelScanId = useViewerStore(
+    (s) =>
+      s.panelScanMap[panelId]
+      ?? s.panelXnatContextMap[panelId]?.scanId
+      ?? '',
+  );
+  const scanSeriesDescription = useViewerStore((s) => {
+    const scanId = s.panelScanMap[panelId] ?? s.panelXnatContextMap[panelId]?.scanId;
+    if (!scanId) return '';
+    const match = (s.sessionScans ?? []).find((scan) => scan.id === scanId);
+    return match?.seriesDescription?.trim() ?? '';
+  });
   const overlay = useMetadataStore((s) => s.overlays[panelId] ?? EMPTY_OVERLAY);
+  const crosshairPoint = useViewerStore((s) => s.crosshairWorldPoint);
+  const activeTool = useViewerStore((s) => s.activeTool);
+  const displayOrientation: MPRPlane =
+    (panelOrientation === 'STACK' ? nativeOrientation : panelOrientation) as MPRPlane;
 
-  // Don't render if no images loaded
-  if (!showContextOverlay || viewport.totalImages === 0) return null;
+  if (viewport.totalImages === 0) return null;
+
+  const crosshairGuides =
+    activeTool === ToolName.Crosshairs && crosshairPoint
+      ? getCrosshairDisplayPoint(panelId, crosshairPoint)
+      : null;
+  const showCrosshairGuides = crosshairGuides !== null;
+
+  if (!showContextOverlay && !showCrosshairGuides) return null;
+
+  const crosshairText =
+    activeTool === ToolName.Crosshairs && crosshairPoint
+      ? `${crosshairPoint[0].toFixed(1)}, ${crosshairPoint[1].toFixed(1)}, ${crosshairPoint[2].toFixed(1)}`
+      : null;
 
   return (
-    <div className="absolute inset-0 pointer-events-none p-2 flex flex-col justify-between font-mono text-xs text-white select-none [text-shadow:_0_1px_3px_rgb(0_0_0_/_80%)]">
-      {/* ─── Top Row ───────────────────────────────────────────── */}
-      <div className="flex justify-between items-start">
-        {/* Top-left: Patient info */}
-        <div className="flex flex-col gap-0.5">
-          {overlay.patientName && <span>{overlay.patientName}</span>}
-          {overlay.patientId && (
-            <span className="text-zinc-300">{overlay.patientId}</span>
-          )}
-          {overlay.studyDate && (
-            <span className="text-zinc-400">{overlay.studyDate}</span>
-          )}
-          {sessionLabel && (
-            <span className="text-zinc-400">{sessionLabel}</span>
-          )}
-        </div>
+    <div className="absolute inset-0 pointer-events-none select-none">
+      {showCrosshairGuides && (() => {
+        const { x, y, width, height } = crosshairGuides;
+        const gap = 12;
+        const stroke = 1;
+        const color = 'rgba(34, 197, 94, 0.95)';
+        const leftWidth = Math.max(0, x - gap);
+        const rightStart = Math.min(width, x + gap);
+        const rightWidth = Math.max(0, width - rightStart);
+        const topHeight = Math.max(0, y - gap);
+        const bottomStart = Math.min(height, y + gap);
+        const bottomHeight = Math.max(0, height - bottomStart);
 
-        {/* Top-right: Institution / series info */}
-        <div className="flex flex-col gap-0.5 items-end">
-          {overlay.institutionName && <span>{overlay.institutionName}</span>}
-          {overlay.seriesDescription && (
-            <span className="text-zinc-300">{overlay.seriesDescription}</span>
-          )}
-          {overlay.seriesNumber && (
-            <span className="text-zinc-400">Series: {overlay.seriesNumber}</span>
-          )}
-        </div>
-      </div>
+        return (
+          <div className="absolute inset-0">
+            <div
+              className="absolute"
+              style={{ left: 0, top: `${y - stroke / 2}px`, width: `${leftWidth}px`, height: `${stroke}px`, background: color }}
+            />
+            <div
+              className="absolute"
+              style={{ left: `${rightStart}px`, top: `${y - stroke / 2}px`, width: `${rightWidth}px`, height: `${stroke}px`, background: color }}
+            />
+            <div
+              className="absolute"
+              style={{ left: `${x - stroke / 2}px`, top: 0, width: `${stroke}px`, height: `${topHeight}px`, background: color }}
+            />
+            <div
+              className="absolute"
+              style={{ left: `${x - stroke / 2}px`, top: `${bottomStart}px`, width: `${stroke}px`, height: `${bottomHeight}px`, background: color }}
+            />
+          </div>
+        );
+      })()}
 
-      {/* ─── Bottom Row ────────────────────────────────────────── */}
-      <div className="flex justify-between items-end">
-        {/* Bottom-left: Slice / W/L */}
-        <div className="flex flex-col gap-0.5">
-          <span>
-            Image: {viewport.imageIndex + 1} / {viewport.totalImages}
-          </span>
-          {overlay.sliceLocation && (
-            <span className="text-zinc-300">
-              Loc: {overlay.sliceLocation} mm
-            </span>
-          )}
-          {overlay.sliceThickness && (
-            <span className="text-zinc-400">
-              Thick: {overlay.sliceThickness} mm
-            </span>
-          )}
-          <span className="text-zinc-300">
-            W: {viewport.windowWidth} L: {viewport.windowCenter}
-          </span>
-        </div>
+      {showContextOverlay && (
+        <div className="absolute inset-0 p-2 flex flex-col justify-between font-mono text-xs text-white [text-shadow:_0_1px_3px_rgb(0_0_0_/_80%)]">
+          {/* ─── Top Row ───────────────────────────────────────────── */}
+          <div className="flex justify-between items-start">
+            {/* Top-left: Patient info */}
+            <div className="flex flex-col gap-0.5">
+              <div className="pointer-events-auto">
+                <select
+                  value={displayOrientation}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  onClick={(e) => e.stopPropagation()}
+                  onChange={(e) => {
+                    e.stopPropagation();
+                    const next = e.target.value as MPRPlane;
+                    setPanelOrientation(panelId, next === nativeOrientation ? 'STACK' : next);
+                  }}
+                  className="bg-zinc-900/85 border border-zinc-700 text-zinc-200 text-[10px] rounded px-1 py-0.5 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                  title="Viewport orientation"
+                  disabled={viewport.totalImages <= 1}
+                >
+                  <option value="AXIAL">Axial</option>
+                  <option value="SAGITTAL">Sagittal</option>
+                  <option value="CORONAL">Coronal</option>
+                </select>
+              </div>
+              {subjectLabel && <span className="text-zinc-200">{subjectLabel}</span>}
+              {sessionLabel && (
+                <span className="text-zinc-400">{sessionLabel}</span>
+              )}
+              {overlay.studyDate && (
+                <span className="text-zinc-400">{overlay.studyDate}</span>
+              )}
+            </div>
 
-        {/* Bottom-right: Zoom / dimensions */}
-        <div className="flex flex-col gap-0.5 items-end">
-          <span>Zoom: {viewport.zoomPercent}%</span>
-          {(overlay.rows > 0 || viewport.imageWidth > 0) && (
-            <span className="text-zinc-300">
-              {overlay.rows || viewport.imageWidth} &times;{' '}
-              {overlay.columns || viewport.imageHeight}
-            </span>
-          )}
-          {viewport.rotation !== 0 && (
-            <span className="text-zinc-400">Rot: {viewport.rotation}&deg;</span>
-          )}
-          {(viewport.flipH || viewport.flipV) && (
-            <span className="text-zinc-400">
-              {viewport.flipH && 'FlipH'}
-              {viewport.flipH && viewport.flipV && ' / '}
-              {viewport.flipV && 'FlipV'}
-            </span>
-          )}
-          {viewport.invert && (
-            <span className="text-zinc-400">Inverted</span>
-          )}
+            {/* Top-right: Institution / series info */}
+            <div className="flex flex-col gap-0.5 items-end">
+              {overlay.institutionName && <span>{overlay.institutionName}</span>}
+              {(overlay.seriesDescription || scanSeriesDescription) && (
+                <span className="text-zinc-300">{overlay.seriesDescription || scanSeriesDescription}</span>
+              )}
+              {(overlay.seriesNumber || panelScanId) && (
+                <span className="text-zinc-400">
+                  Scan: {overlay.seriesNumber || panelScanId}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* ─── Bottom Row ────────────────────────────────────────── */}
+          <div className="flex justify-between items-end">
+            {/* Bottom-left: Slice / W/L */}
+            <div className="flex flex-col gap-0.5">
+              <span>
+                Image: {viewport.imageIndex + 1} / {viewport.totalImages}
+              </span>
+              {overlay.sliceLocation && (
+                <span className="text-zinc-300">
+                  Loc: {overlay.sliceLocation} mm
+                </span>
+              )}
+              {overlay.sliceThickness && (
+                <span className="text-zinc-400">
+                  Thick: {overlay.sliceThickness} mm
+                </span>
+              )}
+              <span className="text-zinc-300">
+                W: {viewport.windowWidth} L: {viewport.windowCenter}
+              </span>
+            </div>
+
+            {/* Bottom-right: Zoom / dimensions */}
+            <div className="flex flex-col gap-0.5 items-end">
+              <span>Zoom: {viewport.zoomPercent}%</span>
+              {(overlay.rows > 0 || viewport.imageWidth > 0) && (
+                <span className="text-zinc-300">
+                  {overlay.rows || viewport.imageWidth} &times;{' '}
+                  {overlay.columns || viewport.imageHeight}
+                </span>
+              )}
+              {viewport.rotation !== 0 && (
+                <span className="text-zinc-400">Rot: {viewport.rotation}&deg;</span>
+              )}
+              {(viewport.flipH || viewport.flipV) && (
+                <span className="text-zinc-400">
+                  {viewport.flipH && 'FlipH'}
+                  {viewport.flipH && viewport.flipV && ' / '}
+                  {viewport.flipV && 'FlipV'}
+                </span>
+              )}
+              {viewport.invert && (
+                <span className="text-zinc-400">Inverted</span>
+              )}
+              {crosshairText && (
+                <span className="text-cyan-300">{crosshairText}</span>
+              )}
+            </div>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/renderer/lib/cornerstone/crosshairGeometry.ts
+++ b/src/renderer/lib/cornerstone/crosshairGeometry.ts
@@ -1,0 +1,249 @@
+import { mprService } from './mprService';
+import { viewportService } from './viewportService';
+import { useViewerStore } from '../../stores/viewerStore';
+
+export type Point3 = [number, number, number];
+type Point2 = [number, number];
+
+type AnyViewport = {
+  canvasToWorld: (canvasPos: Point2) => number[] | Point3;
+  worldToCanvas: (worldPos: Point3) => number[] | Point2;
+};
+
+type PanelCanvasContext = {
+  panelEl: HTMLElement;
+  canvasEl: HTMLCanvasElement | null;
+  panelRect: DOMRect;
+  canvasRect: DOMRect;
+  panelWidth: number;
+  panelHeight: number;
+};
+
+function isFinitePoint2(point: number[] | undefined | null): point is Point2 {
+  return !!point && point.length >= 2 && Number.isFinite(point[0]) && Number.isFinite(point[1]);
+}
+
+function isFinitePoint3(point: number[] | undefined | null): point is Point3 {
+  return !!point && point.length >= 3 && Number.isFinite(point[0]) && Number.isFinite(point[1]) && Number.isFinite(point[2]);
+}
+
+function getPanelCanvasContext(panelId: string): PanelCanvasContext | null {
+  const panelEl = document.querySelector(`[data-panel-id="${panelId}"]`) as HTMLElement | null;
+  if (!panelEl) return null;
+  const panelRect = panelEl.getBoundingClientRect();
+  if (panelRect.width <= 0 || panelRect.height <= 0) return null;
+  const canvasEl = panelEl.querySelector('canvas') as HTMLCanvasElement | null;
+  const canvasRect = (canvasEl ?? panelEl).getBoundingClientRect();
+  return {
+    panelEl,
+    canvasEl,
+    panelRect,
+    canvasRect,
+    panelWidth: panelEl.clientWidth,
+    panelHeight: panelEl.clientHeight,
+  };
+}
+
+function roundTripError(viewport: AnyViewport, candidate: Point2): number {
+  try {
+    const world = viewport.canvasToWorld(candidate);
+    if (!isFinitePoint3(world as number[])) return Number.POSITIVE_INFINITY;
+    const back = viewport.worldToCanvas([Number(world[0]), Number(world[1]), Number(world[2])]);
+    if (!isFinitePoint2(back as number[])) return Number.POSITIVE_INFINITY;
+    const dx = Number(back[0]) - candidate[0];
+    const dy = Number(back[1]) - candidate[1];
+    return Math.hypot(dx, dy);
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+function usesDeviceCanvasSpace(viewport: AnyViewport, ctx: PanelCanvasContext): boolean {
+  const { canvasEl, canvasRect } = ctx;
+  if (!canvasEl) return false;
+  if (canvasEl.width <= 0 || canvasEl.height <= 0 || canvasRect.width <= 0 || canvasRect.height <= 0) {
+    return false;
+  }
+
+  const sx = canvasEl.width / canvasRect.width;
+  const sy = canvasEl.height / canvasRect.height;
+  if (!Number.isFinite(sx) || !Number.isFinite(sy) || Math.abs(sx - 1) < 0.01 || Math.abs(sy - 1) < 0.01) {
+    return false;
+  }
+
+  const testCss: Point2 = [canvasRect.width * 0.37, canvasRect.height * 0.61];
+  const testDevice: Point2 = [testCss[0] * sx, testCss[1] * sy];
+  const cssErr = roundTripError(viewport, testCss);
+  const devErr = roundTripError(viewport, testDevice);
+  return devErr + 0.01 < cssErr;
+}
+
+function clientToCanvasPoint(
+  viewport: AnyViewport,
+  ctx: PanelCanvasContext,
+  clientX: number,
+  clientY: number,
+): Point2 | null {
+  const { canvasEl, canvasRect } = ctx;
+  if (canvasRect.width <= 0 || canvasRect.height <= 0) return null;
+  let x = clientX - canvasRect.left;
+  let y = clientY - canvasRect.top;
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+
+  if (
+    canvasEl &&
+    usesDeviceCanvasSpace(viewport, ctx) &&
+    canvasEl.width > 0 &&
+    canvasEl.height > 0
+  ) {
+    x *= canvasEl.width / canvasRect.width;
+    y *= canvasEl.height / canvasRect.height;
+  }
+  return [x, y];
+}
+
+function worldToPanelPoint(
+  viewport: AnyViewport,
+  ctx: PanelCanvasContext,
+  worldPoint: Point3,
+): Point2 | null {
+  const { canvasEl, canvasRect, panelRect } = ctx;
+  const raw = viewport.worldToCanvas(worldPoint);
+  if (!isFinitePoint2(raw as number[])) return null;
+
+  let x = Number(raw[0]);
+  let y = Number(raw[1]);
+
+  if (
+    canvasEl &&
+    usesDeviceCanvasSpace(viewport, ctx) &&
+    canvasEl.width > 0 &&
+    canvasEl.height > 0 &&
+    canvasRect.width > 0 &&
+    canvasRect.height > 0
+  ) {
+    x *= canvasRect.width / canvasEl.width;
+    y *= canvasRect.height / canvasEl.height;
+  }
+
+  return [
+    (canvasRect.left - panelRect.left) + x,
+    (canvasRect.top - panelRect.top) + y,
+  ];
+}
+
+export function getViewportForPanel(panelId: string): AnyViewport | null {
+  const mprViewport = mprService.getViewport(panelId) as AnyViewport | null;
+  const stackViewport = viewportService.getViewport(panelId) as AnyViewport | null;
+  // Prefer MPR viewport whenever available. During orientation transitions,
+  // panelOrientationMap can lag a frame and point to the wrong service.
+  // MPR service is authoritative for oriented panels; stack service is fallback.
+  return mprViewport ?? stackViewport ?? null;
+}
+
+export function getWorldPointFromClientPoint(
+  panelId: string,
+  clientX: number,
+  clientY: number,
+): Point3 | null {
+  const viewport = getViewportForPanel(panelId);
+  if (!viewport || typeof viewport.canvasToWorld !== 'function') return null;
+  const ctx = getPanelCanvasContext(panelId);
+  if (!ctx) return null;
+  const canvasPoint = clientToCanvasPoint(viewport, ctx, clientX, clientY);
+  if (!canvasPoint) return null;
+  try {
+    const world = viewport.canvasToWorld(canvasPoint);
+    if (!isFinitePoint3(world as number[])) return null;
+    return [Number(world[0]), Number(world[1]), Number(world[2])];
+  } catch {
+    return null;
+  }
+}
+
+export function getPanelDisplayPointForWorld(
+  panelId: string,
+  worldPoint: Point3,
+): { x: number; y: number; width: number; height: number } | null {
+  const viewport = getViewportForPanel(panelId);
+  if (!viewport || typeof viewport.worldToCanvas !== 'function') return null;
+  const ctx = getPanelCanvasContext(panelId);
+  if (!ctx) return null;
+  const point = worldToPanelPoint(viewport, ctx, worldPoint);
+  if (!point) return null;
+  const [x, y] = point;
+  const { panelWidth: width, panelHeight: height } = ctx;
+  if (x < -1 || x > width + 1 || y < -1 || y > height + 1) return null;
+  return {
+    x: Math.max(0, Math.min(width, x)),
+    y: Math.max(0, Math.min(height, y)),
+    width,
+    height,
+  };
+}
+
+type CrosshairHandlerOptions = {
+  element: HTMLElement;
+  panelId: string;
+  isCrosshairActive: () => boolean;
+  onWorldPoint: (point: Point3) => void;
+};
+
+export function wireCrosshairPointerHandlers({
+  element,
+  panelId,
+  isCrosshairActive,
+  onWorldPoint,
+}: CrosshairHandlerOptions): () => void {
+  let clickCandidate: { pointerId: number; x: number; y: number } | null = null;
+
+  const syncFromPointer = (e: PointerEvent): void => {
+    const point = getWorldPointFromClientPoint(panelId, e.clientX, e.clientY);
+    if (point) onWorldPoint(point);
+  };
+
+  const onMove = (e: PointerEvent): void => {
+    if (!isCrosshairActive() || !e.shiftKey) return;
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    syncFromPointer(e);
+  };
+
+  const onDown = (e: PointerEvent): void => {
+    if (!isCrosshairActive() || e.button !== 0) {
+      clickCandidate = null;
+      return;
+    }
+    clickCandidate = { pointerId: e.pointerId, x: e.clientX, y: e.clientY };
+  };
+
+  const onUp = (e: PointerEvent): void => {
+    if (!isCrosshairActive() || e.button !== 0 || !clickCandidate) return;
+    if (clickCandidate.pointerId !== e.pointerId) return;
+    const moved = Math.hypot(e.clientX - clickCandidate.x, e.clientY - clickCandidate.y);
+    clickCandidate = null;
+    if (moved <= 4) {
+      syncFromPointer(e);
+    }
+  };
+
+  const onCancel = (e: PointerEvent): void => {
+    if (clickCandidate?.pointerId === e.pointerId) {
+      clickCandidate = null;
+    }
+  };
+
+  element.addEventListener('pointermove', onMove, true);
+  element.addEventListener('pointerdown', onDown, true);
+  element.addEventListener('pointerup', onUp, true);
+  element.addEventListener('pointercancel', onCancel, true);
+  element.addEventListener('lostpointercapture', onCancel as EventListener, true);
+
+  return () => {
+    element.removeEventListener('pointermove', onMove, true);
+    element.removeEventListener('pointerdown', onDown, true);
+    element.removeEventListener('pointerup', onUp, true);
+    element.removeEventListener('pointercancel', onCancel, true);
+    element.removeEventListener('lostpointercapture', onCancel as EventListener, true);
+  };
+}

--- a/src/renderer/lib/cornerstone/crosshairSyncService.ts
+++ b/src/renderer/lib/cornerstone/crosshairSyncService.ts
@@ -1,0 +1,208 @@
+import { metaData } from '@cornerstonejs/core';
+import { useViewerStore } from '../../stores/viewerStore';
+import { viewportService } from './viewportService';
+import {
+  getPanelDisplayPointForWorld,
+  getViewportForPanel,
+  getWorldPointFromClientPoint,
+} from './crosshairGeometry';
+
+type Point3 = [number, number, number];
+type Point2 = [number, number];
+type AnyViewport = {
+  jumpToWorld?: (worldPos: Point3) => boolean;
+  getCurrentImageIdIndex?: () => number;
+  getCamera?: () => {
+    position?: number[];
+    focalPoint?: number[];
+    viewPlaneNormal?: number[];
+  };
+  setCamera?: (camera: { position?: Point3; focalPoint?: Point3 }) => void;
+  render?: () => void;
+};
+
+function dot(a: Point3, b: Point3): number {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+function cross(a: Point3, b: Point3): Point3 {
+  return [
+    a[1] * b[2] - a[2] * b[1],
+    a[2] * b[0] - a[0] * b[2],
+    a[0] * b[1] - a[1] * b[0],
+  ];
+}
+
+function sub(a: Point3, b: Point3): Point3 {
+  return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+}
+
+function add(a: Point3, b: Point3): Point3 {
+  return [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+}
+
+function scale(a: Point3, s: number): Point3 {
+  return [a[0] * s, a[1] * s, a[2] * s];
+}
+
+function length(a: Point3): number {
+  return Math.hypot(a[0], a[1], a[2]);
+}
+
+function toPoint3(value: number[] | Point3 | undefined | null): Point3 | null {
+  if (!Array.isArray(value) || value.length < 3) return null;
+  const x = Number(value[0]);
+  const y = Number(value[1]);
+  const z = Number(value[2]);
+  if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) return null;
+  return [x, y, z];
+}
+
+function keepPointVisibleByPanning(
+  panelId: string,
+  viewport: AnyViewport,
+  worldPoint: Point3,
+): void {
+  if (typeof viewport.getCamera !== 'function' || typeof viewport.setCamera !== 'function') {
+    return;
+  }
+
+  // Already visible in current view bounds: no pan needed.
+  if (getPanelDisplayPointForWorld(panelId, worldPoint)) return;
+
+  const panelEl = document.querySelector(`[data-panel-id="${panelId}"]`) as HTMLElement | null;
+  if (!panelEl) return;
+  const rect = panelEl.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) return;
+  const centerWorld = getWorldPointFromClientPoint(
+    panelId,
+    rect.left + rect.width / 2,
+    rect.top + rect.height / 2,
+  );
+  if (!centerWorld) return;
+
+  const camera = viewport.getCamera();
+  const focal = toPoint3(camera?.focalPoint);
+  const position = toPoint3(camera?.position);
+  if (!focal || !position) return;
+
+  let delta = sub(worldPoint, centerWorld);
+  const normal = toPoint3(camera?.viewPlaneNormal);
+  if (normal) {
+    const nLen = length(normal);
+    if (nLen > 0) {
+      const n = scale(normal, 1 / nLen);
+      // Pan only in-plane; avoid shifting along view normal.
+      delta = sub(delta, scale(n, dot(delta, n)));
+    }
+  }
+
+  if (length(delta) < 1e-6) return;
+  viewport.setCamera({
+    focalPoint: add(focal, delta),
+    position: add(position, delta),
+  });
+}
+
+function getSeriesUid(imageId: string): string | null {
+  const series = metaData.get('generalSeriesModule', imageId) as { seriesInstanceUID?: string } | undefined;
+  return series?.seriesInstanceUID ?? null;
+}
+
+function getFrameOfReferenceUid(imageId: string): string | null {
+  const plane = metaData.get('imagePlaneModule', imageId) as { frameOfReferenceUID?: string } | undefined;
+  return plane?.frameOfReferenceUID ?? null;
+}
+
+function getImagePlane(imageId: string): { ipp: Point3; normal: Point3 } | null {
+  const imagePlane = metaData.get('imagePlaneModule', imageId) as
+    | { imagePositionPatient?: number[]; imageOrientationPatient?: number[] }
+    | undefined;
+  const ipp = imagePlane?.imagePositionPatient;
+  const iop = imagePlane?.imageOrientationPatient;
+  if (!Array.isArray(ipp) || ipp.length < 3 || !Array.isArray(iop) || iop.length < 6) return null;
+  const position: Point3 = [Number(ipp[0]), Number(ipp[1]), Number(ipp[2])];
+  const row: Point3 = [Number(iop[0]), Number(iop[1]), Number(iop[2])];
+  const col: Point3 = [Number(iop[3]), Number(iop[4]), Number(iop[5])];
+  if (![...position, ...row, ...col].every((v) => Number.isFinite(v))) return null;
+  return { ipp: position, normal: cross(row, col) };
+}
+
+function findNearestStackIndex(imageIds: string[], world: Point3): number | null {
+  if (imageIds.length === 0) return null;
+  const ref = getImagePlane(imageIds[0]);
+  if (!ref) return null;
+  const target = dot(ref.normal, world);
+  let bestIndex = -1;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (let i = 0; i < imageIds.length; i++) {
+    const plane = getImagePlane(imageIds[i]);
+    if (!plane) continue;
+    const value = dot(ref.normal, plane.ipp);
+    const dist = Math.abs(value - target);
+    if (dist < bestDistance) {
+      bestDistance = dist;
+      bestIndex = i;
+    }
+  }
+  return bestIndex >= 0 ? bestIndex : null;
+}
+
+export const crosshairSyncService = {
+  /**
+   * Publish crosshair coordinate globally and sync compatible viewports.
+   * Primary path uses viewport-native world navigation (`jumpToWorld`) to avoid
+   * orientation-specific math and preserve consistent geometric behavior.
+   * Legacy stack-index fallback remains for non-jumpable targets.
+   */
+  syncFromViewport(sourcePanelId: string, worldPoint: Point3): void {
+    const store = useViewerStore.getState();
+    store.setCrosshairWorldPoint(worldPoint, sourcePanelId);
+
+    const sourceIds = store.panelImageIdsMap[sourcePanelId] ?? [];
+    const sourceForUid = sourceIds[0] ? getFrameOfReferenceUid(sourceIds[0]) : null;
+    const sourceSeriesUid = sourceIds[0] ? getSeriesUid(sourceIds[0]) : null;
+
+    for (const [panelId, imageIds] of Object.entries(store.panelImageIdsMap)) {
+      if (panelId === sourcePanelId || imageIds.length === 0) continue;
+      const targetViewport = getViewportForPanel(panelId) as AnyViewport | null;
+      if (!targetViewport) continue;
+
+      // Prefer FrameOfReference matching. Fall back to Series UID matching when needed.
+      const targetForUid = imageIds[0] ? getFrameOfReferenceUid(imageIds[0]) : null;
+      if (sourceForUid && targetForUid && sourceForUid !== targetForUid) continue;
+      if (sourceForUid && !targetForUid) {
+        const panelSeriesUid = imageIds[0] ? getSeriesUid(imageIds[0]) : null;
+        if (!panelSeriesUid || (sourceSeriesUid && panelSeriesUid !== sourceSeriesUid)) continue;
+      }
+
+      // Best-practice path: use viewport-native world navigation.
+      if (typeof targetViewport.jumpToWorld === 'function') {
+        try {
+          const jumped = targetViewport.jumpToWorld(worldPoint);
+          if (jumped) {
+            keepPointVisibleByPanning(panelId, targetViewport, worldPoint);
+            targetViewport.render?.();
+            // Keep stack requested-index state in sync so slider/status remain stable.
+            if (typeof targetViewport.getCurrentImageIdIndex === 'function') {
+              const idx = targetViewport.getCurrentImageIdIndex();
+              if (Number.isFinite(idx) && imageIds.length > 0) {
+                const clamped = Math.max(0, Math.min(imageIds.length - 1, Number(idx)));
+                store._requestImageIndex(panelId, clamped, imageIds.length);
+              }
+            }
+            continue;
+          }
+        } catch {
+          // Fall through to stack-index fallback.
+        }
+      }
+
+      // Fallback for legacy/non-jumpable targets.
+      const targetIndex = findNearestStackIndex(imageIds, worldPoint);
+      if (targetIndex == null) continue;
+      store._requestImageIndex(panelId, targetIndex, imageIds.length);
+      viewportService.scrollToIndex(panelId, targetIndex);
+    }
+  },
+};

--- a/src/renderer/lib/cornerstone/metadataService.ts
+++ b/src/renderer/lib/cornerstone/metadataService.ts
@@ -9,6 +9,7 @@
 import { metaData } from '@cornerstonejs/core';
 import type { OverlayMetadata } from '@shared/types/dicom';
 import { EMPTY_OVERLAY } from '@shared/types/dicom';
+import type { ViewportOrientation } from '@shared/types/viewer';
 
 /**
  * Format a DICOM date string (YYYYMMDD) to a readable format.
@@ -62,6 +63,43 @@ function toStr(val: unknown): string {
 }
 
 export const metadataService = {
+  /**
+   * Infer the native acquisition orientation from the DICOM
+   * ImageOrientationPatient tag. Computes the cross product of
+   * the row and column direction cosines and returns the dominant
+   * axis as AXIAL / SAGITTAL / CORONAL.
+   *
+   * Falls back to 'AXIAL' if metadata is unavailable.
+   */
+  getNativeOrientation(imageId: string): ViewportOrientation {
+    try {
+      const imagePlane = metaData.get('imagePlaneModule', imageId);
+      const iop: number[] | undefined =
+        imagePlane?.imageOrientationPatient ??
+        imagePlane?.rowCosines; // fallback field name
+      if (!iop || iop.length < 6) return 'AXIAL';
+
+      // Row direction cosines
+      const rx = iop[0], ry = iop[1], rz = iop[2];
+      // Column direction cosines
+      const cx = iop[3], cy = iop[4], cz = iop[5];
+      // Normal = row × col
+      const nx = ry * cz - rz * cy;
+      const ny = rz * cx - rx * cz;
+      const nz = rx * cy - ry * cx;
+
+      const absX = Math.abs(nx);
+      const absY = Math.abs(ny);
+      const absZ = Math.abs(nz);
+
+      if (absZ >= absX && absZ >= absY) return 'AXIAL';
+      if (absX >= absY) return 'SAGITTAL';
+      return 'CORONAL';
+    } catch {
+      return 'AXIAL';
+    }
+  },
+
   /**
    * Extract overlay metadata for a given imageId.
    * Returns empty strings/zeros for any missing fields.

--- a/src/renderer/lib/cornerstone/segmentationService.ts
+++ b/src/renderer/lib/cornerstone/segmentationService.ts
@@ -97,6 +97,186 @@ const sourceImageIdsMap = new Map<string, string[]>();
  */
 const loadedColorsMap = new Map<string, Map<number, [number, number, number, number]>>();
 
+// ─── Multi-Layer Group Registry ─────────────────────────────────
+//
+// Each logical segmentation (shown in the UI as one row with N segments)
+// is backed by N independent Cornerstone segmentation objects ("sub-segs"),
+// one per segment. Each sub-seg has its own set of binary (0/1) Uint8Array
+// labelmap images, enabling overlapping segments.
+
+/** Per-segment metadata stored at the group level. */
+interface SegmentMeta {
+  label: string;
+  color: [number, number, number, number];
+  locked: boolean;
+}
+
+/** Image dimensions + source IDs for creating new sub-seg labelmap images. */
+interface GroupDimensions {
+  rows: number;
+  columns: number;
+  rowPixelSpacing: number;
+  columnPixelSpacing: number;
+  sourceImageIds: string[];
+}
+
+/**
+ * Maps group ID (logical segmentation shown in UI) → ordered sub-seg IDs.
+ * Array index + 1 = logical segment index. Null entries = removed segments.
+ */
+const subSegGroupMap = new Map<string, (string | null)[]>();
+
+/**
+ * Reverse lookup: Cornerstone sub-segmentation ID → { groupId, segmentIndex }.
+ */
+const subSegToGroupMap = new Map<string, { groupId: string; segmentIndex: number }>();
+
+/**
+ * Per-segment metadata (label, color, locked) keyed by group ID + segment index.
+ */
+const segmentMetaMap = new Map<string, Map<number, SegmentMeta>>();
+
+/**
+ * Image dimensions for creating new sub-seg labelmap images on demand.
+ */
+const groupDimensionsMap = new Map<string, GroupDimensions>();
+
+/** Group label storage (separate from segments). */
+const groupLabelMap = new Map<string, string>();
+
+/** Returns true if a segmentationId is a multi-layer group. */
+function isMultiLayerGroup(segmentationId: string): boolean {
+  return subSegGroupMap.has(segmentationId);
+}
+
+/** Returns non-null sub-seg IDs for a group. */
+function getActiveSubSegIds(segmentationId: string): string[] {
+  const arr = subSegGroupMap.get(segmentationId);
+  if (!arr) return [];
+  return arr.filter((id): id is string => id !== null);
+}
+
+/** Resolve a group ID + logical segment index to the sub-seg ID. */
+function resolveSubSegId(groupId: string, segmentIndex: number): string | null {
+  const arr = subSegGroupMap.get(groupId);
+  if (!arr) return null;
+  return arr[segmentIndex - 1] ?? null;
+}
+
+/** Find viewport IDs that have any sub-seg of a group attached. */
+function findViewportsWithGroup(groupId: string): string[] {
+  const subSegIds = getActiveSubSegIds(groupId);
+  const vpSet = new Set<string>();
+  for (const subSegId of subSegIds) {
+    for (const vpId of csSegmentation.state.getViewportIdsWithSegmentation(subSegId)) {
+      vpSet.add(vpId);
+    }
+  }
+  return Array.from(vpSet);
+}
+
+/**
+ * Attach a single sub-segmentation to a viewport: add labelmap representation,
+ * populate Cornerstone reference maps, and set the segment color.
+ */
+async function addSubSegToViewport(
+  viewportId: string,
+  subSegId: string,
+  segColor: [number, number, number, number],
+): Promise<void> {
+  // Volume viewports (ORTHOGRAPHIC/MPR) need volume-backed labelmaps.
+  // If the sub-seg only has stack imageIds, convert it first.
+  try {
+    const volEl = getEnabledElementByViewportId(viewportId) as any;
+    const volVp: any = volEl?.viewport;
+    if (volVp && typeof volVp.getAllVolumeIds === 'function') {
+      const segObj = csSegmentation.state.getSegmentation(subSegId) as any;
+      const labelmap = segObj?.representationData?.Labelmap as any;
+      const hasImageIds = Array.isArray(labelmap?.imageIds) && labelmap.imageIds.length > 0;
+      const hasVolumeId = typeof labelmap?.volumeId === 'string' && labelmap.volumeId.length > 0;
+      if (hasImageIds && !hasVolumeId) {
+        try {
+          await (csSegmentation.helpers as any).convertStackToVolumeLabelmap({
+            segmentationId: subSegId,
+          });
+          console.log(`[segmentationService] Converted sub-seg ${subSegId} stack→volume labelmap for ${viewportId}`);
+        } catch (convErr) {
+          console.warn(`[segmentationService] Failed converting ${subSegId} to volume labelmap; continuing with stack path`, convErr);
+        }
+      }
+    }
+  } catch {
+    // Viewport may not be ready yet — proceed with stack path
+  }
+
+  csSegmentation.addLabelmapRepresentationToViewport(viewportId, [
+    { segmentationId: subSegId },
+  ]);
+
+  // Populate internal reference maps for stack viewports.
+  try {
+    const seg = csSegmentation.state.getSegmentation(subSegId);
+    const lmImageIds: string[] = (seg?.representationData?.Labelmap as any)?.imageIds ?? [];
+    const mgr = csSegmentation.defaultSegmentationStateManager as any;
+    if (!mgr._stackLabelmapImageIdReferenceMap.has(subSegId)) {
+      mgr._stackLabelmapImageIdReferenceMap.set(subSegId, new Map());
+    }
+    const perSegMap = mgr._stackLabelmapImageIdReferenceMap.get(subSegId);
+    for (const lmId of lmImageIds) {
+      const lmImg = cache.getImage(lmId);
+      const refId = (lmImg as any)?.referencedImageId;
+      if (!refId) continue;
+      perSegMap.set(refId, lmId);
+      const mapKey = `${subSegId}-${refId}`;
+      const existing = mgr._labelmapImageIdReferenceMap.get(mapKey);
+      if (!existing) {
+        mgr._labelmapImageIdReferenceMap.set(mapKey, [lmId]);
+      } else if (!existing.includes(lmId)) {
+        mgr._labelmapImageIdReferenceMap.set(mapKey, [...existing, lmId]);
+      }
+    }
+
+    // Also map viewport-specific imageIds (wadouri/wadors format differences).
+    const enabledEl = getEnabledElementByViewportId(viewportId) as any;
+    const viewport = enabledEl?.viewport as any;
+    if (viewport && typeof viewport.getAllVolumeIds !== 'function') {
+      const viewportImageIds = viewport.getImageIds?.() as string[] | undefined;
+      if (Array.isArray(viewportImageIds)) {
+        const srcIds = sourceImageIdsMap.get(subSegId) ?? [];
+        const count = Math.min(srcIds.length, viewportImageIds.length);
+        for (let i = 0; i < count; i++) {
+          const vpImgId = viewportImageIds[i];
+          if (typeof vpImgId !== 'string' || vpImgId.length === 0) continue;
+          const lmId = lmImageIds[i];
+          if (!lmId) continue;
+          perSegMap.set(vpImgId, lmId);
+          const vpMapKey = `${subSegId}-${vpImgId}`;
+          const vpExisting = mgr._labelmapImageIdReferenceMap.get(vpMapKey);
+          if (!vpExisting) {
+            mgr._labelmapImageIdReferenceMap.set(vpMapKey, [lmId]);
+          } else if (!vpExisting.includes(lmId)) {
+            mgr._labelmapImageIdReferenceMap.set(vpMapKey, [...vpExisting, lmId]);
+          }
+        }
+      }
+    }
+  } catch (err) {
+    console.warn(`[segmentationService] Failed to populate reference maps for ${subSegId}:`, err);
+  }
+
+  // Set color for segment index 1 on this sub-seg.
+  try {
+    csSegmentation.config.color.setSegmentIndexColor(
+      viewportId,
+      subSegId,
+      1,
+      segColor as any,
+    );
+  } catch {
+    // Color may not be settable yet
+  }
+}
+
 // ─── Types ──────────────────────────────────────────────────────
 
 export type LoadedDicomSeg = {
@@ -415,15 +595,115 @@ function syncSegmentations(): void {
     const allSegmentations = csSegmentation.state.getSegmentations();
     const summaries: SegmentationSummary[] = [];
     const existingSummaries = useSegmentationStore.getState().segmentations;
+    const store = useSegmentationStore.getState();
 
+    // Track which Cornerstone segmentation IDs are sub-segs (skip them in the legacy pass)
+    const processedSubSegIds = new Set<string>();
+
+    // Deterministic reference viewport: prefer the active viewport so
+    // visibility/color queries return consistent results across calls.
+    const activeVpId = useViewerStore.getState().activeViewportId;
+
+    // ─── Pass 1: Multi-layer groups ────────────────────────────
+    for (const [groupId, subSegArr] of subSegGroupMap) {
+      const segments: SegmentSummary[] = [];
+      const priorSummary = existingSummaries.find((s) => s.segmentationId === groupId);
+      const priorColorByIndex = new Map<number, [number, number, number, number]>(
+        (priorSummary?.segments ?? []).map((s) => [s.segmentIndex, s.color]),
+      );
+      const cachedPresentation = useSegmentationManagerStore.getState().presentation[groupId];
+
+      for (let i = 0; i < subSegArr.length; i++) {
+        const subSegId = subSegArr[i];
+        if (subSegId === null) continue; // removed segment slot
+        processedSubSegIds.add(subSegId);
+
+        const segmentIndex = i + 1; // 1-based
+        const meta = segmentMetaMap.get(groupId)?.get(segmentIndex);
+
+        // Color: try Cornerstone API on the sub-seg (segment index 1), then meta, then default
+        let color: [number, number, number, number] =
+          meta?.color ?? DEFAULT_COLORS[(segmentIndex - 1) % DEFAULT_COLORS.length];
+        let gotColorFromCS = false;
+        const vpIds = csSegmentation.state.getViewportIdsWithSegmentation(subSegId);
+        // Prefer active viewport for deterministic reads
+        const refVpId = vpIds.includes(activeVpId) ? activeVpId : vpIds[0];
+        if (vpIds.length > 0) {
+          try {
+            const c = csSegmentation.config.color.getSegmentIndexColor(refVpId, subSegId, 1);
+            if (hasUsableColor(c)) {
+              color = [c[0], c[1], c[2], c.length >= 4 ? c[3] : 255];
+              gotColorFromCS = true;
+            }
+          } catch {
+            // fallback
+          }
+        }
+        if (!gotColorFromCS) {
+          const loadedColors = loadedColorsMap.get(groupId);
+          if (loadedColors?.has(segmentIndex)) {
+            color = loadedColors.get(segmentIndex)!;
+          } else if (priorColorByIndex.has(segmentIndex)) {
+            color = [...priorColorByIndex.get(segmentIndex)!] as [number, number, number, number];
+          }
+        }
+
+        // Visibility: from sub-seg's segment index 1
+        let visible = true;
+        const cachedVisible = cachedPresentation?.visibility?.[segmentIndex];
+        if (typeof cachedVisible === 'boolean') {
+          visible = cachedVisible;
+        } else if (vpIds.length > 0) {
+          try {
+            visible = csSegmentation.config.visibility.getSegmentIndexVisibility(
+              refVpId,
+              { segmentationId: subSegId, type: ToolEnums.SegmentationRepresentations.Labelmap },
+              1,
+            );
+          } catch {
+            // default visible
+          }
+          // Seed the presentation cache when not yet populated
+          if (cachedVisible === undefined) {
+            useSegmentationManagerStore.getState().setPresentation(groupId, segmentIndex, { visible });
+          }
+        }
+
+        // Locked
+        const cachedLocked = cachedPresentation?.locked?.[segmentIndex];
+        let locked = meta?.locked ?? false;
+        if (typeof cachedLocked === 'boolean') locked = cachedLocked;
+
+        segments.push({
+          segmentIndex,
+          label: meta?.label ?? `Segment ${segmentIndex}`,
+          color,
+          visible,
+          locked,
+        });
+      }
+
+      segments.sort((a, b) => a.segmentIndex - b.segmentIndex);
+
+      summaries.push({
+        segmentationId: groupId,
+        label: groupLabelMap.get(groupId) ?? 'Segmentation',
+        segments,
+        isActive: groupId === store.activeSegmentationId,
+      });
+    }
+
+    // ─── Pass 2: Legacy (non-group) segmentations ──────────────
     for (const seg of allSegmentations) {
+      if (processedSubSegIds.has(seg.segmentationId)) continue;
+      if (subSegGroupMap.has(seg.segmentationId)) continue; // group ID itself (no CS object)
+
       const segments: SegmentSummary[] = [];
       const priorSummary = existingSummaries.find((s) => s.segmentationId === seg.segmentationId);
       const priorColorByIndex = new Map<number, [number, number, number, number]>(
         (priorSummary?.segments ?? []).map((s) => [s.segmentIndex, s.color]),
       );
 
-      // Iterate over segments (skip index 0 = background)
       if (seg.segments) {
         const seen = new Set<number>();
         for (const [idxStr, segment] of Object.entries(seg.segments)) {
@@ -434,12 +714,11 @@ function syncSegmentations(): void {
               idx = fallbackIdx;
             }
           }
-          if (!Number.isFinite(idx) || idx <= 0 || !Number.isInteger(idx)) continue; // Skip invalid/background
+          if (!Number.isFinite(idx) || idx <= 0 || !Number.isInteger(idx)) continue;
           if (!segment) continue;
           if (seen.has(idx)) continue;
           seen.add(idx);
 
-          // Get color: Cornerstone API → loadedColorsMap fallback → DEFAULT_COLORS
           let color: [number, number, number, number] = DEFAULT_COLORS[(idx - 1) % DEFAULT_COLORS.length];
           let gotColorFromCS = false;
           const viewportIds = csSegmentation.state.getViewportIdsWithSegmentation(seg.segmentationId);
@@ -458,10 +737,6 @@ function syncSegmentations(): void {
               // Use default color
             }
           }
-          // Fallback to loaded DICOM colors only if Cornerstone API didn't return valid colors.
-          // Previously used reference identity (===) to check if color was still the default,
-          // which always matched because `color` was assigned directly from DEFAULT_COLORS.
-          // Using a boolean flag avoids overriding user-set colors that happen to match defaults.
           if (!gotColorFromCS) {
             const loadedColors = loadedColorsMap.get(seg.segmentationId);
             if (loadedColors?.has(idx)) {
@@ -471,24 +746,23 @@ function syncSegmentations(): void {
             }
           }
 
-          // Check visibility - from the representation's per-segment visibility
-          // Try Labelmap first, then Contour
           let visible = true;
           const cachedPresentation = useSegmentationManagerStore.getState().presentation[seg.segmentationId];
           const cachedVisible = cachedPresentation?.visibility?.[idx];
           if (typeof cachedVisible === 'boolean') {
             visible = cachedVisible;
-          } else if (viewportIds.length > 0) {
+          } else if (csSegmentation.state.getViewportIdsWithSegmentation(seg.segmentationId).length > 0) {
+            const vpId = csSegmentation.state.getViewportIdsWithSegmentation(seg.segmentationId)[0];
             try {
               visible = csSegmentation.config.visibility.getSegmentIndexVisibility(
-                viewportIds[0],
+                vpId,
                 { segmentationId: seg.segmentationId, type: ToolEnums.SegmentationRepresentations.Labelmap },
                 idx,
               );
             } catch {
               try {
                 visible = csSegmentation.config.visibility.getSegmentIndexVisibility(
-                  viewportIds[0],
+                  vpId,
                   { segmentationId: seg.segmentationId, type: ToolEnums.SegmentationRepresentations.Contour },
                   idx,
                 );
@@ -498,7 +772,7 @@ function syncSegmentations(): void {
             }
           }
 
-          const cachedLocked = cachedPresentation?.locked?.[idx];
+          const cachedLocked = useSegmentationManagerStore.getState().presentation[seg.segmentationId]?.locked?.[idx];
 
           segments.push({
             segmentIndex: idx,
@@ -510,10 +784,8 @@ function syncSegmentations(): void {
         }
       }
 
-      // Sort segments by index
       segments.sort((a, b) => a.segmentIndex - b.segmentIndex);
 
-      const store = useSegmentationStore.getState();
       summaries.push({
         segmentationId: seg.segmentationId,
         label: seg.label || 'Segmentation',
@@ -568,6 +840,9 @@ function renderAllSegmentationViewports(): void {
  * or 'both' if it has both representations with data.
  */
 function getSegmentationType(segmentationId: string): 'labelmap' | 'contour' | 'both' {
+  // Multi-layer groups are always labelmap-based
+  if (isMultiLayerGroup(segmentationId)) return 'labelmap';
+
   const seg = csSegmentation.state.getSegmentation(segmentationId);
   if (!seg) return 'labelmap';
 
@@ -635,15 +910,29 @@ function onSegmentationDataModified(evt?: Event): void {
     const detail = (evt as CustomEvent | undefined)?.detail as
       | { segmentationId?: string; segmentIndex?: number }
       | undefined;
+
+    // Resolve sub-seg ID to group ID for dirty tracking
+    let resolvedSegId = detail?.segmentationId ?? null;
+    if (resolvedSegId) {
+      const groupInfo = subSegToGroupMap.get(resolvedSegId);
+      if (groupInfo) {
+        resolvedSegId = groupInfo.groupId;
+      }
+    }
+
     if (detail?.segmentationId) {
+      // For interpolation, use the resolved group ID so it can look up the right sub-seg
+      const groupInfo = subSegToGroupMap.get(detail.segmentationId);
       pendingLabelmapInterpolation = {
-        segmentationId: detail.segmentationId,
-        segmentIndex: Number.isInteger(detail.segmentIndex) ? Number(detail.segmentIndex) : null,
+        segmentationId: groupInfo ? groupInfo.groupId : detail.segmentationId,
+        segmentIndex: groupInfo
+          ? groupInfo.segmentIndex
+          : (Number.isInteger(detail.segmentIndex) ? Number(detail.segmentIndex) : null),
       };
     }
     useSegmentationStore.getState()._markDirty();
     const dirtySegId =
-      detail?.segmentationId
+      resolvedSegId
       ?? useSegmentationStore.getState().activeSegmentationId
       ?? null;
     if (dirtySegId) {
@@ -698,20 +987,32 @@ async function performLabelmapInterpolation(): Promise<void> {
   if (!segStore.interpolationEnabled) return;
   const pending = pendingLabelmapInterpolation;
   pendingLabelmapInterpolation = null;
-  const activeSegId = pending?.segmentationId ?? segStore.activeSegmentationId;
+  let activeSegId = pending?.segmentationId ?? segStore.activeSegmentationId;
   if (!activeSegId) return;
-  if (getSegmentationType(activeSegId) === 'contour') return;
-  const segmentIndex = Number(pending?.segmentIndex ?? segStore.activeSegmentIndex);
+
+  let segmentIndex = Number(pending?.segmentIndex ?? segStore.activeSegmentIndex);
   if (!Number.isInteger(segmentIndex) || segmentIndex <= 0) return;
 
-  const labelmapData = await getCachedLabelmapSliceArrays(activeSegId);
+  // For multi-layer groups, resolve to the sub-seg and use segment index 1
+  let effectiveSegId = activeSegId;
+  let effectiveSegIndex = segmentIndex;
+  if (isMultiLayerGroup(activeSegId)) {
+    const subSegId = resolveSubSegId(activeSegId, segmentIndex);
+    if (!subSegId) return;
+    effectiveSegId = subSegId;
+    effectiveSegIndex = 1; // sub-segs are binary (0/1)
+  }
+
+  if (getSegmentationType(effectiveSegId) === 'contour') return;
+
+  const labelmapData = await getCachedLabelmapSliceArrays(effectiveSegId);
   if (!labelmapData) return;
   const { sliceArrays, width, height } = labelmapData;
   if (sliceArrays.length < 3) return;
 
   const anchors: number[] = [];
   for (let i = 0; i < sliceArrays.length; i++) {
-    if (hasSegmentPixelsOnSlice(sliceArrays[i], segmentIndex)) {
+    if (hasSegmentPixelsOnSlice(sliceArrays[i], effectiveSegIndex)) {
       anchors.push(i);
     }
   }
@@ -728,8 +1029,8 @@ async function performLabelmapInterpolation(): Promise<void> {
       const gap = b - a - 1;
       if (gap <= 0) continue;
 
-      const signedA = buildSignedDistanceForSegment(sliceArrays[a], width, height, segmentIndex);
-      const signedB = buildSignedDistanceForSegment(sliceArrays[b], width, height, segmentIndex);
+      const signedA = buildSignedDistanceForSegment(sliceArrays[a], width, height, effectiveSegIndex);
+      const signedB = buildSignedDistanceForSegment(sliceArrays[b], width, height, effectiveSegIndex);
 
       for (let s = a + 1; s < b; s++) {
         const alpha = (s - a) / (b - a);
@@ -738,11 +1039,11 @@ async function performLabelmapInterpolation(): Promise<void> {
 
         for (let p = 0; p < pixelsPerSlice; p++) {
           const currentValue = Number(slice[p]);
-          if (currentValue !== 0 && currentValue !== segmentIndex) continue;
+          if (currentValue !== 0 && currentValue !== effectiveSegIndex) continue;
 
           const interpolatedDistance = (1 - alpha) * signedA[p] + alpha * signedB[p];
           if (interpolatedDistance <= 0 && currentValue === 0) {
-            slice[p] = segmentIndex;
+            slice[p] = effectiveSegIndex;
             changed = true;
           }
         }
@@ -756,11 +1057,11 @@ async function performLabelmapInterpolation(): Promise<void> {
     if (modifiedSlices.size === 0) return;
 
     csSegmentation.triggerSegmentationEvents.triggerSegmentationDataModified(
-      activeSegId,
+      effectiveSegId,
       Array.from(modifiedSlices).sort((x, y) => x - y),
-      segmentIndex,
+      effectiveSegIndex,
     );
-    const viewportIds = csSegmentation.state.getViewportIdsWithSegmentation(activeSegId);
+    const viewportIds = csSegmentation.state.getViewportIdsWithSegmentation(effectiveSegId);
     for (const viewportId of viewportIds) {
       csToolUtilities.segmentation.triggerSegmentationRender(viewportId);
       const enabledElement = getEnabledElementByViewportId(viewportId) as any;
@@ -926,6 +1227,7 @@ export const segmentationService = {
    * have been removed from viewports.
    */
   segmentationExists(segmentationId: string): boolean {
+    if (isMultiLayerGroup(segmentationId)) return true;
     const seg = csSegmentation.state.getSegmentation(segmentationId);
     return !!seg;
   },
@@ -934,6 +1236,10 @@ export const segmentationService = {
    * Get the viewport IDs that currently display a given segmentation.
    */
   getViewportIdsForSegmentation(segmentationId: string): string[] {
+    // Multi-layer group: union viewport IDs from all sub-segs
+    if (isMultiLayerGroup(segmentationId)) {
+      return findViewportsWithGroup(segmentationId);
+    }
     return csSegmentation.state.getViewportIdsWithSegmentation(segmentationId);
   },
 
@@ -942,6 +1248,11 @@ export const segmentationService = {
    * Used to override generic labels with user-friendly names from XNAT metadata.
    */
   setLabel(segmentationId: string, label: string): void {
+    if (isMultiLayerGroup(segmentationId)) {
+      groupLabelMap.set(segmentationId, label);
+      syncSegmentations();
+      return;
+    }
     const seg = csSegmentation.state.getSegmentation(segmentationId);
     if (seg) {
       (seg as any).label = label;
@@ -1015,8 +1326,6 @@ export const segmentationService = {
     const segLabel = label || `Segmentation ${segmentationCounter}`;
 
     // Step 1: Determine image dimensions from a loaded source image.
-    // Try each sourceImageId until we find one that's cached (the currently
-    // displayed image is guaranteed to be cached).
     let rows = 0;
     let columns = 0;
     let rowPixelSpacing = 1;
@@ -1041,17 +1350,6 @@ export const segmentationService = {
     }
 
     // Step 2: Pre-load source images so their metadata is available.
-    //
-    // Stack segmentation in Cornerstone3D requires every source image to have
-    // imagePlaneModule and generalSeriesModule metadata registered. With wadouri
-    // images, metadata is only available after the DICOM file is fetched. If we
-    // create labelmaps before all images are loaded, Cornerstone crashes when
-    // scrolling to unloaded slices (matchImagesForOverlay and buildMetadata
-    // both assume metadata is present).
-    //
-    // Optimization: skip images that already have metadata cached (i.e., they
-    // were already loaded for viewport display). This avoids re-fetching all
-    // images when most are already cached, reducing creation time dramatically.
     const uncachedIds = sourceImageIds.filter((id) => {
       try {
         return !metaData.get('imagePlaneModule', id);
@@ -1068,116 +1366,36 @@ export const segmentationService = {
       console.log(`[segmentationService] All ${sourceImageIds.length} images already have metadata, skipping pre-load`);
     }
 
-    // Step 3: Create blank labelmap images using createAndCacheLocalImage().
-    // Now that all source images are loaded, every one has valid metadata.
-    //
-    // We pass origin, direction, and frameOfReferenceUID from each source
-    // image's imagePlaneModule so the labelmap overlay can be matched to the
-    // correct source slice. We also register generalSeriesModule (for modality)
-    // which Cornerstone's buildMetadata() requires.
-    const labelmapImageIds: string[] = [];
-    const pixelCount = rows * columns;
-
-    // Grab generalSeriesModule from any source image (same for all slices in a series)
-    let refGeneralSeriesMeta: any = null;
-    for (const srcId of sourceImageIds) {
-      refGeneralSeriesMeta = metaData.get('generalSeriesModule', srcId);
-      if (refGeneralSeriesMeta) break;
-    }
-
-    const genericMeta = (csUtilities as any).genericMetadataProvider;
-
-    for (let i = 0; i < sourceImageIds.length; i++) {
-      const labelmapImageId = `generated:labelmap_${segmentationId}_${i}`;
-      const srcImageId = sourceImageIds[i];
-
-      // Get per-slice spatial metadata from the source image.
-      const imagePlane = metaData.get('imagePlaneModule', srcImageId);
-
-      imageLoader.createAndCacheLocalImage(labelmapImageId, {
-        scalarData: new Uint8Array(pixelCount),
-        dimensions: [columns, rows],
-        spacing: [columnPixelSpacing, rowPixelSpacing],
-        origin: imagePlane?.imagePositionPatient,
-        direction: imagePlane?.imageOrientationPatient,
-        frameOfReferenceUID: imagePlane?.frameOfReferenceUID,
-        referencedImageId: srcImageId,
-      } as any);
-
-      // Register generalSeriesModule metadata for the labelmap image.
-      // Cornerstone's buildMetadata() destructures { modality } from this
-      // module and crashes if it's missing when adding the overlay.
-      if (refGeneralSeriesMeta) {
-        genericMeta.add(labelmapImageId, {
-          type: 'generalSeriesModule',
-          metadata: refGeneralSeriesMeta,
-        });
-      }
-
-      labelmapImageIds.push(labelmapImageId);
-    }
-
-    // Step 4: Register the segmentation with Cornerstone's state,
-    // providing the labelmap imageIds so the state manager can map them.
-    csSegmentation.addSegmentations([
-      {
-        segmentationId,
-        representation: {
-          type: ToolEnums.SegmentationRepresentations.Labelmap,
-          data: {
-            imageIds: labelmapImageIds,
-          } as any,
-        },
-        config: {
-          label: segLabel,
-          segments: createDefaultSegment
-            ? {
-                1: {
-                  label: 'Segment 1',
-                  segmentIndex: 1,
-                  locked: false,
-                  active: true,
-                  cachedStats: {},
-                } as any,
-              }
-            : {},
-        },
-      },
-    ]);
-
-    if (!createDefaultSegment) {
-      // Cornerstone can materialize a default segment even when config.segments
-      // is empty. Force a clean, zero-entry starting state for manual authoring.
-      try {
-        csSegmentation.updateSegmentations([
-          {
-            segmentationId,
-            config: { segments: {} },
-          },
-        ] as any);
-      } catch {
-        const created = csSegmentation.state.getSegmentation(segmentationId);
-        if (created) {
-          (created as any).segments = {};
-        }
-      }
-    }
-
-    // Store: set active segmentation and segment index.
-    const store = useSegmentationStore.getState();
-    store.setActiveSegmentation(segmentationId);
-    if (createDefaultSegment) {
-      store.setActiveSegmentIndex(1);
-      // Set the active segment index in Cornerstone
-      csSegmentation.segmentIndex.setActiveSegmentIndex(segmentationId, 1);
-    } else {
-      store.setActiveSegmentIndex(0);
-    }
+    // Step 3: Initialize the multi-layer group (no labelmap images yet —
+    // those are created per-segment in addSegment()).
+    subSegGroupMap.set(segmentationId, []);
+    segmentMetaMap.set(segmentationId, new Map());
+    groupDimensionsMap.set(segmentationId, {
+      rows,
+      columns,
+      rowPixelSpacing,
+      columnPixelSpacing,
+      sourceImageIds: [...sourceImageIds],
+    });
+    groupLabelMap.set(segmentationId, segLabel);
 
     // Track source imageIds for DICOM SEG export
     sourceImageIdsMap.set(segmentationId, [...sourceImageIds]);
 
-    console.log(`[segmentationService] Created stack segmentation: ${segmentationId} (${labelmapImageIds.length} labelmap images, ${columns}×${rows})`);
+    // Store: set active segmentation.
+    const store = useSegmentationStore.getState();
+    store.setActiveSegmentation(segmentationId);
+
+    // Step 4: If requested, create the first segment (which creates the
+    // first sub-segmentation with its own labelmap images).
+    if (createDefaultSegment) {
+      this.addSegment(segmentationId, 'Segment 1');
+      store.setActiveSegmentIndex(1);
+    } else {
+      store.setActiveSegmentIndex(0);
+    }
+
+    console.log(`[segmentationService] Created multi-layer segmentation group: ${segmentationId} (${sourceImageIds.length} source slices, ${columns}×${rows})`);
 
     syncSegmentations();
     return segmentationId;
@@ -1270,6 +1488,16 @@ export const segmentationService = {
    */
   ensureEmptySegmentation(segmentationId: string): void {
     try {
+      // Multi-layer group: check sub-seg count instead of Cornerstone state
+      if (isMultiLayerGroup(segmentationId)) {
+        const subSegs = getActiveSubSegIds(segmentationId);
+        if (subSegs.length === 0) {
+          useSegmentationStore.getState().setActiveSegmentIndex(0);
+        }
+        syncSegmentations();
+        return;
+      }
+
       const seg = csSegmentation.state.getSegmentation(segmentationId);
       if (!seg) return;
 
@@ -1318,6 +1546,8 @@ export const segmentationService = {
 
   /**
    * Add a new segment to an existing segmentation.
+   * Creates an independent sub-segmentation with its own binary labelmap
+   * images so segments can overlap.
    * Returns the new segment index (1-based).
    */
   addSegment(
@@ -1325,74 +1555,110 @@ export const segmentationService = {
     label: string,
     color?: [number, number, number, number],
   ): number {
-    const seg = csSegmentation.state.getSegmentation(segmentationId);
-    if (!seg) {
-      throw new Error(`[segmentationService] Segmentation not found: ${segmentationId}`);
+    if (!isMultiLayerGroup(segmentationId)) {
+      throw new Error(`[segmentationService] Not a multi-layer group: ${segmentationId}`);
     }
 
-    // Find next available segment index (supports object or Map storage).
-    const existingIndices = getValidSegmentIndices(seg);
-    const nextIndex = existingIndices.length > 0 ? Math.max(...existingIndices) + 1 : 1;
+    const dims = groupDimensionsMap.get(segmentationId);
+    if (!dims) {
+      throw new Error(`[segmentationService] No dimensions stored for group: ${segmentationId}`);
+    }
+
+    // Determine next segment index from existing sub-segs.
+    const subSegIds = subSegGroupMap.get(segmentationId)!;
+    const nextIndex = subSegIds.length + 1;
     const segmentLabel = label.trim() || `Segment ${nextIndex}`;
-
-    // Contour representation needs an annotationUID set per segment index.
-    const contourData = (seg.representationData as any)?.Contour;
-    if (contourData?.annotationUIDsMap instanceof Map && !contourData.annotationUIDsMap.has(nextIndex)) {
-      contourData.annotationUIDsMap.set(nextIndex, new Set<string>());
-    }
-
-    const nextSegments = segmentsToPlainObject(seg.segments);
-    nextSegments[nextIndex] = {
-      ...(nextSegments[nextIndex] ?? {}),
-      label: segmentLabel,
-      SegmentLabel: segmentLabel,
-      locked: false,
-      active: false,
-      segmentIndex: nextIndex,
-      cachedStats: (nextSegments[nextIndex] as any)?.cachedStats ?? {},
-    } as any;
-
-    // Update segmentation state with new segment
-    csSegmentation.updateSegmentations([
-      {
-        segmentationId,
-        config: {
-          segments: nextSegments,
-        },
-      },
-    ] as any);
-
-    // Force the final label on live state as a compatibility fallback.
-    const live = csSegmentation.state.getSegmentation(segmentationId);
-    if (live?.segments instanceof Map) {
-      const entry = live.segments.get(nextIndex) ?? { segmentIndex: nextIndex, locked: false, active: false, cachedStats: {} };
-      entry.label = segmentLabel;
-      entry.SegmentLabel = segmentLabel;
-      live.segments.set(nextIndex, entry);
-    } else if (live?.segments) {
-      const entry = (live.segments as any)[nextIndex] ?? { segmentIndex: nextIndex, locked: false, active: false, cachedStats: {} };
-      entry.label = segmentLabel;
-      entry.SegmentLabel = segmentLabel;
-      (live.segments as any)[nextIndex] = entry;
-    }
-
-    // Set color on all viewports that have this segmentation
     const segColor = color || DEFAULT_COLORS[(nextIndex - 1) % DEFAULT_COLORS.length];
-    const viewportIds = csSegmentation.state.getViewportIdsWithSegmentation(segmentationId);
-    for (const vpId of viewportIds) {
+
+    // Create the sub-segmentation ID and its labelmap images.
+    const subSegId = `${segmentationId}_layer_${nextIndex}`;
+    const labelmapImageIds: string[] = [];
+    const pixelCount = dims.rows * dims.columns;
+    const genericMeta = (csUtilities as any).genericMetadataProvider;
+
+    // Grab generalSeriesModule from any source image.
+    let refGeneralSeriesMeta: any = null;
+    for (const srcId of dims.sourceImageIds) {
+      refGeneralSeriesMeta = metaData.get('generalSeriesModule', srcId);
+      if (refGeneralSeriesMeta) break;
+    }
+
+    for (let i = 0; i < dims.sourceImageIds.length; i++) {
+      const labelmapImageId = `generated:labelmap_${subSegId}_${i}`;
+      const srcImageId = dims.sourceImageIds[i];
+      const imagePlane = metaData.get('imagePlaneModule', srcImageId);
+
+      imageLoader.createAndCacheLocalImage(labelmapImageId, {
+        scalarData: new Uint8Array(pixelCount),
+        dimensions: [dims.columns, dims.rows],
+        spacing: [dims.columnPixelSpacing, dims.rowPixelSpacing],
+        origin: imagePlane?.imagePositionPatient,
+        direction: imagePlane?.imageOrientationPatient,
+        frameOfReferenceUID: imagePlane?.frameOfReferenceUID,
+        referencedImageId: srcImageId,
+      } as any);
+
+      if (refGeneralSeriesMeta) {
+        genericMeta.add(labelmapImageId, {
+          type: 'generalSeriesModule',
+          metadata: refGeneralSeriesMeta,
+        });
+      }
+
+      labelmapImageIds.push(labelmapImageId);
+    }
+
+    // Register as an independent Cornerstone segmentation (segment index 1).
+    suppressDirtyTrackingCount++;
+    try {
+      csSegmentation.addSegmentations([
+        {
+          segmentationId: subSegId,
+          representation: {
+            type: ToolEnums.SegmentationRepresentations.Labelmap,
+            data: { imageIds: labelmapImageIds } as any,
+          },
+          config: {
+            label: segmentLabel,
+            segments: {
+              1: {
+                label: segmentLabel,
+                segmentIndex: 1,
+                locked: false,
+                active: true,
+                cachedStats: {},
+              } as any,
+            },
+          },
+        },
+      ]);
+    } finally {
+      suppressDirtyTrackingCount--;
+    }
+
+    // Track source imageIds on the sub-seg (for export resolution).
+    sourceImageIdsMap.set(subSegId, [...dims.sourceImageIds]);
+
+    // Update group registry.
+    subSegIds.push(subSegId);
+    subSegToGroupMap.set(subSegId, { groupId: segmentationId, segmentIndex: nextIndex });
+    segmentMetaMap.get(segmentationId)!.set(nextIndex, {
+      label: segmentLabel,
+      color: segColor,
+      locked: false,
+    });
+
+    // If the group is already attached to viewports, add the new sub-seg too.
+    const attachedViewportIds = findViewportsWithGroup(segmentationId);
+    for (const vpId of attachedViewportIds) {
       try {
-        csSegmentation.config.color.setSegmentIndexColor(
-          vpId,
-          segmentationId,
-          nextIndex,
-          segColor as any,
-        );
-      } catch {
-        // Color may not be settable if representation not fully loaded
+        addSubSegToViewport(vpId, subSegId, segColor);
+      } catch (err) {
+        console.warn(`[segmentationService] Failed to attach sub-seg ${subSegId} to viewport ${vpId}:`, err);
       }
     }
 
-    console.log(`[segmentationService] Added segment ${nextIndex} to ${segmentationId}: "${segmentLabel}"`);
+    console.log(`[segmentationService] Added segment ${nextIndex} (${subSegId}) to group ${segmentationId}: "${segmentLabel}"`);
 
     syncSegmentations();
     return nextIndex;
@@ -1402,6 +1668,54 @@ export const segmentationService = {
    * Remove a segment from a segmentation.
    */
   removeSegment(segmentationId: string, segmentIndex: number): void {
+    // ─── Multi-layer group path ─────────────────────────────
+    if (isMultiLayerGroup(segmentationId)) {
+      const subSegId = resolveSubSegId(segmentationId, segmentIndex);
+      if (!subSegId) {
+        console.warn(`[segmentationService] No sub-seg for group ${segmentationId} index ${segmentIndex}`);
+        syncSegmentations();
+        return;
+      }
+      try {
+        // Remove from all viewports
+        const vpIds = csSegmentation.state.getViewportIdsWithSegmentation(subSegId);
+        for (const vpId of vpIds) {
+          try { csSegmentation.removeLabelmapRepresentation(vpId, subSegId); } catch { /* ok */ }
+        }
+        // Remove from Cornerstone state
+        csSegmentation.removeSegmentation(subSegId);
+      } catch (err) {
+        console.error('[segmentationService] Failed to remove sub-seg:', err);
+      }
+      // Clean up maps
+      subSegToGroupMap.delete(subSegId);
+      sourceImageIdsMap.delete(subSegId);
+      const groupArr = subSegGroupMap.get(segmentationId);
+      if (groupArr) {
+        groupArr[segmentIndex - 1] = null; // null-out the slot
+      }
+      segmentMetaMap.get(segmentationId)?.delete(segmentIndex);
+
+      // If all sub-segs are removed, clean up the entire group
+      const remaining = getActiveSubSegIds(segmentationId);
+      if (remaining.length === 0) {
+        subSegGroupMap.delete(segmentationId);
+        segmentMetaMap.delete(segmentationId);
+        groupDimensionsMap.delete(segmentationId);
+        groupLabelMap.delete(segmentationId);
+        sourceImageIdsMap.delete(segmentationId);
+        const store = useSegmentationStore.getState();
+        if (store.activeSegmentationId === segmentationId) {
+          store.setActiveSegmentation(null);
+        }
+        store.clearXnatOrigin(segmentationId);
+      }
+      console.log(`[segmentationService] Removed segment ${segmentIndex} (sub-seg: ${subSegId}) from group ${segmentationId}`);
+      syncSegmentations();
+      return;
+    }
+
+    // ─── Legacy path ────────────────────────────────────────
     try {
       csSegmentation.removeSegment(segmentationId, segmentIndex);
       console.log(`[segmentationService] Removed segment ${segmentIndex} from ${segmentationId}`);
@@ -1486,8 +1800,45 @@ export const segmentationService = {
    * Remove an entire segmentation from Cornerstone state.
    */
   removeSegmentation(segmentationId: string): void {
+    // ─── Multi-layer group path ─────────────────────────────
+    if (isMultiLayerGroup(segmentationId)) {
+      try {
+        const allSubSegIds = getActiveSubSegIds(segmentationId);
+        for (const subSegId of allSubSegIds) {
+          // Remove from all viewports
+          const vpIds = csSegmentation.state.getViewportIdsWithSegmentation(subSegId);
+          for (const vpId of vpIds) {
+            try { csSegmentation.removeLabelmapRepresentation(vpId, subSegId); } catch { /* ok */ }
+          }
+          // Remove from Cornerstone state
+          try { csSegmentation.removeSegmentation(subSegId); } catch { /* ok */ }
+          subSegToGroupMap.delete(subSegId);
+          sourceImageIdsMap.delete(subSegId);
+        }
+        // Clean up group maps
+        subSegGroupMap.delete(segmentationId);
+        segmentMetaMap.delete(segmentationId);
+        groupDimensionsMap.delete(segmentationId);
+        groupLabelMap.delete(segmentationId);
+        sourceImageIdsMap.delete(segmentationId);
+        loadedColorsMap.delete(segmentationId);
+
+        const store = useSegmentationStore.getState();
+        if (store.activeSegmentationId === segmentationId) {
+          store.setActiveSegmentation(null);
+        }
+        store.clearXnatOrigin(segmentationId);
+
+        console.log(`[segmentationService] Removed group segmentation: ${segmentationId} (${allSubSegIds.length} sub-segs)`);
+      } catch (err) {
+        console.error('[segmentationService] Failed to remove group segmentation:', err);
+      }
+      syncSegmentations();
+      return;
+    }
+
+    // ─── Legacy path ────────────────────────────────────────
     try {
-      // Remove representations from all viewports first (both Labelmap and Contour)
       const viewportIds = csSegmentation.state.getViewportIdsWithSegmentation(segmentationId);
       for (const vpId of viewportIds) {
         try {
@@ -1502,20 +1853,14 @@ export const segmentationService = {
         }
       }
 
-      // Remove the segmentation itself
       csSegmentation.removeSegmentation(segmentationId);
-
-      // Clean up source imageId tracking and loaded colors
       sourceImageIdsMap.delete(segmentationId);
       loadedColorsMap.delete(segmentationId);
 
-      // Update store
       const store = useSegmentationStore.getState();
       if (store.activeSegmentationId === segmentationId) {
         store.setActiveSegmentation(null);
       }
-
-      // Clean up XNAT origin tracking (prevents stale duplicate detection)
       store.clearXnatOrigin(segmentationId);
 
       console.log(`[segmentationService] Removed segmentation: ${segmentationId}`);
@@ -1527,156 +1872,167 @@ export const segmentationService = {
 
   /**
    * Display a segmentation on a viewport as a labelmap overlay.
-   * Creates the representation and sets it as active.
+   * For multi-layer groups, attaches all sub-segmentations as independent actors.
    */
   async addToViewport(viewportId: string, segmentationId: string): Promise<void> {
-    // Suppress dirty tracking during load — Cornerstone fires SEGMENTATION_DATA_MODIFIED
-    // internally when adding representations, which would falsely mark state as dirty.
     setDirtyTrackingSuppressedFor(400);
     suppressDirtyTrackingCount++;
     try {
-    // NOTE: No polling loop here. The caller MUST ensure the viewport is ready
-    // before calling addToViewport (e.g., by awaiting viewportReadyService.whenReady).
-    // If the viewport doesn't exist, we throw instead of silently retrying.
+    // Verify viewport exists.
     try {
       const enabledEl = getEnabledElementByViewportId(viewportId);
       if (!enabledEl?.viewport) {
         throw new Error(`Viewport ${viewportId} does not exist`);
       }
     } catch (err) {
-      console.error(`[segmentationService] Viewport ${viewportId} not ready — caller must await viewportReadyService.whenReady() first. Error:`, err);
+      console.error(`[segmentationService] Viewport ${viewportId} not ready:`, err);
       throw err;
     }
 
-    // Step 1: Add labelmap representation (core requirement for brush tools)
-    try {
-      csSegmentation.addLabelmapRepresentationToViewport(viewportId, [
-        {
-          segmentationId,
-        },
-      ]);
-    } catch (err) {
-      console.error('[segmentationService] Failed to add labelmap to viewport:', err);
-      syncSegmentations();
-      return; // Can't continue without labelmap
-    }
-
-    // v4.16+ requires both _stackLabelmapImageIdReferenceMap and
-    // _labelmapImageIdReferenceMap to be populated for every source→labelmap
-    // pair. The built-in Cornerstone methods are broken for stack viewports:
-    // - updateLabelmapSegmentationImageReferences: only maps current slice
-    // - _updateAllLabelmapSegmentationImageReferences: maps ALL source slices
-    //   to the SAME labelmap (matchImagesForOverlay always compares against
-    //   the current viewport position, not the iterated source position)
-    //
-    // Fix: directly populate both internal maps using the authoritative
-    // referencedImageId property on each labelmap image. This is O(N) and
-    // produces the correct 1:1 source↔labelmap mapping.
-    try {
-      const seg = csSegmentation.state.getSegmentation(segmentationId);
-      const lmImageIds: string[] = (seg?.representationData?.Labelmap as any)?.imageIds ?? [];
-      // Access the singleton SegmentationStateManager instance
-      const mgr = csSegmentation.defaultSegmentationStateManager as any;
-      if (!mgr._stackLabelmapImageIdReferenceMap.has(segmentationId)) {
-        mgr._stackLabelmapImageIdReferenceMap.set(segmentationId, new Map());
-      }
-      const perSegMap = mgr._stackLabelmapImageIdReferenceMap.get(segmentationId);
-      for (const lmId of lmImageIds) {
-        const lmImg = cache.getImage(lmId);
-        const refId = (lmImg as any)?.referencedImageId;
-        if (!refId) continue;
-        // _stackLabelmapImageIdReferenceMap: srcImageId → labelmapImageId
-        perSegMap.set(refId, lmId);
-        // _labelmapImageIdReferenceMap: "${segId}-${srcImageId}" → [labelmapImageId]
-        const mapKey = `${segmentationId}-${refId}`;
-        const existing = mgr._labelmapImageIdReferenceMap.get(mapKey);
-        if (!existing) {
-          mgr._labelmapImageIdReferenceMap.set(mapKey, [lmId]);
-        } else if (!existing.includes(lmId)) {
-          mgr._labelmapImageIdReferenceMap.set(mapKey, [...existing, lmId]);
-        }
-      }
-    } catch (err) {
-      console.warn('[segmentationService] Failed to populate labelmap reference maps:', err);
-    }
-
-    // Step 2: Set as active segmentation + apply styles (must succeed for brush to work)
-    try {
-      csSegmentation.activeSegmentation.setActiveSegmentation(viewportId, segmentationId);
-    } catch (err) {
-      console.error('[segmentationService] Failed to set active segmentation:', err);
-    }
-
-    // Apply current style settings
-    try {
+    if (isMultiLayerGroup(segmentationId)) {
+      // ─── Multi-layer path: attach each sub-seg as an independent actor ───
+      const subSegIds = getActiveSubSegIds(segmentationId);
+      const metaMap = segmentMetaMap.get(segmentationId);
       const store = useSegmentationStore.getState();
-      this.updateStyle(store.fillAlpha, store.renderOutline);
-    } catch (err) {
-      console.error('[segmentationService] Failed to update style:', err);
-    }
+      const activeSegIdx = store.activeSegmentIndex;
 
-    // Ensure a valid color exists for each segment on this viewport.
-    // Without this, Cornerstone can throw LUT-index errors during cursor/overlay render.
-    try {
-      const segObj = csSegmentation.state.getSegmentation(segmentationId);
-      for (const idx of getValidSegmentIndices(segObj)) {
-        let hasColor = false;
+      for (const subSegId of subSegIds) {
+        const info = subSegToGroupMap.get(subSegId);
+        if (!info) continue;
+        const meta = metaMap?.get(info.segmentIndex);
+        const segColor = meta?.color ?? DEFAULT_COLORS[(info.segmentIndex - 1) % DEFAULT_COLORS.length];
+
         try {
-          const c = csSegmentation.config.color.getSegmentIndexColor(viewportId, segmentationId, idx);
-          hasColor = hasUsableColor(c);
-        } catch {
-          hasColor = false;
-        }
-        if (!hasColor) {
-          const fallback = DEFAULT_COLORS[(idx - 1) % DEFAULT_COLORS.length];
-          csSegmentation.config.color.setSegmentIndexColor(
-            viewportId,
-            segmentationId,
-            idx,
-            fallback as any,
-          );
+          addSubSegToViewport(viewportId, subSegId, segColor);
+        } catch (err) {
+          console.error(`[segmentationService] Failed to add sub-seg ${subSegId} to viewport:`, err);
         }
       }
-    } catch (err) {
-      console.debug('[segmentationService] Failed to ensure segment colors:', err);
-    }
 
-    // Apply ONLY loaded DICOM colors (from RecommendedDisplayRGBValue) — do NOT
-    // stamp default palette colors over user-selected colors. Default colors are
-    // assigned at creation time (createStackSegmentation / addSegment) and should
-    // not be re-applied on every attach. This preserves user color choices across
-    // scan switching and viewport recreation.
-    const loadedColors = loadedColorsMap.get(segmentationId);
-    if (loadedColors && loadedColors.size > 0) {
-      let allColorsApplied = true;
-      for (const [idx, color] of loadedColors.entries()) {
+      // Set the active sub-seg to the one matching the active segment index.
+      const activeSubSegId = resolveSubSegId(segmentationId, activeSegIdx);
+      if (activeSubSegId) {
         try {
-          csSegmentation.config.color.setSegmentIndexColor(
-            viewportId,
-            segmentationId,
-            idx,
-            color as any,
-          );
-        } catch {
-          allColorsApplied = false;
+          csSegmentation.activeSegmentation.setActiveSegmentation(viewportId, activeSubSegId);
+          csSegmentation.segmentIndex.setActiveSegmentIndex(activeSubSegId, 1);
+        } catch (err) {
+          console.debug('[segmentationService] Failed to set active sub-seg:', err);
         }
       }
-      // Only clear loaded colors if ALL were successfully applied
-      if (allColorsApplied) loadedColorsMap.delete(segmentationId);
+
+      // Apply current style settings.
+      try {
+        this.updateStyle(store.fillAlpha, store.renderOutline);
+      } catch (err) {
+        console.error('[segmentationService] Failed to update style:', err);
+      }
+
+      // Trigger render.
+      try {
+        csToolUtilities.segmentation.triggerSegmentationRender(viewportId);
+        const enabledEl = getEnabledElementByViewportId(viewportId);
+        const vp = enabledEl?.viewport as any;
+        vp?.render?.();
+        requestAnimationFrame(() => vp?.render?.());
+      } catch (err) {
+        console.error('[segmentationService] triggerSegmentationRender failed:', err);
+      }
+
+      console.log(`[segmentationService] Added multi-layer group to viewport ${viewportId}: ${segmentationId} (${subSegIds.length} layers)`);
+    } else {
+      // ─── Legacy single-segmentation path ───
+      try {
+        csSegmentation.addLabelmapRepresentationToViewport(viewportId, [
+          { segmentationId },
+        ]);
+      } catch (err) {
+        console.error('[segmentationService] Failed to add labelmap to viewport:', err);
+        syncSegmentations();
+        return;
+      }
+
+      // Populate reference maps.
+      try {
+        const seg = csSegmentation.state.getSegmentation(segmentationId);
+        const lmImageIds: string[] = (seg?.representationData?.Labelmap as any)?.imageIds ?? [];
+        const mgr = csSegmentation.defaultSegmentationStateManager as any;
+        if (!mgr._stackLabelmapImageIdReferenceMap.has(segmentationId)) {
+          mgr._stackLabelmapImageIdReferenceMap.set(segmentationId, new Map());
+        }
+        const perSegMap = mgr._stackLabelmapImageIdReferenceMap.get(segmentationId);
+        for (const lmId of lmImageIds) {
+          const lmImg = cache.getImage(lmId);
+          const refId = (lmImg as any)?.referencedImageId;
+          if (!refId) continue;
+          perSegMap.set(refId, lmId);
+          const mapKey = `${segmentationId}-${refId}`;
+          const existing = mgr._labelmapImageIdReferenceMap.get(mapKey);
+          if (!existing) {
+            mgr._labelmapImageIdReferenceMap.set(mapKey, [lmId]);
+          } else if (!existing.includes(lmId)) {
+            mgr._labelmapImageIdReferenceMap.set(mapKey, [...existing, lmId]);
+          }
+        }
+      } catch (err) {
+        console.warn('[segmentationService] Failed to populate labelmap reference maps:', err);
+      }
+
+      try {
+        csSegmentation.activeSegmentation.setActiveSegmentation(viewportId, segmentationId);
+      } catch (err) {
+        console.error('[segmentationService] Failed to set active segmentation:', err);
+      }
+
+      try {
+        const store = useSegmentationStore.getState();
+        this.updateStyle(store.fillAlpha, store.renderOutline);
+      } catch (err) {
+        console.error('[segmentationService] Failed to update style:', err);
+      }
+
+      // Ensure colors.
+      try {
+        const segObj = csSegmentation.state.getSegmentation(segmentationId);
+        for (const idx of getValidSegmentIndices(segObj)) {
+          let hasColor = false;
+          try {
+            const c = csSegmentation.config.color.getSegmentIndexColor(viewportId, segmentationId, idx);
+            hasColor = hasUsableColor(c);
+          } catch { hasColor = false; }
+          if (!hasColor) {
+            const fallback = DEFAULT_COLORS[(idx - 1) % DEFAULT_COLORS.length];
+            csSegmentation.config.color.setSegmentIndexColor(viewportId, segmentationId, idx, fallback as any);
+          }
+        }
+      } catch (err) {
+        console.debug('[segmentationService] Failed to ensure segment colors:', err);
+      }
+
+      // Apply loaded DICOM colors.
+      const loadedColors = loadedColorsMap.get(segmentationId);
+      if (loadedColors && loadedColors.size > 0) {
+        let allColorsApplied = true;
+        for (const [idx, color] of loadedColors.entries()) {
+          try {
+            csSegmentation.config.color.setSegmentIndexColor(viewportId, segmentationId, idx, color as any);
+          } catch { allColorsApplied = false; }
+        }
+        if (allColorsApplied) loadedColorsMap.delete(segmentationId);
+      }
+
+      try {
+        csToolUtilities.segmentation.triggerSegmentationRender(viewportId);
+        const enabledEl = getEnabledElementByViewportId(viewportId);
+        const vp = enabledEl?.viewport as any;
+        vp?.render?.();
+        requestAnimationFrame(() => vp?.render?.());
+      } catch (err) {
+        console.error('[segmentationService] triggerSegmentationRender failed:', err);
+      }
+
+      console.log(`[segmentationService] Added to viewport ${viewportId}: ${segmentationId}`);
     }
 
-    // Step 3: Trigger segmentation render to ensure overlay is visible.
-    try {
-      csToolUtilities.segmentation.triggerSegmentationRender(viewportId);
-      const enabledEl = getEnabledElementByViewportId(viewportId);
-      const vp = enabledEl?.viewport as any;
-      vp?.render?.();
-      requestAnimationFrame(() => vp?.render?.());
-    } catch (err) {
-      console.error('[segmentationService] triggerSegmentationRender failed:', err);
-    }
-
-    console.log(`[segmentationService] Added to viewport ${viewportId}: ${segmentationId}`);
     syncSegmentations();
     } finally {
       suppressDirtyTrackingCount--;
@@ -1740,8 +2096,31 @@ export const segmentationService = {
    * Also ensures the contour representation exists so contour tools keep working.
    */
   activateOnViewport(viewportId: string, segmentationId: string): void {
-    // First check if this segmentation actually has a representation on this viewport.
-    // If not (e.g., it was cleaned up when switching scans), skip activation.
+    // ─── Multi-layer group path ─────────────────────────────
+    if (isMultiLayerGroup(segmentationId)) {
+      // Check if any sub-seg is on this viewport
+      const subSegIds = getActiveSubSegIds(segmentationId);
+      const hasAny = subSegIds.some((id) =>
+        csSegmentation.state.getViewportIdsWithSegmentation(id).includes(viewportId),
+      );
+      if (!hasAny) {
+        console.debug(`[segmentationService] Group ${segmentationId} not on viewport ${viewportId}, skipping activation`);
+        return;
+      }
+      // Activate the sub-seg matching the current active segment index
+      const activeIdx = useSegmentationStore.getState().activeSegmentIndex;
+      const activeSubSegId = resolveSubSegId(segmentationId, activeIdx) ?? subSegIds[0];
+      if (activeSubSegId) {
+        try {
+          csSegmentation.activeSegmentation.setActiveSegmentation(viewportId, activeSubSegId);
+        } catch (err) {
+          console.debug('[segmentationService] activateOnViewport setActive (group):', err);
+        }
+      }
+      return;
+    }
+
+    // ─── Legacy path ────────────────────────────────────────
     const viewportIds = csSegmentation.state.getViewportIdsWithSegmentation(segmentationId);
     if (!viewportIds.includes(viewportId)) {
       console.debug(`[segmentationService] Segmentation ${segmentationId} not on viewport ${viewportId}, skipping activation`);
@@ -1766,6 +2145,54 @@ export const segmentationService = {
       console.warn(`[segmentationService] Invalid active segment index ${segmentIndex}; using 1`);
       segmentIndex = 1;
     }
+
+    // ─── Multi-layer group path ────────────────────────────────
+    if (isMultiLayerGroup(segmentationId)) {
+      const subSegId = resolveSubSegId(segmentationId, segmentIndex);
+      if (!subSegId) {
+        console.warn(`[segmentationService] No sub-seg for group ${segmentationId} index ${segmentIndex}`);
+        return;
+      }
+
+      // Get the color for this segment from metadata
+      const meta = segmentMetaMap.get(segmentationId)?.get(segmentIndex);
+      const segColor = meta?.color ?? DEFAULT_COLORS[(segmentIndex - 1) % DEFAULT_COLORS.length];
+
+      // Switch the active Cornerstone segmentation to this sub-seg on all viewports
+      const vpIds = findViewportsWithGroup(segmentationId);
+      for (const vpId of vpIds) {
+        try {
+          csSegmentation.activeSegmentation.setActiveSegmentation(vpId, subSegId);
+        } catch {
+          // viewport may be detached
+        }
+        // Ensure color on segment index 1 of the sub-seg
+        try {
+          csSegmentation.config.color.setSegmentIndexColor(vpId, subSegId, 1, segColor as any);
+        } catch {
+          // ignore
+        }
+      }
+
+      this.runWithDirtyTrackingSuppressed(() => {
+        // Within the sub-seg, the brush always paints segment index 1
+        csSegmentation.segmentIndex.setActiveSegmentIndex(subSegId, 1);
+        useSegmentationStore.getState().setActiveSegmentIndex(segmentIndex);
+      });
+
+      // Force render to reflect the active segment change visually
+      for (const vpId of vpIds) {
+        try {
+          csToolUtilities.segmentation.triggerSegmentationRender(vpId);
+          getEnabledElementByViewportId(vpId)?.viewport?.render();
+        } catch { /* ignore detached viewports */ }
+      }
+
+      console.log(`[segmentationService] Active segment: ${segmentIndex} (sub-seg: ${subSegId})`);
+      return;
+    }
+
+    // ─── Legacy (non-group) path ───────────────────────────────
     const fallbackColor = (() => {
       const summary = useSegmentationStore
         .getState()
@@ -1809,6 +2236,15 @@ export const segmentationService = {
       csSegmentation.segmentIndex.setActiveSegmentIndex(segmentationId, segmentIndex);
       useSegmentationStore.getState().setActiveSegmentIndex(segmentIndex);
     });
+
+    // Force render to reflect the active segment change visually
+    for (const vpId of viewportIds) {
+      try {
+        csToolUtilities.segmentation.triggerSegmentationRender(vpId);
+        getEnabledElementByViewportId(vpId)?.viewport?.render();
+      } catch { /* ignore detached viewports */ }
+    }
+
     console.log(`[segmentationService] Active segment: ${segmentIndex}`);
   },
 
@@ -1821,6 +2257,38 @@ export const segmentationService = {
     color: [number, number, number, number],
   ): void {
     if (!Number.isFinite(segmentIndex) || segmentIndex <= 0 || !Number.isInteger(segmentIndex)) return;
+
+    // ─── Multi-layer group path ─────────────────────────────
+    if (isMultiLayerGroup(segmentationId)) {
+      const subSegId = resolveSubSegId(segmentationId, segmentIndex);
+      if (!subSegId) return;
+      // Update metadata
+      const metaMap = segmentMetaMap.get(segmentationId);
+      if (metaMap) {
+        const existing = metaMap.get(segmentIndex);
+        if (existing) existing.color = color;
+      }
+      // Set color on the sub-seg's segment index 1
+      const vpIds = csSegmentation.state.getViewportIdsWithSegmentation(subSegId);
+      for (const vpId of vpIds) {
+        try {
+          csSegmentation.config.color.setSegmentIndexColor(vpId, subSegId, 1, color as any);
+        } catch {
+          // ignore
+        }
+      }
+      // Force render to reflect color change
+      for (const vpId of vpIds) {
+        try {
+          csToolUtilities.segmentation.triggerSegmentationRender(vpId);
+          getEnabledElementByViewportId(vpId)?.viewport?.render();
+        } catch { /* ignore */ }
+      }
+      syncSegmentations();
+      return;
+    }
+
+    // ─── Legacy path ────────────────────────────────────────
     const viewportIds = csSegmentation.state.getViewportIdsWithSegmentation(segmentationId);
     for (const vpId of viewportIds) {
       try {
@@ -1834,6 +2302,13 @@ export const segmentationService = {
         // ignore
       }
     }
+    // Force render to reflect color change
+    for (const vpId of viewportIds) {
+      try {
+        csToolUtilities.segmentation.triggerSegmentationRender(vpId);
+        getEnabledElementByViewportId(vpId)?.viewport?.render();
+      } catch { /* ignore */ }
+    }
     syncSegmentations();
   },
 
@@ -1841,6 +2316,11 @@ export const segmentationService = {
    * Rename a segmentation (the top-level label).
    */
   renameSegmentation(segmentationId: string, newLabel: string): void {
+    if (isMultiLayerGroup(segmentationId)) {
+      groupLabelMap.set(segmentationId, newLabel);
+      syncSegmentations();
+      return;
+    }
     const seg = csSegmentation.state.getSegmentation(segmentationId);
     if (!seg) return;
     seg.label = newLabel;
@@ -1851,6 +2331,13 @@ export const segmentationService = {
    * Rename an individual segment within a segmentation.
    */
   renameSegment(segmentationId: string, segmentIndex: number, newLabel: string): void {
+    if (isMultiLayerGroup(segmentationId)) {
+      const metaMap = segmentMetaMap.get(segmentationId);
+      const meta = metaMap?.get(segmentIndex);
+      if (meta) meta.label = newLabel;
+      syncSegmentations();
+      return;
+    }
     const seg = csSegmentation.state.getSegmentation(segmentationId);
     if (!seg?.segments) return;
     if (seg.segments instanceof Map) {
@@ -1877,10 +2364,52 @@ export const segmentationService = {
     segmentationId: string,
     segmentIndex: number,
   ): void {
-    // Toggle visibility for both Labelmap and Contour representations
-    let currentVisible = true;
+    // ─── Multi-layer group path ─────────────────────────────
+    if (isMultiLayerGroup(segmentationId)) {
+      const subSegId = resolveSubSegId(segmentationId, segmentIndex);
+      if (!subSegId) return;
+      // Read current visibility from sub-seg's segment index 1
+      let currentVisible = true;
+      const vpIds = csSegmentation.state.getViewportIdsWithSegmentation(subSegId);
+      if (vpIds.length > 0) {
+        try {
+          currentVisible = csSegmentation.config.visibility.getSegmentIndexVisibility(
+            vpIds[0],
+            { segmentationId: subSegId, type: ToolEnums.SegmentationRepresentations.Labelmap },
+            1,
+          );
+        } catch {
+          // default visible
+        }
+      }
+      const newVisible = !currentVisible;
+      for (const vpId of vpIds) {
+        try {
+          csSegmentation.config.visibility.setSegmentIndexVisibility(
+            vpId,
+            { segmentationId: subSegId, type: ToolEnums.SegmentationRepresentations.Labelmap },
+            1,
+            newVisible,
+          );
+        } catch {
+          // ignore
+        }
+      }
+      syncSegmentations();
+      for (const vpId of vpIds) {
+        try {
+          csToolUtilities.segmentation.triggerSegmentationRender(vpId);
+          const enabledElement = getEnabledElementByViewportId(vpId) as any;
+          enabledElement?.viewport?.render?.();
+        } catch {
+          // Best effort
+        }
+      }
+      return;
+    }
 
-    // Try to get current visibility from Labelmap first, then Contour
+    // ─── Legacy path ────────────────────────────────────────
+    let currentVisible = true;
     try {
       currentVisible = csSegmentation.config.visibility.getSegmentIndexVisibility(
         viewportId,
@@ -1901,7 +2430,6 @@ export const segmentationService = {
 
     const newVisible = !currentVisible;
 
-    // Set visibility on Labelmap representation
     try {
       csSegmentation.config.visibility.setSegmentIndexVisibility(
         viewportId,
@@ -1913,7 +2441,6 @@ export const segmentationService = {
       // May not have labelmap representation
     }
 
-    // Set visibility on Contour representation
     try {
       csSegmentation.config.visibility.setSegmentIndexVisibility(
         viewportId,
@@ -1944,7 +2471,37 @@ export const segmentationService = {
     segmentIndex: number,
     visible: boolean,
   ): void {
-    // Set visibility on Labelmap representation
+    // ─── Multi-layer group path ─────────────────────────────
+    if (isMultiLayerGroup(segmentationId)) {
+      const subSegId = resolveSubSegId(segmentationId, segmentIndex);
+      if (!subSegId) return;
+      const vpIds = csSegmentation.state.getViewportIdsWithSegmentation(subSegId);
+      for (const vpId of vpIds) {
+        try {
+          csSegmentation.config.visibility.setSegmentIndexVisibility(
+            vpId,
+            { segmentationId: subSegId, type: ToolEnums.SegmentationRepresentations.Labelmap },
+            1,
+            visible,
+          );
+        } catch {
+          // ignore
+        }
+      }
+      syncSegmentations();
+      for (const vpId of vpIds) {
+        try {
+          csToolUtilities.segmentation.triggerSegmentationRender(vpId);
+          const enabledElement = getEnabledElementByViewportId(vpId) as any;
+          enabledElement?.viewport?.render?.();
+        } catch {
+          // Best effort
+        }
+      }
+      return;
+    }
+
+    // ─── Legacy path ────────────────────────────────────────
     try {
       csSegmentation.config.visibility.setSegmentIndexVisibility(
         viewportId,
@@ -1956,7 +2513,6 @@ export const segmentationService = {
       // May not have labelmap representation
     }
 
-    // Set visibility on Contour representation
     try {
       csSegmentation.config.visibility.setSegmentIndexVisibility(
         viewportId,
@@ -1982,6 +2538,20 @@ export const segmentationService = {
    * Toggle lock for a segment (locked segments can't be painted over).
    */
   toggleSegmentLocked(segmentationId: string, segmentIndex: number): void {
+    // ─── Multi-layer group path ─────────────────────────────
+    if (isMultiLayerGroup(segmentationId)) {
+      const subSegId = resolveSubSegId(segmentationId, segmentIndex);
+      if (!subSegId) return;
+      const isLocked = csSegmentation.segmentLocking.isSegmentIndexLocked(subSegId, 1);
+      csSegmentation.segmentLocking.setSegmentIndexLocked(subSegId, 1, !isLocked);
+      // Update metadata
+      const meta = segmentMetaMap.get(segmentationId)?.get(segmentIndex);
+      if (meta) meta.locked = !isLocked;
+      syncSegmentations();
+      return;
+    }
+
+    // ─── Legacy path ────────────────────────────────────────
     const isLocked = csSegmentation.segmentLocking.isSegmentIndexLocked(
       segmentationId,
       segmentIndex,
@@ -2003,6 +2573,22 @@ export const segmentationService = {
     segmentationId: string,
     segmentIndex: number,
   ): boolean {
+    if (isMultiLayerGroup(segmentationId)) {
+      const subSegId = resolveSubSegId(segmentationId, segmentIndex);
+      if (!subSegId) return true;
+      const vpIds = csSegmentation.state.getViewportIdsWithSegmentation(subSegId);
+      if (vpIds.length === 0) return true;
+      try {
+        return csSegmentation.config.visibility.getSegmentIndexVisibility(
+          vpIds[0],
+          { segmentationId: subSegId, type: ToolEnums.SegmentationRepresentations.Labelmap },
+          1,
+        );
+      } catch {
+        return true;
+      }
+    }
+
     try {
       return csSegmentation.config.visibility.getSegmentIndexVisibility(
         viewportId,
@@ -2026,6 +2612,16 @@ export const segmentationService = {
    * Read the current lock state of a segment from Cornerstone.
    */
   getSegmentLocked(segmentationId: string, segmentIndex: number): boolean {
+    if (isMultiLayerGroup(segmentationId)) {
+      const subSegId = resolveSubSegId(segmentationId, segmentIndex);
+      if (!subSegId) return false;
+      try {
+        return csSegmentation.segmentLocking.isSegmentIndexLocked(subSegId, 1);
+      } catch {
+        return false;
+      }
+    }
+
     try {
       return csSegmentation.segmentLocking.isSegmentIndexLocked(
         segmentationId,
@@ -2545,75 +3141,197 @@ export const segmentationService = {
           }
         }
       }
-      // Store loaded colors so addToViewport() can use them
-      if (colorMap.size > 0) {
-        loadedColorsMap.set(segmentationId, colorMap);
-      }
-
-      // Use the adapter's derived labelmap images directly.
-      //
-      // The adapter's createFromDICOMSegBuffer:
-      //   1. Creates one derived:uuid labelmap image per source image
-      //   2. Spatially matches each SEG frame to the correct source image
-      //   3. Writes pixel data directly into the correct labelmap image
-      //   4. Each image has .imageId and .referencedImageId set
-      //
-      // The derived images already have correct spatial metadata inherited
-      // from the source images (via createAndCacheDerivedLabelmapImage),
-      // so Cornerstone's matchImagesForOverlay will match them properly.
-      const labelmapImageIds: string[] = [];
-
-      for (let i = 0; i < adapterImages.length; i++) {
-        const adapterImg = adapterImages[i];
-        if (!adapterImg || !adapterImg.imageId) {
-          console.warn(`[segmentationService] Adapter image ${i} missing or has no imageId`);
-          continue;
-        }
-        labelmapImageIds.push(adapterImg.imageId);
-      }
-
+      // ─── Find first non-zero reference before we clean up adapter images ───
       const { referencedImageId, labelmapImageId } = findFirstNonZeroRef(adapterImages);
 
-      // Register the segmentation with Cornerstone
-      csSegmentation.addSegmentations([
-        {
-          segmentationId,
+      // ─── Map adapter images to base source image IDs for pixel extraction ───
+      const adapterImageBySourceId = new Map<string, any>();
+      for (const adapterImg of adapterImages) {
+        if (!adapterImg || !adapterImg.imageId) continue;
+        const baseId = resolveBaseImageId(adapterImg.referencedImageId);
+        adapterImageBySourceId.set(baseId, adapterImg);
+      }
+
+      // ─── Scan adapter images for unique segment indices ───
+      const uniqueSegmentIndices = new Set<number>();
+      for (const adapterImg of adapterImages) {
+        if (!adapterImg) continue;
+        let pixels: any = null;
+        try {
+          if (adapterImg.voxelManager) pixels = adapterImg.voxelManager.getScalarData();
+          else if (typeof adapterImg.getPixelData === 'function') pixels = adapterImg.getPixelData();
+        } catch { pixels = null; }
+        if (!pixels) continue;
+        for (let k = 0; k < pixels.length; k++) {
+          if (pixels[k] > 0) uniqueSegmentIndices.add(pixels[k]);
+        }
+      }
+      const sortedSegIndices = Array.from(uniqueSegmentIndices).sort((a, b) => a - b);
+      console.log(`[segmentationService] DICOM SEG contains segment indices: [${sortedSegIndices.join(', ')}]`);
+
+      // Determine group label from DICOM metadata
+      const groupLabel = (() => {
+        const headerMeta = segMetadata?.data?.[0];
+        if (headerMeta?.SeriesDescription) return headerMeta.SeriesDescription;
+        if (headerMeta?.ContentDescription) return headerMeta.ContentDescription;
+        if (headerMeta?.ContentLabel) return headerMeta.ContentLabel;
+        const firstSegMeta = segMetadata?.data?.[1];
+        if (firstSegMeta?.SegmentLabel) return firstSegMeta.SegmentLabel;
+        segmentationCounter++;
+        return `Segmentation ${segmentationCounter}`;
+      })();
+
+      // ─── Create multi-layer group ───
+      const loadPlane = metaData.get('imagePlaneModule', effectiveBaseSourceImageIds[0]) as any;
+      const loadRowSpacing = Number(loadPlane?.rowPixelSpacing) || 1;
+      const loadColSpacing = Number(loadPlane?.columnPixelSpacing) || 1;
+
+      subSegGroupMap.set(segmentationId, []);
+      segmentMetaMap.set(segmentationId, new Map());
+      groupDimensionsMap.set(segmentationId, {
+        rows: sourceRows,
+        columns: sourceCols,
+        rowPixelSpacing: loadRowSpacing,
+        columnPixelSpacing: loadColSpacing,
+        sourceImageIds: [...effectiveBaseSourceImageIds],
+      });
+      groupLabelMap.set(segmentationId, groupLabel);
+      sourceImageIdsMap.set(segmentationId, [...effectiveBaseSourceImageIds]);
+
+      const genericMeta = (csUtilities as any).genericMetadataProvider;
+      let refGeneralSeriesMeta: any = null;
+      for (const srcId of effectiveBaseSourceImageIds) {
+        refGeneralSeriesMeta = metaData.get('generalSeriesModule', srcId);
+        if (refGeneralSeriesMeta) break;
+      }
+
+      const pixelCount = sourceRows * sourceCols;
+      const subSegIds = subSegGroupMap.get(segmentationId)!;
+      const metaMapForGroup = segmentMetaMap.get(segmentationId)!;
+
+      // ─── Create per-segment sub-segmentations with binary labelmaps ───
+      for (const segIdx of sortedSegIndices) {
+        const segmentIndex = subSegIds.length + 1; // 1-based position in group
+        const meta = segments[segIdx];
+        const segLabel = meta?.label ?? `Segment ${segmentIndex}`;
+        const segColor = colorMap.get(segIdx) ?? DEFAULT_COLORS[(segmentIndex - 1) % DEFAULT_COLORS.length];
+
+        const subSegId = `${segmentationId}_layer_${segmentIndex}`;
+        const subSegLmImageIds: string[] = [];
+
+        // Create binary labelmap images (0/1) for this segment
+        for (let i = 0; i < effectiveBaseSourceImageIds.length; i++) {
+          const srcImageId = effectiveBaseSourceImageIds[i];
+          const lmImageId = `generated:labelmap_${subSegId}_${i}`;
+
+          // Extract binary data from the adapter's combined image
+          const binaryData = new Uint8Array(pixelCount);
+          const adapterImg = adapterImageBySourceId.get(srcImageId);
+          if (adapterImg) {
+            let adapterPixels: any = null;
+            try {
+              if (adapterImg.voxelManager) adapterPixels = adapterImg.voxelManager.getScalarData();
+              else if (typeof adapterImg.getPixelData === 'function') adapterPixels = adapterImg.getPixelData();
+            } catch { adapterPixels = null; }
+            if (adapterPixels) {
+              for (let p = 0; p < pixelCount && p < adapterPixels.length; p++) {
+                if (Number(adapterPixels[p]) === segIdx) {
+                  binaryData[p] = 1;
+                }
+              }
+            }
+          }
+
+          const imagePlane = metaData.get('imagePlaneModule', srcImageId);
+          imageLoader.createAndCacheLocalImage(lmImageId, {
+            scalarData: binaryData,
+            dimensions: [sourceCols, sourceRows],
+            spacing: [loadColSpacing, loadRowSpacing],
+            origin: imagePlane?.imagePositionPatient,
+            direction: imagePlane?.imageOrientationPatient,
+            frameOfReferenceUID: imagePlane?.frameOfReferenceUID,
+            referencedImageId: srcImageId,
+          } as any);
+
+          if (refGeneralSeriesMeta) {
+            genericMeta.add(lmImageId, {
+              type: 'generalSeriesModule',
+              metadata: refGeneralSeriesMeta,
+            });
+          }
+
+          subSegLmImageIds.push(lmImageId);
+        }
+
+        // Register as independent Cornerstone segmentation (segment index 1)
+        csSegmentation.addSegmentations([{
+          segmentationId: subSegId,
           representation: {
             type: ToolEnums.SegmentationRepresentations.Labelmap,
-            data: labelmapImageIds.length > 0
-              ? { imageIds: labelmapImageIds } as any
-              : undefined,
+            data: { imageIds: subSegLmImageIds } as any,
           },
           config: {
-            label: (() => {
-              // Extract a meaningful label from DICOM metadata
-              const headerMeta = segMetadata?.data?.[0];
-              if (headerMeta?.SeriesDescription) return headerMeta.SeriesDescription;
-              if (headerMeta?.ContentDescription) return headerMeta.ContentDescription;
-              if (headerMeta?.ContentLabel) return headerMeta.ContentLabel;
-              // Try first segment's label as a fallback
-              const firstSegMeta = segMetadata?.data?.[1];
-              if (firstSegMeta?.SegmentLabel) return firstSegMeta.SegmentLabel;
-              segmentationCounter++;
-              return `Segmentation ${segmentationCounter}`;
-            })(),
-            segments,
+            label: segLabel,
+            segments: {
+              1: {
+                label: segLabel,
+                segmentIndex: 1,
+                locked: false,
+                active: segmentIndex === 1,
+                cachedStats: {},
+              } as any,
+            },
           },
-        },
-      ]);
+        }]);
 
-      // Track source imageIds for DICOM SEG re-export
-      sourceImageIdsMap.set(segmentationId, [...effectiveBaseSourceImageIds]);
+        // Track source imageIds on the sub-seg
+        sourceImageIdsMap.set(subSegId, [...effectiveBaseSourceImageIds]);
+
+        // Update group registry
+        subSegIds.push(subSegId);
+        subSegToGroupMap.set(subSegId, { groupId: segmentationId, segmentIndex });
+        metaMapForGroup.set(segmentIndex, {
+          label: segLabel,
+          color: segColor,
+          locked: false,
+        });
+
+        console.log(`[segmentationService] Created sub-seg ${subSegId} for adapter segment ${segIdx} → group index ${segmentIndex}: "${segLabel}"`);
+      }
+
+      // Store loaded colors (remapped from adapter segment index → group segment index)
+      // so addToViewport() can apply them when attaching to viewports.
+      if (colorMap.size > 0) {
+        const remappedColors = new Map<number, [number, number, number, number]>();
+        let groupIdx = 0;
+        for (const segIdx of sortedSegIndices) {
+          groupIdx++;
+          const color = colorMap.get(segIdx);
+          if (color) remappedColors.set(groupIdx, color);
+        }
+        if (remappedColors.size > 0) {
+          loadedColorsMap.set(segmentationId, remappedColors);
+        }
+      }
+
+      // Clean up adapter's combined images from cache to free memory
+      for (const adapterImg of adapterImages) {
+        if (!adapterImg?.imageId) continue;
+        try { cache.removeImageLoadObject(adapterImg.imageId); } catch { /* ok */ }
+      }
 
       // Update store
       const store = useSegmentationStore.getState();
       store.setActiveSegmentation(segmentationId);
       store.setActiveSegmentIndex(1);
-      csSegmentation.segmentIndex.setActiveSegmentIndex(segmentationId, 1);
+      // Set active segment index 1 on the first sub-seg
+      if (subSegIds.length > 0 && subSegIds[0]) {
+        csSegmentation.segmentIndex.setActiveSegmentIndex(subSegIds[0], 1);
+      }
 
       console.log(
-        `[segmentationService] Loaded DICOM SEG: ${segmentationId}`,
-        `(${Object.keys(segments).length} segments, ${labelmapImageIds.length} labelmap images)`,
+        `[segmentationService] Loaded DICOM SEG as multi-layer group: ${segmentationId}`,
+        `(${sortedSegIndices.length} segments as sub-segmentations, ${effectiveBaseSourceImageIds.length} slices)`,
       );
 
       syncSegmentations();
@@ -2751,6 +3469,14 @@ export const segmentationService = {
    * 6. Return base64-encoded string for IPC transport
    */
   async exportToDicomSeg(segmentationId: string): Promise<string> {
+    // ─── Multi-layer group path ─────────────────────────────
+    // Composite all sub-seg binary layers into multi-valued labelmaps,
+    // build a temporary Cornerstone segmentation for the legacy export path.
+    if (isMultiLayerGroup(segmentationId)) {
+      return this._exportGroupToDicomSeg(segmentationId);
+    }
+
+    // ─── Legacy (non-group) path ────────────────────────────
     const seg = csSegmentation.state.getSegmentation(segmentationId);
     if (!seg) {
       throw new Error(`[segmentationService] Segmentation not found: ${segmentationId}`);
@@ -3744,6 +4470,156 @@ export const segmentationService = {
   },
 
   /**
+   * Export a multi-layer group to DICOM SEG by compositing all sub-seg
+   * binary layers into multi-valued labelmaps (pixel value = segment index).
+   * Higher-indexed segments win at overlap pixels.
+   */
+  async _exportGroupToDicomSeg(groupId: string): Promise<string> {
+    const dims = groupDimensionsMap.get(groupId);
+    const srcImageIds = dims?.sourceImageIds ?? sourceImageIdsMap.get(groupId) ?? [];
+    if (srcImageIds.length === 0) {
+      throw new Error('[segmentationService] No source imageIds for group export.');
+    }
+
+    const subSegArr = subSegGroupMap.get(groupId) ?? [];
+    const metaMap = segmentMetaMap.get(groupId);
+    const { rows, columns } = dims ?? { rows: 512, columns: 512 };
+    const sliceCount = srcImageIds.length;
+    const pixelsPerSlice = rows * columns;
+
+    // Build composited labelmaps: for each slice, iterate sub-segs in order.
+    // Higher-indexed segment overwrites lower at overlap pixels.
+    const compositedSlices: Uint8Array[] = [];
+    for (let s = 0; s < sliceCount; s++) {
+      const composited = new Uint8Array(pixelsPerSlice);
+      for (let i = 0; i < subSegArr.length; i++) {
+        const subSegId = subSegArr[i];
+        if (!subSegId) continue;
+        const segmentIndex = i + 1;
+        const subSeg = csSegmentation.state.getSegmentation(subSegId);
+        const lmImageIds: string[] = (subSeg?.representationData as any)?.Labelmap?.imageIds ?? [];
+        if (s >= lmImageIds.length) continue;
+        const lmImage = cache.getImage(lmImageIds[s]);
+        if (!lmImage) continue;
+        const scalarData =
+          lmImage.voxelManager?.getScalarData?.()
+          ?? (lmImage as any).getPixelData?.();
+        if (!scalarData) continue;
+        for (let p = 0; p < pixelsPerSlice && p < scalarData.length; p++) {
+          if (Number(scalarData[p]) > 0) {
+            composited[p] = segmentIndex;
+          }
+        }
+      }
+      compositedSlices.push(composited);
+    }
+
+    // Build segment metadata
+    const segmentMetadata: any[] = [null]; // index 0 = background
+    const maxIdx = subSegArr.length;
+    for (let idx = 1; idx <= maxIdx; idx++) {
+      if (!subSegArr[idx - 1]) {
+        segmentMetadata.push(null);
+        continue;
+      }
+      const meta = metaMap?.get(idx);
+      const color = meta?.color ?? DEFAULT_COLORS[(idx - 1) % DEFAULT_COLORS.length];
+      const normalizedRgb = [color[0] / 255, color[1] / 255, color[2] / 255];
+      const cieLabValues =
+        (dcmjsData as any).Colors?.rgb2DICOMLAB?.(normalizedRgb) ?? [0, 0, 0];
+
+      segmentMetadata.push({
+        SegmentLabel: meta?.label ?? `Segment ${idx}`,
+        SegmentNumber: idx,
+        SegmentAlgorithmType: 'SEMIAUTOMATIC',
+        SegmentAlgorithmName: 'XNAT Workstation',
+        SegmentedPropertyCategoryCodeSequence: {
+          CodeValue: 'T-D0050',
+          CodingSchemeDesignator: 'SRT',
+          CodeMeaning: 'Tissue',
+        },
+        SegmentedPropertyTypeCodeSequence: {
+          CodeValue: 'T-D0050',
+          CodingSchemeDesignator: 'SRT',
+          CodeMeaning: 'Tissue',
+        },
+        RecommendedDisplayCIELabValue: cieLabValues,
+      });
+    }
+
+    // Create a temporary single-layer Cornerstone segmentation with the
+    // composited labelmaps, register it, export, then clean up.
+    const tempSegId = `_export_temp_${groupId}_${Date.now()}`;
+    const tempLmImageIds: string[] = [];
+    try {
+      // Create labelmap images for the temporary segmentation
+      for (let s = 0; s < sliceCount; s++) {
+        const srcId = srcImageIds[s];
+        const localId = `${tempSegId}_slice_${s}`;
+        const pixelData = compositedSlices[s];
+
+        const imagePlane = metaData.get('imagePlaneModule', srcId) as any;
+        imageLoader.createAndCacheLocalImage(localId, {
+          scalarData: pixelData,
+          dimensions: [columns, rows],
+          spacing: [
+            Number(imagePlane?.columnPixelSpacing) || 1,
+            Number(imagePlane?.rowPixelSpacing) || 1,
+          ],
+          origin: imagePlane?.imagePositionPatient,
+          direction: imagePlane?.imageOrientationPatient,
+          frameOfReferenceUID: imagePlane?.frameOfReferenceUID,
+          referencedImageId: srcId,
+        } as any);
+        tempLmImageIds.push(localId);
+      }
+
+      // Build segments object for Cornerstone
+      const segments: Record<number, any> = {};
+      for (let idx = 1; idx <= maxIdx; idx++) {
+        if (!subSegArr[idx - 1]) continue;
+        const meta = metaMap?.get(idx);
+        segments[idx] = {
+          label: meta?.label ?? `Segment ${idx}`,
+          locked: false,
+          active: idx === 1,
+          segmentIndex: idx,
+          cachedStats: {},
+        };
+      }
+
+      // Register temporary segmentation
+      csSegmentation.addSegmentations([{
+        segmentationId: tempSegId,
+        representation: {
+          type: ToolEnums.SegmentationRepresentations.Labelmap,
+          data: { imageIds: tempLmImageIds } as any,
+        },
+        config: {
+          label: groupLabelMap.get(groupId) ?? 'Segmentation',
+          segments,
+        },
+      }]);
+
+      // Track source image IDs for the temp seg
+      sourceImageIdsMap.set(tempSegId, [...srcImageIds]);
+
+      // Delegate to the legacy export path
+      const result = await this.exportToDicomSeg(tempSegId);
+
+      return result;
+    } finally {
+      // Clean up temporary segmentation
+      try { csSegmentation.removeSegmentation(tempSegId); } catch { /* ok */ }
+      sourceImageIdsMap.delete(tempSegId);
+      // Clean up temporary labelmap images from cache
+      for (const lmId of tempLmImageIds) {
+        try { cache.removeImageLoadObject(lmId); } catch { /* ok */ }
+      }
+    }
+  },
+
+  /**
    * Track source image IDs for a segmentation (used for DICOM SEG/RTSTRUCT export).
    * Called by rtStructService when loading RTSTRUCT contours.
    */
@@ -3773,6 +4649,35 @@ export const segmentationService = {
    * Used by UI save flows to avoid hard export errors for empty annotations.
    */
   hasExportableContent(segmentationId: string, targetType?: 'SEG' | 'RTSTRUCT'): boolean {
+    const hasNonZeroPixels = (img: any): boolean => {
+      if (!img) return false;
+      const scalarData: any =
+        img.voxelManager?.getScalarData?.()
+        ?? img.imageFrame?.pixelData
+        ?? img.getPixelData?.();
+      if (!scalarData || typeof scalarData.length !== 'number') return false;
+      for (let i = 0; i < scalarData.length; i++) {
+        if (Number(scalarData[i]) > 0) return true;
+      }
+      return false;
+    };
+
+    // ─── Multi-layer group path ─────────────────────────────
+    if (isMultiLayerGroup(segmentationId)) {
+      if (targetType === 'RTSTRUCT') return false; // groups are labelmap-only
+      // Check if any sub-seg has non-zero pixels
+      const subSegIds = getActiveSubSegIds(segmentationId);
+      for (const subSegId of subSegIds) {
+        const subSeg = csSegmentation.state.getSegmentation(subSegId);
+        const imageIds: string[] = (subSeg?.representationData as any)?.Labelmap?.imageIds ?? [];
+        for (const imageId of imageIds) {
+          if (hasNonZeroPixels(cache.getImage(imageId))) return true;
+        }
+      }
+      return false;
+    }
+
+    // ─── Legacy path ────────────────────────────────────────
     const seg = csSegmentation.state.getSegmentation(segmentationId);
     if (!seg) return false;
 
@@ -3796,19 +4701,6 @@ export const segmentationService = {
     const labelmapData = (seg.representationData as any)?.Labelmap;
     const imageIds: string[] = labelmapData?.imageIds ?? [];
     if (!Array.isArray(imageIds) || imageIds.length === 0) return false;
-
-    const hasNonZeroPixels = (img: any): boolean => {
-      if (!img) return false;
-      const scalarData: any =
-        img.voxelManager?.getScalarData?.()
-        ?? img.imageFrame?.pixelData
-        ?? img.getPixelData?.();
-      if (!scalarData || typeof scalarData.length !== 'number') return false;
-      for (let i = 0; i < scalarData.length; i++) {
-        if (Number(scalarData[i]) > 0) return true;
-      }
-      return false;
-    };
 
     for (const imageId of imageIds) {
       if (hasNonZeroPixels(cache.getImage(imageId))) {
@@ -3948,6 +4840,11 @@ export const segmentationService = {
     // Clean up module-level state
     sourceImageIdsMap.clear();
     loadedColorsMap.clear();
+    subSegGroupMap.clear();
+    subSegToGroupMap.clear();
+    segmentMetaMap.clear();
+    groupDimensionsMap.clear();
+    groupLabelMap.clear();
     segmentationCounter = 0;
 
     initialized = false;

--- a/src/renderer/lib/cornerstone/toolService.ts
+++ b/src/renderer/lib/cornerstone/toolService.ts
@@ -64,6 +64,7 @@ import { viewportService } from './viewportService';
 import { useSegmentationStore } from '../../stores/segmentationStore';
 import { segmentationService } from './segmentationService';
 import { useViewerStore } from '../../stores/viewerStore';
+import { segmentationManager } from '../segmentation/segmentationManagerSingleton';
 
 const TOOL_GROUP_ID = 'xnatToolGroup_primary';
 const CONTOUR_INTERPOLATION_TOOL_NAMES = [
@@ -88,7 +89,10 @@ const TOOL_NAME_MAP: Record<ToolName, string> = {
   [ToolName.Probe]: ProbeTool.toolName,
   [ToolName.ArrowAnnotate]: ArrowAnnotateTool.toolName,
   [ToolName.PlanarFreehandROI]: PlanarFreehandROITool.toolName,
-  [ToolName.Crosshairs]: CrosshairsTool.toolName,
+  // Crosshair sync is handled via custom pointer handlers (crosshairGeometry.ts),
+  // NOT Cornerstone's CrosshairsTool (which has rendering issues on stack viewports).
+  // Map it to WindowLevel so the tool group has valid bindings when Crosshairs is active.
+  [ToolName.Crosshairs]: WindowLevelTool.toolName,
   // Labelmap segmentation tools — Brush/Eraser/ThresholdBrush all map to BrushTool
   [ToolName.Brush]: BrushTool.toolName,
   [ToolName.Eraser]: BrushTool.toolName,
@@ -498,12 +502,19 @@ export const toolService = {
 
       // Active segmentation may belong to a different scan/panel. Prefer a segmentation
       // currently attached to the active viewport; otherwise we'll create a new one.
+      // Use segmentationManager to filter by the visible set for this viewport.
+      const visibleSegIds = segmentationManager.getVisibleSegmentationIdsForViewport(viewportId);
       let activeSegId = segStore.activeSegmentationId;
       if (activeSegId && !isSegOnViewport(activeSegId)) {
         activeSegId = null;
       }
       if (!activeSegId) {
-        const attachedSeg = segStore.segmentations.find((s) => isSegOnViewport(s.segmentationId));
+        const attachedSeg = segStore.segmentations.find((s) => {
+          if (!isSegOnViewport(s.segmentationId)) return false;
+          // If we have a visible-set filter, only consider those
+          if (visibleSegIds && !visibleSegIds.has(s.segmentationId)) return false;
+          return true;
+        });
         if (attachedSeg) {
           activeSegId = attachedSeg.segmentationId;
           segStore.setActiveSegmentation(activeSegId);
@@ -517,55 +528,59 @@ export const toolService = {
         try {
           const engine = getRenderingEngine(viewportService.ENGINE_ID);
           const viewport = engine?.getViewport(viewportId);
+          // Try viewport imageIds first, fall back to panelImageIdsMap
+          let imageIds: string[] | undefined;
           if (viewport && 'getImageIds' in viewport) {
-            const imageIds = (viewport as any).getImageIds() as string[];
-            if (imageIds && imageIds.length > 0) {
-              // Create segmentation first, then activate the tool
-              segmentationService.createStackSegmentation(imageIds, undefined, true).then(async (segId) => {
-                await segmentationService.addToViewport(viewportId, segId);
+            imageIds = (viewport as any).getImageIds() as string[];
+          }
+          if ((!imageIds || imageIds.length === 0)) {
+            imageIds = useViewerStore.getState().panelImageIdsMap[viewportId];
+          }
+          if (imageIds && imageIds.length > 0) {
+            // Create segmentation first, then activate the tool.
+            // Use segmentationManager for cross-panel attachment.
+            segmentationManager.createNewSegmentation(viewportId, imageIds, undefined, true).then(async (segId) => {
+              // Track local unsaved origin so auto-save/save targets stay bound
+              // to the source scan even if the user changes panels before saving.
+              const viewerState = useViewerStore.getState();
+              const sourceScanId =
+                viewerState.panelScanMap[viewportId] ?? viewerState.xnatContext?.scanId;
+              if (
+                sourceScanId &&
+                viewerState.xnatContext?.projectId &&
+                viewerState.xnatContext?.sessionId
+              ) {
+                useSegmentationStore.getState().setXnatOrigin(segId, {
+                  scanId: '',
+                  sourceScanId,
+                  projectId: viewerState.xnatContext.projectId,
+                  sessionId: viewerState.xnatContext.sessionId,
+                });
+              }
 
-                // Track local unsaved origin so auto-save/save targets stay bound
-                // to the source scan even if the user changes panels before saving.
-                const viewerState = useViewerStore.getState();
-                const sourceScanId =
-                  viewerState.panelScanMap[viewportId] ?? viewerState.xnatContext?.scanId;
-                if (
-                  sourceScanId &&
-                  viewerState.xnatContext?.projectId &&
-                  viewerState.xnatContext?.sessionId
-                ) {
-                  useSegmentationStore.getState().setXnatOrigin(segId, {
-                    scanId: '',
-                    sourceScanId,
-                    projectId: viewerState.xnatContext.projectId,
-                    sessionId: viewerState.xnatContext.sessionId,
-                  });
+              if (segId) {
+                // Keep active segment index valid for cursor/LUT resolution.
+                // Eraser behavior is controlled by Brush strategy, not segment index 0.
+                const paintIdx = getSafePaintSegmentIndex(
+                  useSegmentationStore.getState().activeSegmentIndex,
+                );
+                segmentationService.setActiveSegmentIndex(segId, paintIdx);
+
+                // Ensure contour representation for contour tools
+                if (CONTOUR_SEG_TOOLS.has(toolName)) {
+                  await segmentationService.ensureContourRepresentation(viewportId, segId);
                 }
+              }
 
-                if (segId) {
-                  // Keep active segment index valid for cursor/LUT resolution.
-                  // Eraser behavior is controlled by Brush strategy, not segment index 0.
-                  const paintIdx = getSafePaintSegmentIndex(
-                    useSegmentationStore.getState().activeSegmentIndex,
-                  );
-                  segmentationService.setActiveSegmentIndex(segId, paintIdx);
-
-                  // Ensure contour representation for contour tools
-                  if (CONTOUR_SEG_TOOLS.has(toolName)) {
-                    await segmentationService.ensureContourRepresentation(viewportId, segId);
-                  }
-                }
-
-                // NOW activate the tool — segmentation is fully registered
-                currentActiveTool = toolName;
-                rebuildToolGroup(toolName);
-                console.log('[toolService] Active tool:', toolName, '(after auto-creating segmentation)');
-              }).catch((err) => {
-                console.error('[toolService] Failed to auto-create segmentation:', err);
-              });
-            } else {
-              console.debug('[toolService] Cannot auto-create segmentation — no images in viewport');
-            }
+              // NOW activate the tool — segmentation is fully registered
+              currentActiveTool = toolName;
+              rebuildToolGroup(toolName);
+              console.log('[toolService] Active tool:', toolName, '(after auto-creating segmentation)');
+            }).catch((err) => {
+              console.error('[toolService] Failed to auto-create segmentation:', err);
+            });
+          } else {
+            console.debug('[toolService] Cannot auto-create segmentation — no images in viewport');
           }
         } catch (err) {
           console.debug('[toolService] Cannot auto-create segmentation:', err);
@@ -575,13 +590,11 @@ export const toolService = {
         return;
       }
 
-      // Segmentation already exists
+      // Segmentation already exists — use segmentationManager for activation
       const segId = activeSegId;
       if (segId) {
-        segmentationService.setActiveSegmentIndex(
-          segId,
-          getSafePaintSegmentIndex(segStore.activeSegmentIndex),
-        );
+        const paintIdx = getSafePaintSegmentIndex(segStore.activeSegmentIndex);
+        segmentationManager.userSelectedSegmentation(viewportId, segId, paintIdx);
 
         // Ensure contour representation for contour tools
         if (CONTOUR_SEG_TOOLS.has(toolName)) {

--- a/src/renderer/lib/cornerstone/volumeService.ts
+++ b/src/renderer/lib/cornerstone/volumeService.ts
@@ -23,13 +23,22 @@ import {
 } from '@cornerstonejs/core';
 
 const VOLUME_SCHEME = 'cornerstoneStreamingImageVolume';
+let lastVolumeTs = 0;
+let volumeSeq = 0;
 
 /**
  * Generate a unique volume ID for MPR use.
- * Format: cornerstoneStreamingImageVolume:xnat_mpr_<timestamp>
+ * Format: cornerstoneStreamingImageVolume:xnat_mpr_<timestamp>_<seq>
  */
 export function generateVolumeId(): string {
-  return `${VOLUME_SCHEME}:xnat_mpr_${Date.now()}`;
+  const now = Date.now();
+  if (now === lastVolumeTs) {
+    volumeSeq += 1;
+  } else {
+    lastVolumeTs = now;
+    volumeSeq = 0;
+  }
+  return `${VOLUME_SCHEME}:xnat_mpr_${now}_${volumeSeq}`;
 }
 
 /** Keep a reference to volumes so we can call load() later */

--- a/src/renderer/lib/hotkeys/defaultHotkeyMap.ts
+++ b/src/renderer/lib/hotkeys/defaultHotkeyMap.ts
@@ -49,6 +49,7 @@ export const DEFAULT_HOTKEY_MAP: HotkeyMap = {
   // ─── Panel Toggles ──────────────────────────────────────────
   'panel.toggleAnnotations':  [{ key: 'o' }], // O for list/overview
   'panel.toggleSegmentation': [{ key: 'g' }], // G for seGmentation
+  'panel.nextViewport': [{ key: 'Tab' }, { key: 'Tab', modifiers: { shift: true } }],
 
   // ─── Brush Size ──────────────────────────────────────────────
   'brush.decrease': [{ key: '[' }],

--- a/src/renderer/lib/hotkeys/hotkeyService.ts
+++ b/src/renderer/lib/hotkeys/hotkeyService.ts
@@ -11,7 +11,7 @@
  * through existing stores (viewerStore, segmentationStore, annotationStore).
  */
 import type { HotkeyAction, HotkeyBinding, HotkeyMap } from '@shared/types/hotkeys';
-import { ToolName, WL_PRESETS } from '@shared/types/viewer';
+import { ToolName, WL_PRESETS, panelId as makePanelId } from '@shared/types/viewer';
 import type { LayoutType } from '@shared/types/viewer';
 import { DEFAULT_HOTKEY_MAP } from './defaultHotkeyMap';
 import { useViewerStore } from '../../stores/viewerStore';
@@ -89,6 +89,41 @@ const LAYOUT_ACTION_MAP: Partial<Record<HotkeyAction, LayoutType>> = {
   'layout.2x2': '2x2',
 };
 
+// ─── Clockwise Panel Ordering ─────────────────────────────────────
+
+/**
+ * Build a clockwise traversal order for a rows×cols grid layout.
+ * For a 2×2 grid: TL → TR → BR → BL (i.e., panel_0 → panel_1 → panel_3 → panel_2).
+ */
+function buildClockwisePanelOrder(rows: number, cols: number): string[] {
+  const order: string[] = [];
+  if (rows <= 0 || cols <= 0) return order;
+
+  // Simple cases: 1 row or 1 col → normal L-to-R / T-to-B order
+  if (rows === 1 || cols === 1) {
+    for (let i = 0; i < rows * cols; i++) {
+      order.push(makePanelId(i));
+    }
+    return order;
+  }
+
+  // Multi-row, multi-col: clockwise spiral (simplified for 2×2)
+  // Top row L→R, right col T→B, bottom row R→L, left col B→T
+  const visited = new Set<number>();
+  let top = 0, bottom = rows - 1, left = 0, right = cols - 1;
+  while (top <= bottom && left <= right) {
+    for (let c = left; c <= right; c++) { const idx = top * cols + c; if (!visited.has(idx)) { visited.add(idx); order.push(makePanelId(idx)); } }
+    top++;
+    for (let r = top; r <= bottom; r++) { const idx = r * cols + right; if (!visited.has(idx)) { visited.add(idx); order.push(makePanelId(idx)); } }
+    right--;
+    for (let c = right; c >= left; c--) { const idx = bottom * cols + c; if (!visited.has(idx)) { visited.add(idx); order.push(makePanelId(idx)); } }
+    bottom--;
+    for (let r = bottom; r >= top; r--) { const idx = r * cols + left; if (!visited.has(idx)) { visited.add(idx); order.push(makePanelId(idx)); } }
+    left++;
+  }
+  return order;
+}
+
 // ─── Action Dispatch ──────────────────────────────────────────────
 
 /**
@@ -149,6 +184,16 @@ function dispatchAction(action: HotkeyAction): boolean {
     case 'panel.toggleSegmentation':
       useSegmentationStore.getState().togglePanel();
       return true;
+    case 'panel.nextViewport': {
+      // Cycle active viewport clockwise through visible panels
+      const panelCount = viewerState.layoutConfig.panelCount;
+      if (panelCount <= 1) return true;
+      const order = buildClockwisePanelOrder(viewerState.layoutConfig.rows, viewerState.layoutConfig.cols);
+      const currentIdx = order.indexOf(viewerState.activeViewportId);
+      const nextIdx = (currentIdx + 1) % order.length;
+      viewerState.setActiveViewport(order[nextIdx]);
+      return true;
+    }
 
     // Brush size
     case 'brush.decrease': {
@@ -241,6 +286,24 @@ function handleSliceNavigation(
     return true;
   }
 
+  // Oriented viewport (AXIAL/SAGITTAL/CORONAL → uses volume viewport via mprService)
+  const panelOrientation = viewerState.panelOrientationMap[pid];
+  if (panelOrientation && panelOrientation !== 'STACK') {
+    let delta = 0;
+    switch (action) {
+      case 'slice.prev':     delta = -1;  break;
+      case 'slice.next':     delta = 1;   break;
+      case 'slice.prevPage': delta = -10; break;
+      case 'slice.nextPage': delta = 10;  break;
+      case 'slice.first':    mprService.scrollToIndex(pid, 0); return true;
+      case 'slice.last':     mprService.scroll(pid, 999999); return true; // jump to end
+    }
+    if (delta !== 0) {
+      mprService.scroll(pid, delta);
+    }
+    return true;
+  }
+
   // Stack viewport
   const vp = viewerState.viewports[pid];
   if (!vp || vp.totalImages <= 1) return false;
@@ -282,12 +345,18 @@ let listenerInstalled = false;
 // ─── Keydown Handler ──────────────────────────────────────────────
 
 function handleKeyDown(e: KeyboardEvent): void {
-  // Input guard: don't intercept when focus is in a form element
+  // Input guard: don't intercept when focus is in a form element,
+  // UNLESS it's Tab which we want for viewport cycling even from controls.
   const tag = (e.target as HTMLElement)?.tagName;
-  if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
+  const isTextInput = tag === 'INPUT' || tag === 'TEXTAREA';
+  const isFormControl = isTextInput || tag === 'SELECT';
+  if (isFormControl) {
+    // Allow Tab through even in form controls (for viewport cycling)
+    if (e.key !== 'Tab') return;
+  }
 
-  // Also guard for contentEditable elements
-  if ((e.target as HTMLElement)?.isContentEditable) return;
+  // Also guard for contentEditable elements (except Tab)
+  if ((e.target as HTMLElement)?.isContentEditable && e.key !== 'Tab') return;
 
   // Build normalized key from the event
   const parts: string[] = [];

--- a/src/renderer/lib/segmentation/SegmentationManager.ts
+++ b/src/renderer/lib/segmentation/SegmentationManager.ts
@@ -73,6 +73,90 @@ export class SegmentationManager {
     console.log('[SegmentationManager] Disposed');
   }
 
+  // ─── Panel readiness ────────────────────────────────────────────
+
+  /**
+   * Wait for a panel's viewport to be ready. Uses viewportReadyService
+   * with a timeout fallback — if the viewport already exists in the
+   * rendering engine, we proceed after a short delay even if no ready
+   * event fires (the event may have already fired).
+   */
+  async waitForPanelReady(panelId: string, epoch?: number): Promise<void> {
+    const useEpoch = epoch ?? viewportReadyService.getEpoch(panelId);
+    try {
+      await viewportReadyService.whenReady(panelId, useEpoch);
+    } catch {
+      // Timeout — if viewport exists, proceed anyway after a short delay
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  }
+
+  // ─── Cross-panel attachment ────────────────────────────────────
+
+  /**
+   * Ensure a segmentation is visible on ALL panels that are showing
+   * the same source scan. Called after loading or creating a segmentation
+   * so it appears in every viewport where that scan is displayed.
+   */
+  async attachSegmentationToPanelsForSource(
+    segmentationId: string,
+    originPanelId: string,
+  ): Promise<void> {
+    const viewerState = useViewerStore.getState();
+    const sourceScanId = viewerState.panelScanMap[originPanelId];
+    if (!sourceScanId) return;
+
+    const panelCtx = viewerState.panelXnatContextMap[originPanelId] ?? viewerState.xnatContext;
+    const sessionId = panelCtx?.sessionId;
+
+    const panelCount = viewerState.layoutConfig.panelCount;
+    for (let i = 0; i < panelCount; i++) {
+      const pid = `panel_${i}`;
+      if (pid === originPanelId) continue;
+
+      // Only attach to panels showing the same scan in the same session
+      const otherScanId = viewerState.panelScanMap[pid];
+      const otherCtx = viewerState.panelXnatContextMap[pid] ?? viewerState.xnatContext;
+      if (otherScanId !== sourceScanId) continue;
+      if (sessionId && otherCtx?.sessionId !== sessionId) continue;
+
+      if (!this.isSegOnViewport(pid, segmentationId)) {
+        try {
+          await this.waitForPanelReady(pid);
+          await this.attachSegmentationToViewport(pid, segmentationId);
+          this.restorePresentationState(segmentationId);
+        } catch (err) {
+          console.debug(`[SegmentationManager] Failed to attach ${segmentationId} to ${pid}:`, err);
+        }
+      }
+    }
+  }
+
+  /**
+   * Re-attach all visible segmentations to a viewport after it has been
+   * recreated (e.g., orientation change from STACK to volume viewport).
+   * Called from OrientedViewport after creating the volume viewport.
+   */
+  async attachVisibleSegmentationsToViewport(panelId: string): Promise<void> {
+    const viewerState = useViewerStore.getState();
+    const sourceScanId = viewerState.panelScanMap[panelId];
+    if (!sourceScanId) return;
+
+    const visibleIds = this.getVisibleSegmentationIdsForViewport(panelId);
+    if (!visibleIds) return;
+
+    for (const segId of visibleIds) {
+      if (!this.isSegOnViewport(panelId, segId)) {
+        try {
+          await this.attachSegmentationToViewport(panelId, segId);
+          this.restorePresentationState(segId);
+        } catch (err) {
+          console.debug(`[SegmentationManager] Failed re-attach ${segId} to ${panelId}:`, err);
+        }
+      }
+    }
+  }
+
   // ─── Panel lifecycle ──────────────────────────────────────────
 
   /**
@@ -422,6 +506,9 @@ export class SegmentationManager {
         // presentation cache so they survive viewport recreation.
         this.captureInitialPresentationState(segmentationId);
 
+        // Attach to all other panels showing the same source scan
+        await this.attachSegmentationToPanelsForSource(segmentationId, panelId);
+
         // Wait two rAF cycles for render pipeline to settle, then clean dirty state
         await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
         if (!this.disposed) {
@@ -620,7 +707,12 @@ export class SegmentationManager {
       : (segment?.visible ?? segmentationService.getSegmentVisibility(viewportId, segmentationId, segmentIndex));
     const newVisible = !currentVisible;
 
-    segmentationService.setSegmentVisibility(viewportId, segmentationId, segmentIndex, newVisible);
+    // Apply to ALL viewport representations (not just the requesting viewport)
+    // so visibility stays in sync across multiple panels showing the same scan.
+    const allVpIds = segmentationService.getViewportIdsForSegmentation(segmentationId);
+    for (const vpId of allVpIds) {
+      segmentationService.setSegmentVisibility(vpId, segmentationId, segmentIndex, newVisible);
+    }
     managerStore.setPresentation(segmentationId, segmentIndex, { visible: newVisible });
   }
 
@@ -644,11 +736,17 @@ export class SegmentationManager {
     viewportId: string,
     sourceImageIds: string[],
     label?: string,
+    createDefaultSegment = false,
   ): Promise<string> {
     const segId = await segmentationService.createStackSegmentation(sourceImageIds, label, false);
     await segmentationService.addToViewport(viewportId, segId);
     segmentationService.ensureEmptySegmentation(segId);
     useSegmentationStore.getState().setDicomType(segId, 'SEG');
+
+    if (createDefaultSegment) {
+      segmentationService.addSegment(segId, 'Segment 1');
+      segmentationService.setActiveSegmentIndex(segId, 1);
+    }
 
     // Record local origin with session-scoped composite key so the
     // segmentation panel can filter by the active viewport's source scan.
@@ -664,6 +762,9 @@ export class SegmentationManager {
         `${projectId}/${sessionId}/${sourceScanId}`,
       );
     }
+
+    // Attach to all other panels showing the same source scan
+    await this.attachSegmentationToPanelsForSource(segId, viewportId);
 
     return segId;
   }
@@ -704,6 +805,8 @@ export class SegmentationManager {
   addSegment(segmentationId: string, label: string): number {
     const nextIndex = segmentationService.addSegment(segmentationId, label);
     segmentationService.setActiveSegmentIndex(segmentationId, nextIndex);
+    // Seed presentation visibility so the new segment is visible by default
+    useSegmentationManagerStore.getState().setPresentation(segmentationId, nextIndex, { visible: true });
     return nextIndex;
   }
 

--- a/src/renderer/stores/viewerStore.ts
+++ b/src/renderer/stores/viewerStore.ts
@@ -18,7 +18,9 @@ import type {
   PanelConfig,
   MPRViewportState,
   VolumeLoadProgress,
+  ViewportOrientation,
 } from '@shared/types/viewer';
+import type { Types as CsTypes } from '@cornerstonejs/core';
 import { ToolName, LAYOUT_CONFIGS, panelId } from '@shared/types/viewer';
 import type { HangingProtocol } from '@shared/types/hangingProtocol';
 import type { XnatScan, XnatUploadContext } from '@shared/types/xnat';
@@ -75,6 +77,22 @@ interface ViewerStore {
   panelScanMap: Record<string, string>;
   /** Maps panel IDs to their loaded session label (for per-viewport overlay context). */
   panelSessionLabelMap: Record<string, string>;
+  /** Maps panel IDs to subject labels (e.g., panel-0 → "SUBJ001"). */
+  panelSubjectLabelMap: Record<string, string>;
+  /** Maps panel IDs to their loaded imageId arrays. */
+  panelImageIdsMap: Record<string, string[]>;
+
+  // ─── Per-Panel Orientation State ───────────────────────────────
+  /** Current viewing orientation per panel (STACK = original, or AXIAL/SAGITTAL/CORONAL). */
+  panelOrientationMap: Record<string, ViewportOrientation>;
+  /** Native acquisition orientation per panel (detected from DICOM metadata). */
+  panelNativeOrientationMap: Record<string, ViewportOrientation>;
+
+  // ─── Crosshair State ──────────────────────────────────────────
+  /** World-space crosshair coordinate synced across viewports. */
+  crosshairWorldPoint: CsTypes.Point3 | null;
+  /** Panel that originated the crosshair position. */
+  crosshairSourcePanelId: string | null;
 
   // ─── MPR State ─────────────────────────────────────────────────
   mprActive: boolean;
@@ -104,6 +122,16 @@ interface ViewerStore {
   setPanelScan: (panelId: string, scanId: string) => void;
   /** Record which XNAT session label is associated with a given panel */
   setPanelSessionLabel: (panelId: string, sessionLabel: string) => void;
+  /** Record subject label for a panel. */
+  setPanelSubjectLabel: (panelId: string, subjectLabel: string) => void;
+  /** Record imageIds loaded in a panel. */
+  setPanelImageIds: (panelId: string, imageIds: string[]) => void;
+  /** Set viewing orientation for a panel. */
+  setPanelOrientation: (panelId: string, orientation: ViewportOrientation) => void;
+  /** Set native acquisition orientation for a panel. */
+  setPanelNativeOrientation: (panelId: string, orientation: ViewportOrientation) => void;
+  /** Set crosshair world point and source panel. */
+  setCrosshairWorldPoint: (point: CsTypes.Point3 | null, sourcePanelId: string | null) => void;
 
   // ─── Tool / Viewport Actions (target active viewport) ────────
   setActiveTool: (tool: ToolName) => void;
@@ -159,6 +187,12 @@ export const useViewerStore = create<ViewerStore>((set, get) => ({
   panelXnatContextMap: {},
   panelScanMap: {},
   panelSessionLabelMap: {},
+  panelSubjectLabelMap: {},
+  panelImageIdsMap: {},
+  panelOrientationMap: {},
+  panelNativeOrientationMap: {},
+  crosshairWorldPoint: null,
+  crosshairSourcePanelId: null,
   mprActive: false,
   mprVolumeId: null,
   mprSourcePanelId: null,
@@ -222,6 +256,29 @@ export const useViewerStore = create<ViewerStore>((set, get) => ({
     set(updates);
   },
 
+  setPanelSubjectLabel: (pid, subjectLabel) =>
+    set((s) => ({
+      panelSubjectLabelMap: { ...s.panelSubjectLabelMap, [pid]: subjectLabel },
+    })),
+
+  setPanelImageIds: (pid, imageIds) =>
+    set((s) => ({
+      panelImageIdsMap: { ...s.panelImageIdsMap, [pid]: imageIds },
+    })),
+
+  setPanelOrientation: (pid, orientation) =>
+    set((s) => ({
+      panelOrientationMap: { ...s.panelOrientationMap, [pid]: orientation },
+    })),
+
+  setPanelNativeOrientation: (pid, orientation) =>
+    set((s) => ({
+      panelNativeOrientationMap: { ...s.panelNativeOrientationMap, [pid]: orientation },
+    })),
+
+  setCrosshairWorldPoint: (point, sourcePanelId) =>
+    set({ crosshairWorldPoint: point, crosshairSourcePanelId: sourcePanelId }),
+
   // ─── Layout Actions ────────────────────────────────────────────
 
   setLayout: (layout) => {
@@ -242,6 +299,10 @@ export const useViewerStore = create<ViewerStore>((set, get) => ({
     const newPanelScanMap: Record<string, string> = {};
     const newPanelSessionLabelMap: Record<string, string> = {};
     const newPanelXnatContextMap: Record<string, XnatUploadContext> = {};
+    const newPanelSubjectLabelMap: Record<string, string> = {};
+    const newPanelImageIdsMap: Record<string, string[]> = {};
+    const newPanelOrientationMap: Record<string, ViewportOrientation> = {};
+    const newPanelNativeOrientationMap: Record<string, ViewportOrientation> = {};
     for (const pid of newPanelIds) {
       newViewports[pid] = state.viewports[pid] ?? { ...INITIAL_VIEWPORT };
       newCineStates[pid] = state.cineStates[pid] ?? { ...INITIAL_CINE };
@@ -253,6 +314,18 @@ export const useViewerStore = create<ViewerStore>((set, get) => ({
       }
       if (state.panelXnatContextMap[pid]) {
         newPanelXnatContextMap[pid] = state.panelXnatContextMap[pid];
+      }
+      if (state.panelSubjectLabelMap[pid]) {
+        newPanelSubjectLabelMap[pid] = state.panelSubjectLabelMap[pid];
+      }
+      if (state.panelImageIdsMap[pid]) {
+        newPanelImageIdsMap[pid] = state.panelImageIdsMap[pid];
+      }
+      if (state.panelOrientationMap[pid]) {
+        newPanelOrientationMap[pid] = state.panelOrientationMap[pid];
+      }
+      if (state.panelNativeOrientationMap[pid]) {
+        newPanelNativeOrientationMap[pid] = state.panelNativeOrientationMap[pid];
       }
       // Mark cine as not playing for removed panels that got stopped
       if (!newPanelIds.has(pid) && newCineStates[pid]) {
@@ -291,6 +364,10 @@ export const useViewerStore = create<ViewerStore>((set, get) => ({
       panelScanMap: newPanelScanMap,
       panelSessionLabelMap: newPanelSessionLabelMap,
       panelXnatContextMap: newPanelXnatContextMap,
+      panelSubjectLabelMap: newPanelSubjectLabelMap,
+      panelImageIdsMap: newPanelImageIdsMap,
+      panelOrientationMap: newPanelOrientationMap,
+      panelNativeOrientationMap: newPanelNativeOrientationMap,
     });
   },
 
@@ -316,6 +393,10 @@ export const useViewerStore = create<ViewerStore>((set, get) => ({
     const newPanelScanMap: Record<string, string> = {};
     const newPanelSessionLabelMap: Record<string, string> = {};
     const newPanelXnatContextMap: Record<string, XnatUploadContext> = {};
+    const newPanelSubjectLabelMap: Record<string, string> = {};
+    const newPanelImageIdsMap: Record<string, string[]> = {};
+    const newPanelOrientationMap: Record<string, ViewportOrientation> = {};
+    const newPanelNativeOrientationMap: Record<string, ViewportOrientation> = {};
     for (const pid of newPanelIds) {
       newViewports[pid] = state.viewports[pid] ?? { ...INITIAL_VIEWPORT };
       newCineStates[pid] = state.cineStates[pid] ?? { ...INITIAL_CINE };
@@ -327,6 +408,18 @@ export const useViewerStore = create<ViewerStore>((set, get) => ({
       }
       if (state.panelXnatContextMap[pid]) {
         newPanelXnatContextMap[pid] = state.panelXnatContextMap[pid];
+      }
+      if (state.panelSubjectLabelMap[pid]) {
+        newPanelSubjectLabelMap[pid] = state.panelSubjectLabelMap[pid];
+      }
+      if (state.panelImageIdsMap[pid]) {
+        newPanelImageIdsMap[pid] = state.panelImageIdsMap[pid];
+      }
+      if (state.panelOrientationMap[pid]) {
+        newPanelOrientationMap[pid] = state.panelOrientationMap[pid];
+      }
+      if (state.panelNativeOrientationMap[pid]) {
+        newPanelNativeOrientationMap[pid] = state.panelNativeOrientationMap[pid];
       }
     }
 
@@ -360,6 +453,10 @@ export const useViewerStore = create<ViewerStore>((set, get) => ({
       panelScanMap: newPanelScanMap,
       panelSessionLabelMap: newPanelSessionLabelMap,
       panelXnatContextMap: newPanelXnatContextMap,
+      panelSubjectLabelMap: newPanelSubjectLabelMap,
+      panelImageIdsMap: newPanelImageIdsMap,
+      panelOrientationMap: newPanelOrientationMap,
+      panelNativeOrientationMap: newPanelNativeOrientationMap,
     });
   },
 
@@ -577,16 +674,9 @@ export const useViewerStore = create<ViewerStore>((set, get) => ({
 
   exitMPR: () => {
     const state = get();
+    const volumeIdToDestroy = state.mprVolumeId;
 
-    // Destroy volume from cache
-    if (state.mprVolumeId) {
-      volumeService.destroy(state.mprVolumeId);
-    }
-
-    // Destroy MPR tool group
-    mprToolService.destroy();
-
-    // Restore prior state
+    // Restore prior state FIRST (toggle off mprActive so viewports unmount)
     const prior = state.mprPriorState;
 
     set({
@@ -604,9 +694,17 @@ export const useViewerStore = create<ViewerStore>((set, get) => ({
       } : {}),
     });
 
+    // Destroy MPR tool group AFTER toggling off mprActive
+    mprToolService.destroy();
+
     // Restore tool activation in the stack tool group
     if (prior) {
       toolService.setActiveTool(prior.activeTool);
+    }
+
+    // Defer volume destruction so viewports can unmount cleanly first
+    if (volumeIdToDestroy) {
+      setTimeout(() => volumeService.destroy(volumeIdToDestroy), 100);
     }
 
     console.log('[viewerStore] Exited MPR mode');

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -8,3 +8,9 @@ html, body, #root {
   padding: 0;
   overflow: hidden;
 }
+
+.crosshair-mode [data-panel-id],
+.crosshair-mode [data-panel-id] *,
+.crosshair-mode [data-panel-id] canvas {
+  cursor: crosshair !important;
+}

--- a/src/shared/types/hotkeys.ts
+++ b/src/shared/types/hotkeys.ts
@@ -50,6 +50,7 @@ export type HotkeyAction =
   // Panel toggles
   | 'panel.toggleAnnotations'
   | 'panel.toggleSegmentation'
+  | 'panel.nextViewport'
   // Brush size
   | 'brush.decrease'
   | 'brush.increase'

--- a/src/shared/types/viewer.ts
+++ b/src/shared/types/viewer.ts
@@ -208,6 +208,9 @@ export function mprPanelId(index: number): string {
 /** Orientation axis for MPR planes */
 export type MPRPlane = 'AXIAL' | 'SAGITTAL' | 'CORONAL';
 
+/** Per-viewport viewing orientation (stack/original or orthographic plane) */
+export type ViewportOrientation = 'STACK' | MPRPlane;
+
 /** Fixed MPR panel assignments: 3 orthogonal planes */
 export const MPR_PANELS: { panelIndex: number; plane: MPRPlane; label: string }[] = [
   { panelIndex: 0, plane: 'AXIAL', label: 'Axial' },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,11 +39,18 @@ export default defineConfig({
   optimizeDeps: {
     // dicom-image-loader MUST be excluded — if Vite pre-bundles it,
     // the internal import.meta.url-based worker creation breaks.
-    exclude: ['@cornerstonejs/dicom-image-loader'],
+    // polymorphic-segmentation MUST be excluded so its worker URL
+    // (`./workers/polySegConverters.js`) resolves from package files, not
+    // from optimize-deps virtual output.
+    exclude: ['@cornerstonejs/dicom-image-loader', '@cornerstonejs/polymorphic-segmentation'],
     include: [
       '@cornerstonejs/core',
       '@cornerstonejs/tools',
       'dicom-parser',
+      // Keep CJS interop explicit for ToolGroup dependencies.
+      'lodash.get',
+      // Ensure vtk.js dependency graph is optimized for browser ESM/CJS interop.
+      '@kitware/vtk.js',
       // Codec packages are CJS/UMD — must be pre-bundled for ESM default-export interop.
       // They're transitive deps of dicom-image-loader (which itself must stay excluded).
       '@cornerstonejs/codec-libjpeg-turbo-8bit/decodewasmjs',


### PR DESCRIPTION
…el segmentation

Port orientation/crosshair features from select-orientation branch onto layered-seg, adapting them to work with the multi-layer sub-segmentation group system.

New capabilities:
- Per-viewport orientation dropdown (Axial/Sagittal/Coronal) with OrientedViewport
- Shift-click scan in XNAT browser opens 2x2 grid with all three planes + stack
- Crosshair tool with synchronized green guide lines across viewports
- Tab key cycles active viewport clockwise through grid panels
- Automatic stack-to-volume labelmap conversion for segments in oriented views
- Cross-panel segmentation visibility for panels showing the same source scan