### PR TITLE
Add annotation tool preferences panel and defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "dist/main/main/index.js",
   "scripts": {
     "dev": "concurrently \"npm run dev:renderer\" \"npm run dev:main\"",
-    "dev:renderer": "vite",
+    "dev:renderer": "vite --port ${VITE_DEV_SERVER_PORT:-5173}",
     "postinstall": "node scripts/fix-dev-app-name.js",
-    "dev:main": "node scripts/fix-dev-app-name.js && wait-on http://localhost:5173 && tsc -p tsconfig.main.json && electron .",
+    "dev:main": "node scripts/fix-dev-app-name.js && wait-on http://localhost:${VITE_DEV_SERVER_PORT:-5173} && tsc -p tsconfig.main.json && VITE_DEV_SERVER_URL=http://localhost:${VITE_DEV_SERVER_PORT:-5173} electron .",
     "build": "npm run build:main && npm run build:renderer",
     "build:main": "tsc -p tsconfig.main.json",
     "build:renderer": "vite build",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,6 +18,11 @@ app.name = 'XNAT';
 let mainWindow: BrowserWindow | null = null;
 
 const isDev = !app.isPackaged;
+const devServerUrl = (() => {
+  const raw = process.env.VITE_DEV_SERVER_URL?.trim();
+  if (!raw) return 'http://localhost:5173/';
+  return raw.endsWith('/') ? raw : `${raw}/`;
+})();
 
 // ─── Icon Paths ─────────────────────────────────────────────────
 // The official XNAT icon lives in build/. In dev mode __dirname is
@@ -155,7 +160,7 @@ function createWindow(): void {
   });
 
   if (isDev) {
-    mainWindow.loadURL('http://localhost:5173/');
+    mainWindow.loadURL(devServerUrl);
     mainWindow.webContents.openDevTools();
   } else {
     // In production: dist/main/main/index.js -> ../../renderer/index.html

--- a/src/renderer/components/settings/SettingsModal.tsx
+++ b/src/renderer/components/settings/SettingsModal.tsx
@@ -5,7 +5,7 @@ import { DEFAULT_HOTKEY_MAP } from '../../lib/hotkeys/defaultHotkeyMap';
 import { usePreferencesStore } from '../../stores/preferencesStore';
 import { IconClose } from '../icons';
 
-type SettingsTab = 'hotkeys' | 'overlay';
+type SettingsTab = 'hotkeys' | 'overlay' | 'annotation';
 
 interface SettingsModalProps {
   open: boolean;
@@ -15,6 +15,7 @@ interface SettingsModalProps {
 const TAB_ITEMS: Array<{ id: SettingsTab; label: string }> = [
   { id: 'hotkeys', label: 'Hotkeys' },
   { id: 'overlay', label: 'Overlay' },
+  { id: 'annotation', label: 'Annotation' },
 ];
 
 const CORNER_OPTIONS: Array<{
@@ -106,6 +107,25 @@ function normalizeKeyInput(input: string): string {
   return trimmed;
 }
 
+function normalizeHexColor(value: string): string | null {
+  const match = value.trim().match(/^#?([0-9a-fA-F]{6})$/);
+  if (!match) return null;
+  return `#${match[1].toUpperCase()}`;
+}
+
+function parseColorSequenceInput(input: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const token of input.split(',')) {
+    const color = normalizeHexColor(token);
+    if (!color) continue;
+    if (seen.has(color)) continue;
+    seen.add(color);
+    out.push(color);
+  }
+  return out;
+}
+
 function bindingToDraft(binding: HotkeyBinding): { key: string; modifiers: Required<HotkeyModifiers> } {
   return {
     key: binding.key === ' ' ? 'Space' : binding.key,
@@ -121,6 +141,7 @@ function bindingToDraft(binding: HotkeyBinding): { key: string; modifiers: Requi
 export default function SettingsModal({ open, onClose }: SettingsModalProps) {
   const overrides = usePreferencesStore((s) => s.preferences.hotkeys.overrides);
   const overlayPrefs = usePreferencesStore((s) => s.preferences.overlay);
+  const annotationPrefs = usePreferencesStore((s) => s.preferences.annotation);
   const setHotkeyOverride = usePreferencesStore((s) => s.setHotkeyOverride);
   const clearHotkeyOverride = usePreferencesStore((s) => s.clearHotkeyOverride);
   const resetHotkeys = usePreferencesStore((s) => s.resetHotkeys);
@@ -129,6 +150,11 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
   const setShowOverlayVerticalRuler = usePreferencesStore((s) => s.setShowOverlayVerticalRuler);
   const setShowOverlayOrientationMarkers = usePreferencesStore((s) => s.setShowOverlayOrientationMarkers);
   const setOverlayCornerField = usePreferencesStore((s) => s.setOverlayCornerField);
+  const setAnnotationBrushSize = usePreferencesStore((s) => s.setAnnotationBrushSize);
+  const setAnnotationContourThickness = usePreferencesStore((s) => s.setAnnotationContourThickness);
+  const setAnnotationMaskOutlines = usePreferencesStore((s) => s.setAnnotationMaskOutlines);
+  const setAnnotationSegmentOpacity = usePreferencesStore((s) => s.setAnnotationSegmentOpacity);
+  const setAnnotationColorSequence = usePreferencesStore((s) => s.setAnnotationColorSequence);
   const resetAll = usePreferencesStore((s) => s.resetAll);
 
   const actionOptions = useMemo(() => {
@@ -148,6 +174,7 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
     alt: false,
     meta: false,
   });
+  const [colorSequenceDraft, setColorSequenceDraft] = useState('');
 
   useEffect(() => {
     if (!open) return;
@@ -180,6 +207,10 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
     setDraftModifiers(draft.modifiers);
   }, [overrides, selectedAction]);
 
+  useEffect(() => {
+    setColorSequenceDraft(annotationPrefs.defaultColorSequence.join(', '));
+  }, [annotationPrefs.defaultColorSequence]);
+
   const overrideEntries = useMemo(
     () => Object.entries(overrides) as Array<[HotkeyAction, HotkeyBinding[]]>,
     [overrides],
@@ -210,6 +241,12 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
     const draft = bindingToDraft(first);
     setDraftKey(draft.key);
     setDraftModifiers(draft.modifiers);
+  };
+
+  const applyColorSequence = () => {
+    const parsed = parseColorSequenceInput(colorSequenceDraft);
+    if (parsed.length === 0) return;
+    setAnnotationColorSequence(parsed);
   };
 
   if (!open) return null;
@@ -452,6 +489,103 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
                       </div>
                     </div>
                   ))}
+                </div>
+              </>
+            )}
+
+            {activeTab === 'annotation' && (
+              <>
+                <div className="rounded-lg border border-zinc-800 bg-zinc-950/40 p-4 space-y-4">
+                  <div>
+                    <div className="flex items-center justify-between mb-1">
+                      <label className="text-xs text-zinc-300">Default brush size</label>
+                      <span className="text-[11px] text-zinc-400 tabular-nums">{annotationPrefs.defaultBrushSize}px</span>
+                    </div>
+                    <input
+                      type="range"
+                      min={1}
+                      max={50}
+                      value={annotationPrefs.defaultBrushSize}
+                      onChange={(e) => setAnnotationBrushSize(parseInt(e.target.value, 10) || 1)}
+                      className="w-full h-1 bg-zinc-700 rounded-full appearance-none cursor-pointer accent-blue-500"
+                    />
+                  </div>
+
+                  <div>
+                    <div className="flex items-center justify-between mb-1">
+                      <label className="text-xs text-zinc-300">Default contour thickness</label>
+                      <span className="text-[11px] text-zinc-400 tabular-nums">{annotationPrefs.defaultContourThickness}px</span>
+                    </div>
+                    <input
+                      type="range"
+                      min={1}
+                      max={8}
+                      value={annotationPrefs.defaultContourThickness}
+                      onChange={(e) => setAnnotationContourThickness(parseInt(e.target.value, 10) || 1)}
+                      className="w-full h-1 bg-zinc-700 rounded-full appearance-none cursor-pointer accent-emerald-500"
+                    />
+                  </div>
+
+                  <div>
+                    <div className="flex items-center justify-between mb-1">
+                      <label className="text-xs text-zinc-300">Default segment opacity</label>
+                      <span className="text-[11px] text-zinc-400 tabular-nums">
+                        {Math.round(annotationPrefs.defaultSegmentOpacity * 100)}%
+                      </span>
+                    </div>
+                    <input
+                      type="range"
+                      min={0}
+                      max={1}
+                      step={0.05}
+                      value={annotationPrefs.defaultSegmentOpacity}
+                      onChange={(e) => setAnnotationSegmentOpacity(parseFloat(e.target.value))}
+                      className="w-full h-1 bg-zinc-700 rounded-full appearance-none cursor-pointer accent-blue-500"
+                    />
+                  </div>
+
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={annotationPrefs.defaultMaskOutlines}
+                      onChange={(e) => setAnnotationMaskOutlines(e.target.checked)}
+                      className="w-3.5 h-3.5 rounded border-zinc-600 bg-zinc-800 accent-blue-500"
+                    />
+                    <span className="text-xs text-zinc-300">Default display mask outlines</span>
+                  </label>
+                </div>
+
+                <div className="rounded-lg border border-zinc-800 bg-zinc-950/40 p-4 space-y-3">
+                  <div className="text-xs text-zinc-300">Default color sequence</div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {annotationPrefs.defaultColorSequence.map((color) => (
+                      <div
+                        key={color}
+                        className="w-5 h-5 rounded border border-zinc-700"
+                        style={{ backgroundColor: color }}
+                        title={color}
+                      />
+                    ))}
+                  </div>
+                  <label className="space-y-1 block">
+                    <span className="text-[11px] text-zinc-500">Comma-separated hex colors</span>
+                    <input
+                      value={colorSequenceDraft}
+                      onChange={(e) => setColorSequenceDraft(e.target.value)}
+                      placeholder="#DC3232, #32C832, #3264DC"
+                      className="w-full bg-zinc-800 border border-zinc-700 rounded px-2 py-1.5 text-xs text-zinc-200"
+                    />
+                  </label>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={applyColorSequence}
+                      disabled={parseColorSequenceInput(colorSequenceDraft).length === 0}
+                      className="px-2.5 py-1.5 rounded bg-zinc-800 text-zinc-200 text-xs hover:bg-zinc-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    >
+                      Apply Sequence
+                    </button>
+                  </div>
                 </div>
               </>
             )}

--- a/src/renderer/components/viewer/SegmentationPanel.tsx
+++ b/src/renderer/components/viewer/SegmentationPanel.tsx
@@ -8,6 +8,7 @@ import { useSegmentationStore, type SegmentationDicomType } from '../../stores/s
 import { useViewerStore } from '../../stores/viewerStore';
 import { useConnectionStore } from '../../stores/connectionStore';
 import { useSegmentationManagerStore } from '../../stores/segmentationManagerStore';
+import { usePreferencesStore } from '../../stores/preferencesStore';
 import {
   useSessionDerivedIndexStore,
   isDerivedScan,
@@ -136,7 +137,7 @@ function SegToolIcon({ tool }: { tool: ToolName }) {
 }
 
 /** Color palette for quick segment color picking */
-const COLOR_PALETTE: [number, number, number, number][] = [
+const DEFAULT_COLOR_PALETTE: [number, number, number, number][] = [
   [220, 50, 50, 255],    // Red
   [50, 200, 50, 255],    // Green
   [50, 100, 220, 255],   // Blue
@@ -148,6 +149,17 @@ const COLOR_PALETTE: [number, number, number, number][] = [
   [50, 220, 130, 255],   // Spring Green
   [255, 130, 130, 255],  // Light Red
 ];
+
+function hexToRgbaColor(hex: string): [number, number, number, number] | null {
+  const match = hex.trim().match(/^#?([0-9a-fA-F]{6})$/);
+  if (!match) return null;
+  const raw = match[1];
+  const r = parseInt(raw.slice(0, 2), 16);
+  const g = parseInt(raw.slice(2, 4), 16);
+  const b = parseInt(raw.slice(4, 6), 16);
+  if (!Number.isFinite(r) || !Number.isFinite(g) || !Number.isFinite(b)) return null;
+  return [r, g, b, 255];
+}
 
 /** Convert RGBA array to CSS rgba() string */
 function rgbaStr(c: [number, number, number, number]): string {
@@ -242,6 +254,7 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
   const thresholdRange = useSegmentationStore((s) => s.thresholdRange);
   const splineType = useSegmentationStore((s) => s.splineType);
   const setSplineType = useSegmentationStore((s) => s.setSplineType);
+  const defaultColorSequence = usePreferencesStore((s) => s.preferences.annotation.defaultColorSequence);
   const autoSaveEnabled = useSegmentationStore((s) => s.autoSaveEnabled);
   const autoSaveStatus = useSegmentationStore((s) => s.autoSaveStatus);
   const setAutoSaveEnabled = useSegmentationStore((s) => s.setAutoSaveEnabled);
@@ -521,6 +534,12 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
   const [segmentNamingDialog, setSegmentNamingDialog] = useState<SegmentNamingDialogState | null>(null);
   const segmentNamingInputRef = useRef<HTMLInputElement>(null);
   const segmentNamingDialogWasOpenRef = useRef(false);
+  const colorPalette = useMemo(() => {
+    const parsed = defaultColorSequence
+      .map((color) => hexToRgbaColor(color))
+      .filter((color): color is [number, number, number, number] => color !== null);
+    return parsed.length > 0 ? parsed : DEFAULT_COLOR_PALETTE;
+  }, [defaultColorSequence]);
 
   // Focus the naming input when it appears
   useEffect(() => {
@@ -1656,7 +1675,7 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
                       {/* Inline color picker */}
                       {colorPickerTarget?.segmentationId === seg.segmentationId && (
                         <div className="flex flex-wrap gap-1 px-2 py-1.5 mt-0.5">
-                          {COLOR_PALETTE.map((color, i) => (
+                          {colorPalette.map((color, i) => (
                             <button
                               key={i}
                               className="w-4 h-4 rounded-sm border border-zinc-600 hover:border-white transition-colors"

--- a/src/renderer/lib/cornerstone/segmentationService.ts
+++ b/src/renderer/lib/cornerstone/segmentationService.ts
@@ -61,8 +61,8 @@ const TOOL_GROUP_ID = 'xnatToolGroup_primary';
 
 // ─── Constants ──────────────────────────────────────────────────
 
-/** Default color palette for segments (10 colors, RGBA 0-255, cycles) */
-const DEFAULT_COLORS: [number, number, number, number][] = [
+/** Built-in fallback color palette for segments (10 colors, RGBA 0-255, cycles) */
+const BUILTIN_DEFAULT_COLORS: [number, number, number, number][] = [
   [220, 50, 50, 255],    // Red
   [50, 200, 50, 255],    // Green
   [50, 100, 220, 255],   // Blue
@@ -74,6 +74,16 @@ const DEFAULT_COLORS: [number, number, number, number][] = [
   [50, 220, 130, 255],   // Spring Green
   [255, 130, 130, 255],  // Light Red
 ];
+let DEFAULT_COLORS: [number, number, number, number][] = BUILTIN_DEFAULT_COLORS.map((c) => [...c] as [number, number, number, number]);
+
+function isValidColorTuple(color: unknown): color is [number, number, number, number] {
+  if (!Array.isArray(color) || color.length !== 4) return false;
+  for (const entry of color) {
+    if (typeof entry !== 'number' || !Number.isFinite(entry)) return false;
+    if (entry < 0 || entry > 255) return false;
+  }
+  return true;
+}
 
 let segmentationCounter = 0;
 
@@ -2725,6 +2735,24 @@ export const segmentationService = {
     } catch (err) {
       console.error('[segmentationService] Failed to set brush size:', err);
     }
+  },
+
+  /**
+   * Override the default segment color sequence used for new segments.
+   */
+  setDefaultColorSequence(colors: [number, number, number, number][]): void {
+    const valid = colors
+      .filter((color) => isValidColorTuple(color))
+      .map((color) => ([
+        Math.round(color[0]),
+        Math.round(color[1]),
+        Math.round(color[2]),
+        Math.round(color[3]),
+      ] as [number, number, number, number]));
+
+    DEFAULT_COLORS = valid.length > 0
+      ? valid
+      : BUILTIN_DEFAULT_COLORS.map((color) => [...color] as [number, number, number, number]);
   },
 
   /**

--- a/src/renderer/lib/preferences/applyPreferences.ts
+++ b/src/renderer/lib/preferences/applyPreferences.ts
@@ -1,18 +1,49 @@
 import { DEFAULT_PREFERENCES, type PreferencesV1 } from '@shared/types/preferences';
+import { segmentationService } from '../cornerstone/segmentationService';
 import { useSegmentationStore } from '../../stores/segmentationStore';
 import { DEFAULT_HOTKEY_MAP } from '../hotkeys/defaultHotkeyMap';
 import { hotkeyService } from '../hotkeys/hotkeyService';
+
+function hexToRgba(hex: string): [number, number, number, number] | null {
+  const match = hex.trim().match(/^#?([0-9a-fA-F]{6})$/);
+  if (!match) return null;
+  const raw = match[1];
+  const r = parseInt(raw.slice(0, 2), 16);
+  const g = parseInt(raw.slice(2, 4), 16);
+  const b = parseInt(raw.slice(4, 6), 16);
+  if (!Number.isFinite(r) || !Number.isFinite(g) || !Number.isFinite(b)) return null;
+  return [r, g, b, 255];
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
 
 export function applyPreferences(preferences: PreferencesV1): void {
   const showViewportContextOverlay =
     preferences.overlay?.showViewportContextOverlay
     ?? DEFAULT_PREFERENCES.overlay.showViewportContextOverlay;
   const hotkeyOverrides = preferences.hotkeys?.overrides ?? {};
+  const annotationPrefs = preferences.annotation ?? DEFAULT_PREFERENCES.annotation;
+  const brushSize = clamp(Math.round(annotationPrefs.defaultBrushSize), 1, 100);
+  const contourThickness = clamp(Math.round(annotationPrefs.defaultContourThickness), 1, 8);
+  const segmentOpacity = clamp(annotationPrefs.defaultSegmentOpacity, 0, 1);
+  const colorSequence = (annotationPrefs.defaultColorSequence ?? DEFAULT_PREFERENCES.annotation.defaultColorSequence)
+    .map((hex) => hexToRgba(hex))
+    .filter((color): color is [number, number, number, number] => color !== null);
 
   hotkeyService.setHotkeyMap(DEFAULT_HOTKEY_MAP);
   hotkeyService.mergeOverrides(hotkeyOverrides);
 
-  useSegmentationStore
-    .getState()
-    .setShowViewportContextOverlay(showViewportContextOverlay);
+  const segmentationState = useSegmentationStore.getState();
+  segmentationState.setShowViewportContextOverlay(showViewportContextOverlay);
+  segmentationState.setBrushSize(brushSize);
+  segmentationState.setContourLineWidth(contourThickness);
+  segmentationState.setRenderOutline(annotationPrefs.defaultMaskOutlines);
+  segmentationState.setFillAlpha(segmentOpacity);
+
+  segmentationService.setDefaultColorSequence(colorSequence);
+  segmentationService.setBrushSize(brushSize);
+  segmentationService.updateStyle(segmentOpacity, annotationPrefs.defaultMaskOutlines);
+  segmentationService.updateContourStyle(contourThickness);
 }

--- a/src/renderer/stores/preferencesStore.ts
+++ b/src/renderer/stores/preferencesStore.ts
@@ -3,6 +3,9 @@ import {
   ALL_OVERLAY_FIELD_KEYS,
   DEFAULT_OVERLAY_CORNERS,
   DEFAULT_PREFERENCES,
+  DEFAULT_SEGMENT_COLOR_SEQUENCE,
+  type AnnotationToolPreferences,
+  type HexColor,
   type OverlayCornerId,
   type OverlayFieldKey,
   type OverlayPreferences,
@@ -21,10 +24,16 @@ interface PreferencesStore {
   setShowOverlayVerticalRuler: (enabled: boolean) => void;
   setShowOverlayOrientationMarkers: (enabled: boolean) => void;
   setOverlayCornerField: (corner: OverlayCornerId, field: OverlayFieldKey, enabled: boolean) => void;
+  setAnnotationBrushSize: (size: number) => void;
+  setAnnotationContourThickness: (size: number) => void;
+  setAnnotationMaskOutlines: (enabled: boolean) => void;
+  setAnnotationSegmentOpacity: (opacity: number) => void;
+  setAnnotationColorSequence: (colors: string[]) => void;
   resetAll: () => void;
 }
 
 const OVERLAY_FIELD_SET = new Set<OverlayFieldKey>(ALL_OVERLAY_FIELD_KEYS);
+const HEX_COLOR_PATTERN = /^#?([0-9a-fA-F]{6})$/;
 
 function cloneDefaultCorners(): Record<OverlayCornerId, OverlayFieldKey[]> {
   return {
@@ -33,6 +42,36 @@ function cloneDefaultCorners(): Record<OverlayCornerId, OverlayFieldKey[]> {
     bottomLeft: [...DEFAULT_OVERLAY_CORNERS.bottomLeft],
     bottomRight: [...DEFAULT_OVERLAY_CORNERS.bottomRight],
   };
+}
+
+function cloneDefaultColorSequence(): HexColor[] {
+  return [...DEFAULT_SEGMENT_COLOR_SEQUENCE];
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function sanitizeHexColor(value: unknown): HexColor | null {
+  if (typeof value !== 'string') return null;
+  const match = value.trim().match(HEX_COLOR_PATTERN);
+  if (!match) return null;
+  return (`#${match[1].toUpperCase()}`) as HexColor;
+}
+
+function sanitizeColorSequence(value: unknown): HexColor[] {
+  if (!Array.isArray(value)) return cloneDefaultColorSequence();
+  const seen = new Set<HexColor>();
+  const out: HexColor[] = [];
+  for (const entry of value) {
+    const color = sanitizeHexColor(entry);
+    if (!color) continue;
+    if (seen.has(color)) continue;
+    seen.add(color);
+    out.push(color);
+    if (out.length >= 32) break;
+  }
+  return out.length > 0 ? out : cloneDefaultColorSequence();
 }
 
 function makeDefaultPreferences(): PreferencesV1 {
@@ -46,6 +85,13 @@ function makeDefaultPreferences(): PreferencesV1 {
       showVerticalRuler: DEFAULT_PREFERENCES.overlay.showVerticalRuler,
       showOrientationMarkers: DEFAULT_PREFERENCES.overlay.showOrientationMarkers,
       corners: cloneDefaultCorners(),
+    },
+    annotation: {
+      defaultBrushSize: DEFAULT_PREFERENCES.annotation.defaultBrushSize,
+      defaultContourThickness: DEFAULT_PREFERENCES.annotation.defaultContourThickness,
+      defaultMaskOutlines: DEFAULT_PREFERENCES.annotation.defaultMaskOutlines,
+      defaultSegmentOpacity: DEFAULT_PREFERENCES.annotation.defaultSegmentOpacity,
+      defaultColorSequence: cloneDefaultColorSequence(),
     },
   };
 }
@@ -113,6 +159,40 @@ function mergeOverlayPreferences(current: OverlayPreferences, incoming: unknown)
         ? sanitizeOverlayFields(incomingCorners.bottomRight)
         : [...current.corners.bottomRight],
     },
+  };
+}
+
+function mergeAnnotationPreferences(current: AnnotationToolPreferences, incoming: unknown): AnnotationToolPreferences {
+  if (!incoming || typeof incoming !== 'object') {
+    return {
+      ...current,
+      defaultColorSequence: [...current.defaultColorSequence],
+    };
+  }
+
+  const candidate = incoming as Partial<AnnotationToolPreferences>;
+
+  return {
+    defaultBrushSize:
+      typeof candidate.defaultBrushSize === 'number' && Number.isFinite(candidate.defaultBrushSize)
+        ? clampNumber(Math.round(candidate.defaultBrushSize), 1, 100)
+        : current.defaultBrushSize,
+    defaultContourThickness:
+      typeof candidate.defaultContourThickness === 'number' && Number.isFinite(candidate.defaultContourThickness)
+        ? clampNumber(Math.round(candidate.defaultContourThickness), 1, 8)
+        : current.defaultContourThickness,
+    defaultMaskOutlines:
+      typeof candidate.defaultMaskOutlines === 'boolean'
+        ? candidate.defaultMaskOutlines
+        : current.defaultMaskOutlines,
+    defaultSegmentOpacity:
+      typeof candidate.defaultSegmentOpacity === 'number' && Number.isFinite(candidate.defaultSegmentOpacity)
+        ? clampNumber(candidate.defaultSegmentOpacity, 0, 1)
+        : current.defaultSegmentOpacity,
+    defaultColorSequence:
+      Object.prototype.hasOwnProperty.call(candidate, 'defaultColorSequence')
+        ? sanitizeColorSequence(candidate.defaultColorSequence)
+        : [...current.defaultColorSequence],
   };
 }
 
@@ -226,6 +306,61 @@ export const usePreferencesStore = create<PreferencesStore>()(
           };
         }),
 
+      setAnnotationBrushSize: (size) =>
+        set((state) => ({
+          preferences: {
+            ...state.preferences,
+            annotation: {
+              ...state.preferences.annotation,
+              defaultBrushSize: clampNumber(Math.round(size), 1, 100),
+            },
+          },
+        })),
+
+      setAnnotationContourThickness: (size) =>
+        set((state) => ({
+          preferences: {
+            ...state.preferences,
+            annotation: {
+              ...state.preferences.annotation,
+              defaultContourThickness: clampNumber(Math.round(size), 1, 8),
+            },
+          },
+        })),
+
+      setAnnotationMaskOutlines: (enabled) =>
+        set((state) => ({
+          preferences: {
+            ...state.preferences,
+            annotation: {
+              ...state.preferences.annotation,
+              defaultMaskOutlines: enabled,
+            },
+          },
+        })),
+
+      setAnnotationSegmentOpacity: (opacity) =>
+        set((state) => ({
+          preferences: {
+            ...state.preferences,
+            annotation: {
+              ...state.preferences.annotation,
+              defaultSegmentOpacity: clampNumber(opacity, 0, 1),
+            },
+          },
+        })),
+
+      setAnnotationColorSequence: (colors) =>
+        set((state) => ({
+          preferences: {
+            ...state.preferences,
+            annotation: {
+              ...state.preferences.annotation,
+              defaultColorSequence: sanitizeColorSequence(colors),
+            },
+          },
+        })),
+
       resetAll: () =>
         set({
           preferences: makeDefaultPreferences(),
@@ -248,6 +383,7 @@ export const usePreferencesStore = create<PreferencesStore>()(
               overrides: incoming.hotkeys?.overrides ?? base.preferences.hotkeys.overrides,
             },
             overlay: mergeOverlayPreferences(base.preferences.overlay, incoming.overlay),
+            annotation: mergeAnnotationPreferences(base.preferences.annotation, incoming.annotation),
           },
         };
       },

--- a/src/renderer/stores/segmentationStore.ts
+++ b/src/renderer/stores/segmentationStore.ts
@@ -116,6 +116,8 @@ interface SegmentationStore {
 
   /** Toggle outline rendering */
   toggleOutline: () => void;
+  /** Set outline rendering */
+  setRenderOutline: (enabled: boolean) => void;
 
   /** Set contour line thickness */
   setContourLineWidth: (width: number) => void;
@@ -227,6 +229,7 @@ export const useSegmentationStore = create<SegmentationStore>((set) => ({
   setFillAlpha: (alpha) => set({ fillAlpha: alpha }),
 
   toggleOutline: () => set((s) => ({ renderOutline: !s.renderOutline })),
+  setRenderOutline: (enabled) => set({ renderOutline: enabled }),
 
   setContourLineWidth: (width) => set({ contourLineWidth: width }),
 

--- a/src/shared/types/preferences.ts
+++ b/src/shared/types/preferences.ts
@@ -1,6 +1,7 @@
 import type { HotkeyMap } from './hotkeys';
 
 export type OverlayCornerId = 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
+export type HexColor = `#${string}`;
 
 export type OverlayFieldKey =
   | 'orientationSelector'
@@ -31,11 +32,20 @@ export interface OverlayPreferences {
   corners: Record<OverlayCornerId, OverlayFieldKey[]>;
 }
 
+export interface AnnotationToolPreferences {
+  defaultBrushSize: number;
+  defaultContourThickness: number;
+  defaultMaskOutlines: boolean;
+  defaultSegmentOpacity: number;
+  defaultColorSequence: HexColor[];
+}
+
 export interface PreferencesV1 {
   hotkeys: {
     overrides: HotkeyMap;
   };
   overlay: OverlayPreferences;
+  annotation: AnnotationToolPreferences;
 }
 
 export const DEFAULT_OVERLAY_CORNERS: Record<OverlayCornerId, OverlayFieldKey[]> = {
@@ -67,6 +77,19 @@ export const ALL_OVERLAY_FIELD_KEYS: OverlayFieldKey[] = [
   'crosshair',
 ];
 
+export const DEFAULT_SEGMENT_COLOR_SEQUENCE: HexColor[] = [
+  '#DC3232',
+  '#32C832',
+  '#3264DC',
+  '#E6C828',
+  '#C832C8',
+  '#32C8C8',
+  '#F08C28',
+  '#9650C8',
+  '#32DC82',
+  '#FF8282',
+];
+
 export const DEFAULT_PREFERENCES: PreferencesV1 = {
   hotkeys: {
     overrides: {},
@@ -77,5 +100,12 @@ export const DEFAULT_PREFERENCES: PreferencesV1 = {
     showVerticalRuler: true,
     showOrientationMarkers: true,
     corners: DEFAULT_OVERLAY_CORNERS,
+  },
+  annotation: {
+    defaultBrushSize: 5,
+    defaultContourThickness: 2,
+    defaultMaskOutlines: true,
+    defaultSegmentOpacity: 0.5,
+    defaultColorSequence: DEFAULT_SEGMENT_COLOR_SEQUENCE,
   },
 };


### PR DESCRIPTION
## Summary
- add persisted annotation tool preferences (brush size, contour thickness, mask outlines, segment opacity, default color sequence)
- add new Settings > Annotation panel to manage these defaults
- apply annotation defaults globally through applyPreferences at app startup and preference changes
- make dev runtime support configurable non-standard Vite ports via VITE_DEV_SERVER_PORT / VITE_DEV_SERVER_URL

## Validation
- npm run build