### PR TITLE
Fix RTSTRUCT creation, export, and detection

### DIFF
--- a/src/renderer/lib/cornerstone/init.ts
+++ b/src/renderer/lib/cornerstone/init.ts
@@ -33,6 +33,7 @@ import {
   LabelMapEditWithContourTool,
 } from '@cornerstonejs/tools';
 import SafePaintFillTool from './tools/SafePaintFillTool';
+import { utilities as csToolsUtilities } from '@cornerstonejs/tools';
 import { init as initDicomImageLoader } from '@cornerstonejs/dicom-image-loader';
 
 let initialized = false;
@@ -94,6 +95,15 @@ export async function initCornerstone(): Promise<void> {
   addTool(LivewireContourSegmentationTool);
   addTool(SculptorTool);
   addTool(LabelMapEditWithContourTool);
+
+  // SplineContourSegmentationTool inherits getContourSequence from
+  // ContourBaseTool but doesn't self-register with AnnotationToPointData
+  // (unlike PlanarFreehand and Livewire which do). Without registration,
+  // RTSTRUCT export throws "Unknown tool type" for spline annotations.
+  const { AnnotationToPointData } = csToolsUtilities.contours;
+  if (AnnotationToPointData && !AnnotationToPointData.TOOL_NAMES[SplineContourSegmentationTool.toolName]) {
+    AnnotationToPointData.register(SplineContourSegmentationTool);
+  }
 
   // Segmentation tools — smart/AI (GrowCut)
   addTool(RegionSegmentTool);

--- a/src/renderer/lib/cornerstone/segmentationService.ts
+++ b/src/renderer/lib/cornerstone/segmentationService.ts
@@ -1546,8 +1546,10 @@ export const segmentationService = {
 
   /**
    * Add a new segment to an existing segmentation.
-   * Creates an independent sub-segmentation with its own binary labelmap
-   * images so segments can overlap.
+   * For multi-layer groups: creates an independent sub-segmentation with its
+   * own binary labelmap images so segments can overlap.
+   * For contour segmentations (RTSTRUCT): adds a segment entry to the
+   * Cornerstone segmentation state and annotation map.
    * Returns the new segment index (1-based).
    */
   addSegment(
@@ -1555,6 +1557,59 @@ export const segmentationService = {
     label: string,
     color?: [number, number, number, number],
   ): number {
+    // ─── Contour (RTSTRUCT) path ─────────────────────────────
+    const segType = getSegmentationType(segmentationId);
+    if (segType === 'contour') {
+      const seg = csSegmentation.state.getSegmentation(segmentationId);
+      if (!seg) throw new Error(`[segmentationService] Segmentation not found: ${segmentationId}`);
+
+      // Determine next index from existing segments
+      const existingIndices = seg.segments
+        ? Object.keys(seg.segments).map(Number).filter((n) => n > 0)
+        : [];
+      const nextIndex = existingIndices.length > 0
+        ? Math.max(...existingIndices) + 1
+        : 1;
+      const segLabel = label.trim() || `Structure ${nextIndex}`;
+      const segColor = color || DEFAULT_COLORS[(nextIndex - 1) % DEFAULT_COLORS.length];
+
+      // Add segment entry to Cornerstone's segmentation state
+      if (!seg.segments) (seg as any).segments = {};
+      (seg.segments as any)[nextIndex] = {
+        segmentIndex: nextIndex,
+        label: segLabel,
+        locked: false,
+        active: true,
+        cachedStats: {},
+      };
+
+      // Ensure contour annotation map has an entry for this segment
+      const contourData = (seg.representationData as any)?.Contour;
+      if (contourData?.annotationUIDsMap instanceof Map) {
+        if (!contourData.annotationUIDsMap.has(nextIndex)) {
+          contourData.annotationUIDsMap.set(nextIndex, new Set<string>());
+        }
+      }
+
+      // Set active segment index in Cornerstone
+      csSegmentation.segmentIndex.setActiveSegmentIndex(segmentationId, nextIndex);
+
+      // Apply color on all viewports showing this segmentation
+      const vpIds = csSegmentation.state.getViewportIdsWithSegmentation(segmentationId);
+      for (const vpId of vpIds) {
+        try {
+          csSegmentation.config.color.setSegmentIndexColor(
+            vpId, segmentationId, nextIndex, segColor as any,
+          );
+        } catch { /* viewport may be detached */ }
+      }
+
+      console.log(`[segmentationService] Added contour segment ${nextIndex} to ${segmentationId}: "${segLabel}"`);
+      syncSegmentations();
+      return nextIndex;
+    }
+
+    // ─── Multi-layer group (SEG) path ────────────────────────
     if (!isMultiLayerGroup(segmentationId)) {
       throw new Error(`[segmentationService] Not a multi-layer group: ${segmentationId}`);
     }

--- a/src/renderer/lib/cornerstone/toolService.ts
+++ b/src/renderer/lib/cornerstone/toolService.ts
@@ -539,7 +539,14 @@ export const toolService = {
           if (imageIds && imageIds.length > 0) {
             // Create segmentation first, then activate the tool.
             // Use segmentationManager for cross-panel attachment.
-            segmentationManager.createNewSegmentation(viewportId, imageIds, undefined, true).then(async (segId) => {
+            // Contour tools get a contour (RTSTRUCT) segmentation;
+            // labelmap tools get a multi-layer (SEG) segmentation.
+            const isContourTool = CONTOUR_SEG_TOOLS.has(toolName);
+            const createPromise = isContourTool
+              ? segmentationManager.createNewStructure(viewportId, imageIds, undefined)
+              : segmentationManager.createNewSegmentation(viewportId, imageIds, undefined, true);
+
+            createPromise.then(async (segId) => {
               // Track local unsaved origin so auto-save/save targets stay bound
               // to the source scan even if the user changes panels before saving.
               const viewerState = useViewerStore.getState();
@@ -559,16 +566,17 @@ export const toolService = {
               }
 
               if (segId) {
-                // Keep active segment index valid for cursor/LUT resolution.
-                // Eraser behavior is controlled by Brush strategy, not segment index 0.
-                const paintIdx = getSafePaintSegmentIndex(
-                  useSegmentationStore.getState().activeSegmentIndex,
-                );
-                segmentationService.setActiveSegmentIndex(segId, paintIdx);
-
-                // Ensure contour representation for contour tools
-                if (CONTOUR_SEG_TOOLS.has(toolName)) {
+                if (isContourTool) {
+                  // Contour: add a default structure and ensure representation
+                  segmentationService.addSegment(segId, 'Structure 1');
+                  segmentationService.setActiveSegmentIndex(segId, 1);
                   await segmentationService.ensureContourRepresentation(viewportId, segId);
+                } else {
+                  // Labelmap: keep active segment index valid for cursor/LUT resolution.
+                  const paintIdx = getSafePaintSegmentIndex(
+                    useSegmentationStore.getState().activeSegmentIndex,
+                  );
+                  segmentationService.setActiveSegmentIndex(segId, paintIdx);
                 }
               }
 

--- a/src/renderer/stores/sessionDerivedIndexStore.ts
+++ b/src/renderer/stores/sessionDerivedIndexStore.ts
@@ -27,6 +27,7 @@ const RTSTRUCT_SOP_CLASS_UID = '1.2.840.10008.5.1.4.1.1.481.3';
 const XSI_SEG = 'xnat:segscandata';
 const XSI_SR = 'xnat:srscandata';
 const XSI_OTHER_DICOM = 'xnat:otherdicomscandata';
+const XSI_RT_IMAGE = 'xnat:rtimagescandata';
 
 function norm(value: string | undefined): string {
   return (value ?? '').trim().toLowerCase();
@@ -42,6 +43,9 @@ export function isSegScan(scan: XnatScan): boolean {
 export function isRtStructScan(scan: XnatScan): boolean {
   const xsiType = norm(scan.xsiType);
   if (scan.sopClassUID === RTSTRUCT_SOP_CLASS_UID) return true;
+
+  // Our uploads create scans with xnat:rtImageScanData — recognise this directly.
+  if (xsiType === XSI_RT_IMAGE) return true;
 
   // Metadata-first path requested by product:
   // RTSTRUCT rows are expected to arrive as xnat:otherDicomScanData.
@@ -60,6 +64,12 @@ export function isRtStructScan(scan: XnatScan): boolean {
       desc.includes('structure set')
     );
   }
+
+  // Fallback: type/description heuristics regardless of xsiType, so that
+  // scans created by external tools with unexpected xsiTypes are still caught.
+  const type = norm(scan.type);
+  if (type === 'rtstruct' || type === 'rt structure set') return true;
+
   return false;
 }
 


### PR DESCRIPTION
## Summary
- **RTSTRUCT creation fixed**: `addSegment()` now handles contour segmentations before the multi-layer group guard, so adding structure segments no longer throws
- **Contour tool auto-create fixed**: Activating a contour tool (Freehand/Spline/Livewire) with no existing segmentation now creates an RTSTRUCT instead of a labelmap SEG
- **Spline export fixed**: `SplineContourSegmentationTool` registered with `AnnotationToPointData` so spline annotations export correctly to DICOM RTSTRUCT
- **Post-upload detection fixed**: `isRtStructScan()` now recognises `xnat:rtImageScanData` xsiType, so uploaded RTSTRUCTs appear in the browser pane and annotation panel

## Test plan
- [ ] Create a new structure via the "+" button → naming dialog → confirm → structure appears in panel
- [ ] Add structure segments via "Add Structure" → segments listed with distinct colors
- [ ] Draw contours with Freehand, Spline, and Livewire tools → contours render correctly
- [ ] Save RTSTRUCT to XNAT → all segments present in saved file
- [ ] After save, RTSTRUCT appears linked to the source scan in the browser pane
- [ ] RTSTRUCT shows in the annotation panel for the scan
- [ ] Activate a contour tool with no segmentation → auto-creates RTSTRUCT (not SEG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)