### PR TITLE
Add interpolation preferences and algorithm selection

### DIFF
--- a/src/renderer/components/settings/SettingsModal.tsx
+++ b/src/renderer/components/settings/SettingsModal.tsx
@@ -1,11 +1,15 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { HotkeyAction, HotkeyBinding, HotkeyModifiers } from '@shared/types/hotkeys';
-import type { OverlayCornerId, OverlayFieldKey } from '@shared/types/preferences';
+import type { OverlayCornerId, OverlayFieldKey, InterpolationAlgorithm } from '@shared/types/preferences';
+import {
+  INTERPOLATION_ALGORITHM_LABELS,
+  INTERPOLATION_ALGORITHM_DESCRIPTIONS,
+} from '@shared/types/preferences';
 import { DEFAULT_HOTKEY_MAP } from '../../lib/hotkeys/defaultHotkeyMap';
 import { usePreferencesStore } from '../../stores/preferencesStore';
 import { IconClose } from '../icons';
 
-type SettingsTab = 'hotkeys' | 'overlay';
+type SettingsTab = 'hotkeys' | 'overlay' | 'interpolation';
 
 interface SettingsModalProps {
   open: boolean;
@@ -15,6 +19,7 @@ interface SettingsModalProps {
 const TAB_ITEMS: Array<{ id: SettingsTab; label: string }> = [
   { id: 'hotkeys', label: 'Hotkeys' },
   { id: 'overlay', label: 'Overlay' },
+  { id: 'interpolation', label: 'Interpolation' },
 ];
 
 const CORNER_OPTIONS: Array<{
@@ -121,6 +126,7 @@ function bindingToDraft(binding: HotkeyBinding): { key: string; modifiers: Requi
 export default function SettingsModal({ open, onClose }: SettingsModalProps) {
   const overrides = usePreferencesStore((s) => s.preferences.hotkeys.overrides);
   const overlayPrefs = usePreferencesStore((s) => s.preferences.overlay);
+  const interpPrefs = usePreferencesStore((s) => s.preferences.interpolation);
   const setHotkeyOverride = usePreferencesStore((s) => s.setHotkeyOverride);
   const clearHotkeyOverride = usePreferencesStore((s) => s.clearHotkeyOverride);
   const resetHotkeys = usePreferencesStore((s) => s.resetHotkeys);
@@ -129,6 +135,9 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
   const setShowOverlayVerticalRuler = usePreferencesStore((s) => s.setShowOverlayVerticalRuler);
   const setShowOverlayOrientationMarkers = usePreferencesStore((s) => s.setShowOverlayOrientationMarkers);
   const setOverlayCornerField = usePreferencesStore((s) => s.setOverlayCornerField);
+  const setInterpolationEnabled = usePreferencesStore((s) => s.setInterpolationEnabled);
+  const setInterpolationAlgorithm = usePreferencesStore((s) => s.setInterpolationAlgorithm);
+  const setLinearThreshold = usePreferencesStore((s) => s.setLinearThreshold);
   const resetAll = usePreferencesStore((s) => s.resetAll);
 
   const actionOptions = useMemo(() => {
@@ -452,6 +461,78 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
                       </div>
                     </div>
                   ))}
+                </div>
+              </>
+            )}
+
+            {activeTab === 'interpolation' && (
+              <>
+                <div className="text-xs text-zinc-400">
+                  Configure between-slice interpolation for labelmap segmentations. When enabled,
+                  painting on two or more separated slices will automatically fill the gap slices
+                  using the selected algorithm.
+                </div>
+
+                <div className="rounded-lg border border-zinc-800 bg-zinc-950/40 p-4 space-y-4">
+                  {/* Enable toggle */}
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={interpPrefs.enabled}
+                      onChange={(e) => setInterpolationEnabled(e.target.checked)}
+                      className="w-3.5 h-3.5 rounded border-zinc-600 bg-zinc-800 accent-blue-500"
+                    />
+                    <span className="text-xs text-zinc-300">Enable between-slice interpolation</span>
+                  </label>
+
+                  {/* Algorithm selector */}
+                  <label className="space-y-1">
+                    <span className="text-[11px] text-zinc-500">Algorithm</span>
+                    <select
+                      value={interpPrefs.algorithm}
+                      onChange={(e) =>
+                        setInterpolationAlgorithm(e.target.value as InterpolationAlgorithm)
+                      }
+                      disabled={!interpPrefs.enabled}
+                      className="w-full bg-zinc-800 border border-zinc-700 rounded px-2 py-1.5 text-xs text-zinc-200 disabled:opacity-50"
+                    >
+                      {(Object.keys(INTERPOLATION_ALGORITHM_LABELS) as InterpolationAlgorithm[]).map(
+                        (algo) => (
+                          <option key={algo} value={algo}>
+                            {INTERPOLATION_ALGORITHM_LABELS[algo]}
+                          </option>
+                        ),
+                      )}
+                    </select>
+                  </label>
+
+                  {/* Algorithm description */}
+                  <p className="text-[11px] text-zinc-500 leading-relaxed">
+                    {INTERPOLATION_ALGORITHM_DESCRIPTIONS[interpPrefs.algorithm]}
+                  </p>
+
+                  {/* Linear threshold — only shown for 'linear' algorithm */}
+                  {interpPrefs.algorithm === 'linear' && (
+                    <div className="space-y-1.5">
+                      <label className="text-[11px] text-zinc-500 block">
+                        Blend Threshold: {interpPrefs.linearThreshold.toFixed(2)}
+                      </label>
+                      <input
+                        type="range"
+                        min="0"
+                        max="1"
+                        step="0.05"
+                        value={interpPrefs.linearThreshold}
+                        onChange={(e) => setLinearThreshold(parseFloat(e.target.value))}
+                        disabled={!interpPrefs.enabled}
+                        className="w-full h-1.5 bg-zinc-700 rounded-lg appearance-none cursor-pointer accent-blue-500 disabled:opacity-50"
+                      />
+                      <div className="flex justify-between text-[10px] text-zinc-600">
+                        <span>0.0 (aggressive fill)</span>
+                        <span>1.0 (conservative)</span>
+                      </div>
+                    </div>
+                  )}
                 </div>
               </>
             )}

--- a/src/renderer/components/viewer/SegmentationPanel.tsx
+++ b/src/renderer/components/viewer/SegmentationPanel.tsx
@@ -16,7 +16,6 @@ import {
 } from '../../stores/sessionDerivedIndexStore';
 import { segmentationService } from '../../lib/cornerstone/segmentationService';
 import { rtStructService } from '../../lib/cornerstone/rtStructService';
-import { toolService } from '../../lib/cornerstone/toolService';
 import { segmentationManager } from '../../lib/segmentation/segmentationManagerSingleton';
 import { dicomwebLoader } from '../../lib/cornerstone/dicomwebLoader';
 import { ToolName, TOOL_DISPLAY_NAMES, SEGMENTATION_TOOLS } from '@shared/types/viewer';
@@ -236,7 +235,6 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
   const renderOutline = useSegmentationStore((s) => s.renderOutline);
   const contourLineWidth = useSegmentationStore((s) => s.contourLineWidth);
   const contourOpacity = useSegmentationStore((s) => s.contourOpacity);
-  const interpolationEnabled = useSegmentationStore((s) => s.interpolationEnabled);
   const brushSize = useSegmentationStore((s) => s.brushSize);
   const activeSegTool = useSegmentationStore((s) => s.activeSegTool);
   const thresholdRange = useSegmentationStore((s) => s.thresholdRange);
@@ -615,6 +613,8 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
         ? await segmentationManager.createNewStructure(activeViewportId, sourceImageIds, name)
         : await segmentationManager.createNewSegmentation(activeViewportId, sourceImageIds, name);
       setDicomType(segId, pendingCreateType);
+      // Set as the active segmentation so subsequent tool activation finds it
+      useSegmentationStore.getState().setActiveSegmentation(segId);
       // Auto-expand the new segmentation
       setExpandedIds((prev) => new Set(prev).add(segId));
       // Track the source scan ID so auto-save targets the correct scan even
@@ -667,6 +667,8 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
     }
     try {
       await segmentationManager.addSegment(segmentNamingDialog.segmentationId, finalName);
+      // Ensure the parent segmentation is active so tool activation finds it
+      useSegmentationStore.getState().setActiveSegmentation(segmentNamingDialog.segmentationId);
     } catch (err) {
       setToast({ message: getErrorMessage(err, 'Failed to add segment'), type: 'error' });
       return;
@@ -757,9 +759,6 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
     [setContourOpacity],
   );
 
-  const handleInterpolationToggle = useCallback((enabled: boolean) => {
-    toolService.setInterpolationEnabled(enabled);
-  }, []);
 
   const handleColorSelect = useCallback(
     (color: [number, number, number, number]) => {
@@ -1818,20 +1817,6 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
               className="w-3 h-3 rounded border-zinc-600 bg-zinc-800 accent-blue-500"
             />
             <span className="text-[10px] text-zinc-400">Show Outline</span>
-          </label>
-        )}
-
-        {toolPanelAnnotationType && (
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={interpolationEnabled}
-              onChange={(e) => handleInterpolationToggle(e.target.checked)}
-              className="w-3 h-3 rounded border-zinc-600 bg-zinc-800 accent-blue-500"
-            />
-            <span className="text-[10px] text-zinc-400">
-              Interpolate between slices
-            </span>
           </label>
         )}
 

--- a/src/renderer/lib/cornerstone/segmentationService.ts
+++ b/src/renderer/lib/cornerstone/segmentationService.ts
@@ -49,6 +49,7 @@ import { adaptersSEG, utilities as adaptersUtilities } from '@cornerstonejs/adap
 // Cornerstone core utilities and reference it below to prevent tree-shaking.
 void adaptersUtilities;
 import { data as dcmjsData } from 'dcmjs';
+import { usePreferencesStore } from '../../stores/preferencesStore';
 import { useSegmentationStore } from '../../stores/segmentationStore';
 import type { SegmentationSummary, SegmentSummary } from '../../stores/segmentationStore';
 import { useViewerStore } from '../../stores/viewerStore';
@@ -144,6 +145,22 @@ const groupDimensionsMap = new Map<string, GroupDimensions>();
 /** Group label storage (separate from segments). */
 const groupLabelMap = new Map<string, string>();
 
+/**
+ * Viewport attachment tracking for multi-layer groups.
+ * Records which viewports a group was added to via addToViewport(),
+ * even before any sub-segs exist. Without this, the first addSegment()
+ * cannot discover the target viewports because findViewportsWithGroup()
+ * iterates sub-segs — which are empty until the first segment is created.
+ */
+const groupViewportAttachments = new Map<string, Set<string>>();
+
+/**
+ * Background metadata pre-load promises per group.
+ * Started in createStackSegmentation() and awaited lazily in addSegment()
+ * so the UI doesn't block on first creation.
+ */
+const metadataPreloadPromises = new Map<string, Promise<void>>();
+
 /** Returns true if a segmentationId is a multi-layer group. */
 function isMultiLayerGroup(segmentationId: string): boolean {
   return subSegGroupMap.has(segmentationId);
@@ -170,6 +187,15 @@ function findViewportsWithGroup(groupId: string): string[] {
   for (const subSegId of subSegIds) {
     for (const vpId of csSegmentation.state.getViewportIdsWithSegmentation(subSegId)) {
       vpSet.add(vpId);
+    }
+  }
+  // Fall back to recorded viewport attachments — the group may have been added
+  // to viewports before any sub-segs existed (e.g. panel-created segmentations
+  // where the first segment is added separately).
+  if (vpSet.size === 0) {
+    const recorded = groupViewportAttachments.get(groupId);
+    if (recorded) {
+      for (const vpId of recorded) vpSet.add(vpId);
     }
   }
   return Array.from(vpSet);
@@ -487,43 +513,85 @@ function hasSegmentPixelsOnSlice(
   return false;
 }
 
-function chamferDistanceToMask(
+/**
+ * 1-D squared-Euclidean distance transform (Felzenszwalb–Huttenlocher).
+ * Operates in-place on `f` which contains 0 for mask pixels and +Inf for
+ * non-mask pixels. On output `f[i]` = squared Euclidean distance to the
+ * nearest mask pixel along this 1-D scanline.
+ *
+ * Reference: P. Felzenszwalb & D. Huttenlocher, "Distance Transforms of
+ *            Sampled Functions", Theory of Computing 8 (2012), 415–428.
+ */
+function edt1d(f: Float64Array, n: number): void {
+  const v = new Int32Array(n);   // locations of parabolas in lower envelope
+  const z = new Float64Array(n + 1); // boundaries between parabolas
+  let k = 0;
+  v[0] = 0;
+  z[0] = -Infinity;
+  z[1] = Infinity;
+
+  for (let q = 1; q < n; q++) {
+    let s = ((f[q] + q * q) - (f[v[k]] + v[k] * v[k])) / (2 * q - 2 * v[k]);
+    while (s <= z[k]) {
+      k--;
+      s = ((f[q] + q * q) - (f[v[k]] + v[k] * v[k])) / (2 * q - 2 * v[k]);
+    }
+    k++;
+    v[k] = q;
+    z[k] = s;
+    z[k + 1] = Infinity;
+  }
+
+  k = 0;
+  for (let q = 0; q < n; q++) {
+    while (z[k + 1] < q) k++;
+    const dq = q - v[k];
+    f[q] = dq * dq + f[v[k]];
+  }
+}
+
+/**
+ * Exact 2-D Euclidean Distance Transform using separable 1-D transforms.
+ * Returns a Float32Array of Euclidean distances (not squared) from each
+ * non-mask pixel to the nearest mask pixel. Mask pixels get distance 0.
+ */
+function euclideanDistanceToMask(
   mask: Uint8Array,
   width: number,
   height: number,
 ): Float32Array {
-  const dist = new Float32Array(mask.length);
-  for (let i = 0; i < mask.length; i++) {
-    dist[i] = mask[i] ? 0 : 1e12;
+  const INF = 1e20;
+  const size = width * height;
+
+  // Working buffer holds squared distances.
+  const grid = new Float64Array(size);
+  for (let i = 0; i < size; i++) {
+    grid[i] = mask[i] ? 0 : INF;
   }
 
+  // Transform columns (along Y for each X).
+  const col = new Float64Array(height);
+  for (let x = 0; x < width; x++) {
+    for (let y = 0; y < height; y++) col[y] = grid[y * width + x];
+    edt1d(col, height);
+    for (let y = 0; y < height; y++) grid[y * width + x] = col[y];
+  }
+
+  // Transform rows (along X for each Y).
+  const row = new Float64Array(width);
   for (let y = 0; y < height; y++) {
-    const row = y * width;
-    for (let x = 0; x < width; x++) {
-      const i = row + x;
-      let best = dist[i];
-      if (x > 0) best = Math.min(best, dist[i - 1] + 1);
-      if (y > 0) best = Math.min(best, dist[i - width] + 1);
-      if (x > 0 && y > 0) best = Math.min(best, dist[i - width - 1] + Math.SQRT2);
-      if (x + 1 < width && y > 0) best = Math.min(best, dist[i - width + 1] + Math.SQRT2);
-      dist[i] = best;
-    }
+    const off = y * width;
+    for (let x = 0; x < width; x++) row[x] = grid[off + x];
+    edt1d(row, width);
+    for (let x = 0; x < width; x++) grid[off + x] = row[x];
   }
 
-  for (let y = height - 1; y >= 0; y--) {
-    const row = y * width;
-    for (let x = width - 1; x >= 0; x--) {
-      const i = row + x;
-      let best = dist[i];
-      if (x + 1 < width) best = Math.min(best, dist[i + 1] + 1);
-      if (y + 1 < height) best = Math.min(best, dist[i + width] + 1);
-      if (x + 1 < width && y + 1 < height) best = Math.min(best, dist[i + width + 1] + Math.SQRT2);
-      if (x > 0 && y + 1 < height) best = Math.min(best, dist[i + width - 1] + Math.SQRT2);
-      dist[i] = best;
-    }
+  // Take square root → Euclidean distance.
+  const result = new Float32Array(size);
+  for (let i = 0; i < size; i++) {
+    result[i] = Math.sqrt(grid[i]);
   }
-
-  return dist;
+  return result;
 }
 
 function buildSignedDistanceForSegment(
@@ -542,8 +610,8 @@ function buildSignedDistanceForSegment(
     outside[i] = isInside ? 0 : 1;
   }
 
-  const distToInside = chamferDistanceToMask(inside, width, height);
-  const distToOutside = chamferDistanceToMask(outside, width, height);
+  const distToInside = euclideanDistanceToMask(inside, width, height);
+  const distToOutside = euclideanDistanceToMask(outside, width, height);
   const signed = new Float32Array(size);
 
   for (let i = 0; i < size; i++) {
@@ -551,6 +619,136 @@ function buildSignedDistanceForSegment(
   }
 
   return signed;
+}
+
+// ─── Interpolation Algorithm Implementations ─────────────────────
+
+/**
+ * Build an "inside distance" field for the Raya-Udupa morphological algorithm.
+ * Returns a Float32Array where inside pixels hold their Euclidean distance
+ * to the nearest boundary (>0), and outside/boundary pixels hold 0.
+ */
+function buildInsideDistanceField(
+  scalarData: ArrayLike<number>,
+  width: number,
+  height: number,
+  segmentIndex: number,
+): Float32Array {
+  const size = width * height;
+  const outside = new Uint8Array(size); // mask of outside pixels
+  for (let i = 0; i < size; i++) {
+    outside[i] = Number(scalarData[i]) === segmentIndex ? 0 : 1;
+  }
+  // EDT of outside mask gives: for each pixel, distance to nearest outside pixel.
+  // Inside pixels distant from boundary get high values; outside pixels get 0.
+  const distToOutside = euclideanDistanceToMask(outside, width, height);
+  return distToOutside;
+}
+
+/**
+ * Morphological (Raya-Udupa) interpolation between two anchor slices.
+ * Uses inside-distance fields: for each gap pixel, linearly blends the
+ * inside-distances from both anchors. Pixel is filled where the blended
+ * distance > 0, meaning the point is "inside" the interpolated shape.
+ *
+ * This produces larger (more volume-preserving) regions than SDF interpolation
+ * because it only considers positive inside-distances rather than the full
+ * signed distance field.
+ */
+function interpolateMorphological(
+  sliceA: ArrayLike<number>,
+  sliceB: ArrayLike<number>,
+  alpha: number,
+  width: number,
+  height: number,
+  segIdx: number,
+): Uint8Array {
+  const size = width * height;
+  const insideDistA = buildInsideDistanceField(sliceA, width, height, segIdx);
+  const insideDistB = buildInsideDistanceField(sliceB, width, height, segIdx);
+  const result = new Uint8Array(size);
+  for (let p = 0; p < size; p++) {
+    const blended = (1 - alpha) * insideDistA[p] + alpha * insideDistB[p];
+    if (blended > 0) {
+      result[p] = segIdx;
+    }
+  }
+  return result;
+}
+
+/**
+ * Nearest-slice interpolation. Returns the data from whichever anchor
+ * slice is nearest in position (alpha < 0.5 → slice A, else slice B).
+ */
+function interpolateNearestSlice(
+  sliceA: ArrayLike<number>,
+  sliceB: ArrayLike<number>,
+  alpha: number,
+  width: number,
+  height: number,
+  segIdx: number,
+): Uint8Array {
+  const size = width * height;
+  const source = alpha < 0.5 ? sliceA : sliceB;
+  const result = new Uint8Array(size);
+  for (let p = 0; p < size; p++) {
+    if (Number(source[p]) === segIdx) {
+      result[p] = segIdx;
+    }
+  }
+  return result;
+}
+
+/**
+ * Linear per-pixel blend interpolation. Blends binary presence values from
+ * both anchors and fills where the blend meets or exceeds the threshold.
+ * Lower threshold = more aggressive fill; 0.5 = standard midpoint.
+ */
+function interpolateLinearBlend(
+  sliceA: ArrayLike<number>,
+  sliceB: ArrayLike<number>,
+  alpha: number,
+  width: number,
+  height: number,
+  segIdx: number,
+  threshold: number,
+): Uint8Array {
+  const size = width * height;
+  const result = new Uint8Array(size);
+  for (let p = 0; p < size; p++) {
+    const valA = Number(sliceA[p]) === segIdx ? 1 : 0;
+    const valB = Number(sliceB[p]) === segIdx ? 1 : 0;
+    const blend = (1 - alpha) * valA + alpha * valB;
+    if (blend >= threshold) {
+      result[p] = segIdx;
+    }
+  }
+  return result;
+}
+
+/**
+ * SDF interpolation for a single gap slice (factored out from performLabelmapInterpolation).
+ * Returns a Uint8Array where filled pixels have value segIdx.
+ */
+function interpolateSDF(
+  sliceA: ArrayLike<number>,
+  sliceB: ArrayLike<number>,
+  alpha: number,
+  width: number,
+  height: number,
+  segIdx: number,
+): Uint8Array {
+  const size = width * height;
+  const signedA = buildSignedDistanceForSegment(sliceA, width, height, segIdx);
+  const signedB = buildSignedDistanceForSegment(sliceB, width, height, segIdx);
+  const result = new Uint8Array(size);
+  for (let p = 0; p < size; p++) {
+    const dist = (1 - alpha) * signedA[p] + alpha * signedB[p];
+    if (dist <= 0) {
+      result[p] = segIdx;
+    }
+  }
+  return result;
 }
 
 function applySourceDicomContextToSegDataset(dataset: any, sourceImageId: string): void {
@@ -983,8 +1181,12 @@ async function performLabelmapInterpolation(): Promise<void> {
   if (isDirtyTrackingSuppressed()) return;
   if (loadInProgressCount > 0) return;
 
+  // Read interpolation settings from preferences store (canonical source)
+  const prefState = usePreferencesStore.getState();
+  const interpPrefs = prefState.preferences.interpolation;
+  if (!interpPrefs.enabled) return;
+
   const segStore = useSegmentationStore.getState();
-  if (!segStore.interpolationEnabled) return;
   const pending = pendingLabelmapInterpolation;
   pendingLabelmapInterpolation = null;
   let activeSegId = pending?.segmentationId ?? segStore.activeSegmentationId;
@@ -1003,7 +1205,8 @@ async function performLabelmapInterpolation(): Promise<void> {
     effectiveSegIndex = 1; // sub-segs are binary (0/1)
   }
 
-  if (getSegmentationType(effectiveSegId) === 'contour') return;
+  const segType = getSegmentationType(effectiveSegId);
+  if (segType === 'contour') return;
 
   const labelmapData = await getCachedLabelmapSliceArrays(effectiveSegId);
   if (!labelmapData) return;
@@ -1019,6 +1222,9 @@ async function performLabelmapInterpolation(): Promise<void> {
   if (anchors.length < 2) return;
 
   labelmapInterpolationInProgress = true;
+  const algorithm = interpPrefs.algorithm;
+  const linearThreshold = interpPrefs.linearThreshold;
+
   try {
     const modifiedSlices = new Set<number>();
     const pixelsPerSlice = width * height;
@@ -1029,20 +1235,36 @@ async function performLabelmapInterpolation(): Promise<void> {
       const gap = b - a - 1;
       if (gap <= 0) continue;
 
-      const signedA = buildSignedDistanceForSegment(sliceArrays[a], width, height, effectiveSegIndex);
-      const signedB = buildSignedDistanceForSegment(sliceArrays[b], width, height, effectiveSegIndex);
-
       for (let s = a + 1; s < b; s++) {
         const alpha = (s - a) / (b - a);
         const slice = sliceArrays[s] as any;
-        let changed = false;
 
+        // Dispatch to the selected algorithm
+        let interpolated: Uint8Array;
+        switch (algorithm) {
+          case 'morphological':
+            interpolated = interpolateMorphological(sliceArrays[a], sliceArrays[b], alpha, width, height, effectiveSegIndex);
+            break;
+          case 'nearestSlice':
+            interpolated = interpolateNearestSlice(sliceArrays[a], sliceArrays[b], alpha, width, height, effectiveSegIndex);
+            break;
+          case 'linear':
+            interpolated = interpolateLinearBlend(sliceArrays[a], sliceArrays[b], alpha, width, height, effectiveSegIndex, linearThreshold);
+            break;
+          case 'sdf':
+          default:
+            interpolated = interpolateSDF(sliceArrays[a], sliceArrays[b], alpha, width, height, effectiveSegIndex);
+            break;
+        }
+
+        // Apply interpolated result to the gap slice
+        let changed = false;
         for (let p = 0; p < pixelsPerSlice; p++) {
           const currentValue = Number(slice[p]);
+          // Skip pixels that belong to a different segment
           if (currentValue !== 0 && currentValue !== effectiveSegIndex) continue;
-
-          const interpolatedDistance = (1 - alpha) * signedA[p] + alpha * signedB[p];
-          if (interpolatedDistance <= 0 && currentValue === 0) {
+          // Fill empty pixels where the algorithm says there should be data
+          if (interpolated[p] === effectiveSegIndex && currentValue === 0) {
             slice[p] = effectiveSegIndex;
             changed = true;
           }
@@ -1068,7 +1290,7 @@ async function performLabelmapInterpolation(): Promise<void> {
       enabledElement?.viewport?.render?.();
     }
   } catch (err) {
-    console.debug('[segmentationService] Labelmap interpolation failed:', err);
+    console.error('[segmentationService] Labelmap interpolation failed:', err);
   } finally {
     labelmapInterpolationInProgress = false;
   }
@@ -1349,21 +1571,29 @@ export const segmentationService = {
       );
     }
 
-    // Step 2: Pre-load source images so their metadata is available.
+    // Step 2: Start background pre-load of source image metadata.
+    // This is needed before addSegment() creates labelmap images, but we
+    // don't need to block creation — the promise is awaited lazily in
+    // addSegment() so the segmentation appears in the UI immediately.
     const uncachedIds = sourceImageIds.filter((id) => {
       try {
         return !metaData.get('imagePlaneModule', id);
       } catch { return true; }
     });
     if (uncachedIds.length > 0) {
-      console.log(`[segmentationService] Pre-loading ${uncachedIds.length}/${sourceImageIds.length} uncached images for segmentation metadata...`);
-      await Promise.all(uncachedIds.map((id) =>
+      console.log(`[segmentationService] Starting background pre-load of ${uncachedIds.length}/${sourceImageIds.length} uncached images...`);
+      const preloadPromise = Promise.all(uncachedIds.map((id) =>
         imageLoader.loadAndCacheImage(id).catch((err: any) => {
           console.warn(`[segmentationService] Failed to pre-load image ${id}:`, err);
         }),
-      ));
-    } else {
-      console.log(`[segmentationService] All ${sourceImageIds.length} images already have metadata, skipping pre-load`);
+      )).then(() => { metadataPreloadPromises.delete(segmentationId); });
+      metadataPreloadPromises.set(segmentationId, preloadPromise);
+
+      // If creating a default segment, we must await now because addSegment
+      // needs metadata synchronously within this call.
+      if (createDefaultSegment) {
+        await preloadPromise;
+      }
     }
 
     // Step 3: Initialize the multi-layer group (no labelmap images yet —
@@ -1389,7 +1619,7 @@ export const segmentationService = {
     // Step 4: If requested, create the first segment (which creates the
     // first sub-segmentation with its own labelmap images).
     if (createDefaultSegment) {
-      this.addSegment(segmentationId, 'Segment 1');
+      await this.addSegment(segmentationId, 'Segment 1');
       store.setActiveSegmentIndex(1);
     } else {
       store.setActiveSegmentIndex(0);
@@ -1552,11 +1782,11 @@ export const segmentationService = {
    * Cornerstone segmentation state and annotation map.
    * Returns the new segment index (1-based).
    */
-  addSegment(
+  async addSegment(
     segmentationId: string,
     label: string,
     color?: [number, number, number, number],
-  ): number {
+  ): Promise<number> {
     // ─── Contour (RTSTRUCT) path ─────────────────────────────
     const segType = getSegmentationType(segmentationId);
     if (segType === 'contour') {
@@ -1612,6 +1842,13 @@ export const segmentationService = {
     // ─── Multi-layer group (SEG) path ────────────────────────
     if (!isMultiLayerGroup(segmentationId)) {
       throw new Error(`[segmentationService] Not a multi-layer group: ${segmentationId}`);
+    }
+
+    // Ensure background metadata pre-load is complete before creating
+    // labelmap images (each needs imagePlaneModule from its source image).
+    const preloadPromise = metadataPreloadPromises.get(segmentationId);
+    if (preloadPromise) {
+      await preloadPromise;
     }
 
     const dims = groupDimensionsMap.get(segmentationId);
@@ -1877,6 +2114,8 @@ export const segmentationService = {
         groupLabelMap.delete(segmentationId);
         sourceImageIdsMap.delete(segmentationId);
         loadedColorsMap.delete(segmentationId);
+        groupViewportAttachments.delete(segmentationId);
+        metadataPreloadPromises.delete(segmentationId);
 
         const store = useSegmentationStore.getState();
         if (store.activeSegmentationId === segmentationId) {
@@ -1946,6 +2185,13 @@ export const segmentationService = {
 
     if (isMultiLayerGroup(segmentationId)) {
       // ─── Multi-layer path: attach each sub-seg as an independent actor ───
+      // Record viewport attachment so addSegment() can discover the target
+      // viewports even before any sub-segs exist (first segment case).
+      if (!groupViewportAttachments.has(segmentationId)) {
+        groupViewportAttachments.set(segmentationId, new Set());
+      }
+      groupViewportAttachments.get(segmentationId)!.add(viewportId);
+
       const subSegIds = getActiveSubSegIds(segmentationId);
       const metaMap = segmentMetaMap.get(segmentationId);
       const store = useSegmentationStore.getState();

--- a/src/renderer/lib/cornerstone/toolService.ts
+++ b/src/renderer/lib/cornerstone/toolService.ts
@@ -61,6 +61,7 @@ import {
   LABELMAP_SEG_TOOLS,
 } from '@shared/types/viewer';
 import { viewportService } from './viewportService';
+import { usePreferencesStore } from '../../stores/preferencesStore';
 import { useSegmentationStore } from '../../stores/segmentationStore';
 import { segmentationService } from './segmentationService';
 import { useViewerStore } from '../../stores/viewerStore';
@@ -213,7 +214,7 @@ function rebuildToolGroup(primaryTool: ToolName): ToolTypes.IToolGroup | undefin
   addAllTools(toolGroup);
   applyInterpolationConfiguration(
     toolGroup,
-    useSegmentationStore.getState().interpolationEnabled,
+    usePreferencesStore.getState().preferences.interpolation.enabled,
   );
 
   // Re-add viewports
@@ -421,7 +422,7 @@ export const toolService = {
     addAllTools(toolGroup);
     applyInterpolationConfiguration(
       toolGroup,
-      useSegmentationStore.getState().interpolationEnabled,
+      usePreferencesStore.getState().preferences.interpolation.enabled,
     );
 
     // Restore the brush size from the store — addAllTools creates fresh tool
@@ -568,7 +569,7 @@ export const toolService = {
               if (segId) {
                 if (isContourTool) {
                   // Contour: add a default structure and ensure representation
-                  segmentationService.addSegment(segId, 'Structure 1');
+                  await segmentationService.addSegment(segId, 'Structure 1');
                   segmentationService.setActiveSegmentIndex(segId, 1);
                   await segmentationService.ensureContourRepresentation(viewportId, segId);
                 } else {
@@ -634,17 +635,6 @@ export const toolService = {
    */
   getActiveTool(): ToolName {
     return currentActiveTool;
-  },
-
-  /**
-   * Enable/disable between-slice interpolation for contour segmentation tools.
-   * Labelmap interpolation reads the same store flag inside segmentationService.
-   */
-  setInterpolationEnabled(enabled: boolean): void {
-    useSegmentationStore.getState().setInterpolationEnabled(enabled);
-    const toolGroup = getToolGroup();
-    if (!toolGroup) return;
-    applyInterpolationConfiguration(toolGroup, enabled);
   },
 
   /**

--- a/src/renderer/lib/hotkeys/defaultHotkeyMap.ts
+++ b/src/renderer/lib/hotkeys/defaultHotkeyMap.ts
@@ -24,6 +24,7 @@ export const DEFAULT_HOTKEY_MAP: HotkeyMap = {
   'tool.crosshairs':  [{ key: 'c' }],
   'tool.probe':       [{ key: 'd' }],   // D for density probe
   'tool.arrowAnnotate': [{ key: 't' }], // T for text annotation
+  'tool.paintFill':   [{ key: 'f' }],
   'tool.stackScroll': [{ key: 's' }],
 
   // ─── Viewport Actions ────────────────────────────────────────

--- a/src/renderer/lib/segmentation/SegmentationManager.ts
+++ b/src/renderer/lib/segmentation/SegmentationManager.ts
@@ -744,7 +744,7 @@ export class SegmentationManager {
     useSegmentationStore.getState().setDicomType(segId, 'SEG');
 
     if (createDefaultSegment) {
-      segmentationService.addSegment(segId, 'Segment 1');
+      await segmentationService.addSegment(segId, 'Segment 1');
       segmentationService.setActiveSegmentIndex(segId, 1);
     }
 
@@ -802,8 +802,8 @@ export class SegmentationManager {
    * Add a new segment to an existing segmentation.
    * Returns the new segment index.
    */
-  addSegment(segmentationId: string, label: string): number {
-    const nextIndex = segmentationService.addSegment(segmentationId, label);
+  async addSegment(segmentationId: string, label: string): Promise<number> {
+    const nextIndex = await segmentationService.addSegment(segmentationId, label);
     segmentationService.setActiveSegmentIndex(segmentationId, nextIndex);
     // Seed presentation visibility so the new segment is visible by default
     useSegmentationManagerStore.getState().setPresentation(segmentationId, nextIndex, { visible: true });

--- a/src/renderer/stores/preferencesStore.ts
+++ b/src/renderer/stores/preferencesStore.ts
@@ -3,6 +3,9 @@ import {
   ALL_OVERLAY_FIELD_KEYS,
   DEFAULT_OVERLAY_CORNERS,
   DEFAULT_PREFERENCES,
+  DEFAULT_INTERPOLATION_PREFERENCES,
+  type InterpolationAlgorithm,
+  type InterpolationPreferences,
   type OverlayCornerId,
   type OverlayFieldKey,
   type OverlayPreferences,
@@ -21,6 +24,10 @@ interface PreferencesStore {
   setShowOverlayVerticalRuler: (enabled: boolean) => void;
   setShowOverlayOrientationMarkers: (enabled: boolean) => void;
   setOverlayCornerField: (corner: OverlayCornerId, field: OverlayFieldKey, enabled: boolean) => void;
+  // ─── Interpolation ─────────────────────────────────────
+  setInterpolationEnabled: (enabled: boolean) => void;
+  setInterpolationAlgorithm: (algorithm: InterpolationAlgorithm) => void;
+  setLinearThreshold: (threshold: number) => void;
   resetAll: () => void;
 }
 
@@ -47,6 +54,7 @@ function makeDefaultPreferences(): PreferencesV1 {
       showOrientationMarkers: DEFAULT_PREFERENCES.overlay.showOrientationMarkers,
       corners: cloneDefaultCorners(),
     },
+    interpolation: { ...DEFAULT_INTERPOLATION_PREFERENCES },
   };
 }
 
@@ -226,6 +234,35 @@ export const usePreferencesStore = create<PreferencesStore>()(
           };
         }),
 
+      // ─── Interpolation ────────────────────────────────────
+
+      setInterpolationEnabled: (enabled) =>
+        set((state) => ({
+          preferences: {
+            ...state.preferences,
+            interpolation: { ...state.preferences.interpolation, enabled },
+          },
+        })),
+
+      setInterpolationAlgorithm: (algorithm) =>
+        set((state) => ({
+          preferences: {
+            ...state.preferences,
+            interpolation: { ...state.preferences.interpolation, algorithm },
+          },
+        })),
+
+      setLinearThreshold: (threshold) =>
+        set((state) => ({
+          preferences: {
+            ...state.preferences,
+            interpolation: {
+              ...state.preferences.interpolation,
+              linearThreshold: Math.max(0, Math.min(1, threshold)),
+            },
+          },
+        })),
+
       resetAll: () =>
         set({
           preferences: makeDefaultPreferences(),
@@ -241,6 +278,24 @@ export const usePreferencesStore = create<PreferencesStore>()(
         const incoming = (persisted as Partial<PreferencesStore>)?.preferences;
         if (!incoming) return base;
 
+        // Merge interpolation preferences with defaults as fallback
+        const incomingInterp = (incoming as Partial<PreferencesV1>).interpolation;
+        const mergedInterpolation: InterpolationPreferences = {
+          enabled:
+            typeof incomingInterp?.enabled === 'boolean'
+              ? incomingInterp.enabled
+              : base.preferences.interpolation.enabled,
+          algorithm:
+            incomingInterp?.algorithm &&
+            ['sdf', 'morphological', 'nearestSlice', 'linear'].includes(incomingInterp.algorithm)
+              ? incomingInterp.algorithm
+              : base.preferences.interpolation.algorithm,
+          linearThreshold:
+            typeof incomingInterp?.linearThreshold === 'number'
+              ? Math.max(0, Math.min(1, incomingInterp.linearThreshold))
+              : base.preferences.interpolation.linearThreshold,
+        };
+
         return {
           ...base,
           preferences: {
@@ -248,6 +303,7 @@ export const usePreferencesStore = create<PreferencesStore>()(
               overrides: incoming.hotkeys?.overrides ?? base.preferences.hotkeys.overrides,
             },
             overlay: mergeOverlayPreferences(base.preferences.overlay, incoming.overlay),
+            interpolation: mergedInterpolation,
           },
         };
       },

--- a/src/renderer/stores/segmentationStore.ts
+++ b/src/renderer/stores/segmentationStore.ts
@@ -54,9 +54,6 @@ interface SegmentationStore {
   /** Contour outline opacity (0-1) */
   contourOpacity: number;
 
-  /** Whether between-slice interpolation is enabled for annotations */
-  interpolationEnabled: boolean;
-
   /** Brush tool radius in pixels */
   brushSize: number;
 
@@ -122,9 +119,6 @@ interface SegmentationStore {
 
   /** Set contour opacity */
   setContourOpacity: (opacity: number) => void;
-
-  /** Enable/disable between-slice interpolation */
-  setInterpolationEnabled: (enabled: boolean) => void;
 
   /** Set brush size */
   setBrushSize: (size: number) => void;
@@ -197,7 +191,6 @@ export const useSegmentationStore = create<SegmentationStore>((set) => ({
   renderOutline: true,
   contourLineWidth: 2,
   contourOpacity: 1,
-  interpolationEnabled: true,
   brushSize: 5,
   thresholdRange: [-200, 200],
   activeSegTool: null,
@@ -231,8 +224,6 @@ export const useSegmentationStore = create<SegmentationStore>((set) => ({
   setContourLineWidth: (width) => set({ contourLineWidth: width }),
 
   setContourOpacity: (opacity) => set({ contourOpacity: opacity }),
-
-  setInterpolationEnabled: (enabled) => set({ interpolationEnabled: enabled }),
 
   setBrushSize: (size) => set({ brushSize: size }),
 

--- a/src/shared/types/preferences.ts
+++ b/src/shared/types/preferences.ts
@@ -31,11 +31,47 @@ export interface OverlayPreferences {
   corners: Record<OverlayCornerId, OverlayFieldKey[]>;
 }
 
+// ─── Interpolation Preferences ───────────────────────────────────
+
+export type InterpolationAlgorithm = 'sdf' | 'morphological' | 'nearestSlice' | 'linear';
+
+export interface InterpolationPreferences {
+  /** Whether between-slice interpolation is enabled */
+  enabled: boolean;
+  /** Which interpolation algorithm to use */
+  algorithm: InterpolationAlgorithm;
+  /** Blend threshold for the 'linear' algorithm (0–1, default 0.5). Lower = more aggressive fill. */
+  linearThreshold: number;
+}
+
+export const DEFAULT_INTERPOLATION_PREFERENCES: InterpolationPreferences = {
+  enabled: true,
+  algorithm: 'morphological',
+  linearThreshold: 0.5,
+};
+
+export const INTERPOLATION_ALGORITHM_LABELS: Record<InterpolationAlgorithm, string> = {
+  sdf: 'Signed Distance Field (SDF)',
+  morphological: 'Morphological (Raya-Udupa)',
+  nearestSlice: 'Nearest Slice',
+  linear: 'Linear Blend',
+};
+
+export const INTERPOLATION_ALGORITHM_DESCRIPTIONS: Record<InterpolationAlgorithm, string> = {
+  sdf: 'Blends signed Euclidean distance fields between anchor slices. Tends to produce conservative (smaller) regions.',
+  morphological: 'Classic medical image interpolation. Interpolates inside-distance fields for better volume preservation and shape handling.',
+  nearestSlice: 'Copies the nearest painted slice. Fast, no blending artifacts, but produces staircase boundaries.',
+  linear: 'Blends pixel values linearly between anchors. Adjustable threshold controls fill aggressiveness.',
+};
+
+// ─── Top-level Preferences ──────────────────────────────────────
+
 export interface PreferencesV1 {
   hotkeys: {
     overrides: HotkeyMap;
   };
   overlay: OverlayPreferences;
+  interpolation: InterpolationPreferences;
 }
 
 export const DEFAULT_OVERLAY_CORNERS: Record<OverlayCornerId, OverlayFieldKey[]> = {
@@ -78,4 +114,5 @@ export const DEFAULT_PREFERENCES: PreferencesV1 = {
     showOrientationMarkers: true,
     corners: DEFAULT_OVERLAY_CORNERS,
   },
+  interpolation: { ...DEFAULT_INTERPOLATION_PREFERENCES },
 };


### PR DESCRIPTION
## Summary
- **Interpolation preferences panel**: New Interpolation tab in Settings with enable/disable toggle, algorithm dropdown (SDF, Morphological/Raya-Udupa, Nearest Slice, Linear Blend), algorithm descriptions, and configurable linear threshold slider
- **Four interpolation algorithms**: SDF (signed distance field), Morphological (Raya-Udupa — classic medical image interpolation), Nearest Slice (copy nearest anchor), and Linear Blend (per-pixel with adjustable threshold)
- **Performance fix**: First segmentation creation no longer blocks on metadata pre-load — images load in background, awaited lazily when first segment is added
- **Duplicate segmentation fix**: Added `groupViewportAttachments` map so multi-layer groups with zero sub-segs can be found on viewports, preventing unwanted auto-creation
- **Cleanup**: Removed redundant interpolation checkbox from annotation panel, removed `interpolationEnabled` from segmentation store (preferences store is canonical), removed all `[INTERP-DBG]` diagnostic logging
- **Paint Fill hotkey**: Added `F` as default hotkey for the Paint Fill tool

## Test plan
- [ ] Open Settings → Interpolation tab, verify toggle and algorithm dropdown render correctly
- [ ] Select each algorithm, paint on 2+ separated slices, verify interpolation fills gap slices
- [ ] Verify Linear Blend shows threshold slider; other algorithms do not
- [ ] Verify interpolation preference persists across app restarts (localStorage)
- [ ] Create a new segmentation on a fresh image — confirm it appears immediately (no multi-second delay)
- [ ] Verify subsequent segmentation creation is also fast
- [ ] Press `F` key to confirm Paint Fill tool activates
- [ ] Verify no duplicate segmentations are created when selecting brush tool after creating a segmentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)