### PR TITLE
Add mac signing setup and UI preferences cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,12 @@ node_modules/
 
 # Build output
 dist/
-build/
+build/*
+!build/icon.icns
+!build/icon.png
+!build/xnat-logo.png
+!build/entitlements.mac.plist
+!build/entitlements.mac.inherit.plist
 out/
 
 # Vite

--- a/README.md
+++ b/README.md
@@ -155,6 +155,48 @@ Creates distributable installers in `release/`:
 - **Windows** — NSIS installer, portable EXE
 - **Linux** — AppImage, DEB
 
+### Signed macOS Package (Developer ID)
+
+To avoid Gatekeeper "unidentified developer" warnings, build with Apple signing + notarization credentials:
+
+```bash
+# Code signing certificate (.p12 exported from Keychain Access)
+export CSC_LINK="/absolute/path/to/DeveloperIDApplication.p12"
+export CSC_KEY_PASSWORD="your-p12-password"
+
+# Notarization (recommended: App Store Connect API key)
+export APPLE_API_KEY="/absolute/path/to/AuthKey_XXXXXX.p8"
+export APPLE_API_KEY_ID="XXXXXX"
+export APPLE_API_ISSUER="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+# Alternative notarization auth:
+# export APPLE_ID="name@example.com"
+# export APPLE_APP_SPECIFIC_PASSWORD="xxxx-xxxx-xxxx-xxxx"
+# export APPLE_TEAM_ID="XXXXXXXXXX"
+
+npm run package -- --mac
+```
+
+Quick validation after build:
+
+```bash
+codesign --verify --deep --strict --verbose=2 "release/mac/XNAT Workstation.app"
+spctl -a -vv -t install "release/XNAT Workstation-*.dmg"
+```
+
+If `codesign` fails with `unable to build chain to self-signed root`, restore standard keychain search paths and remove custom trust overrides on `Developer ID Certification Authority`:
+
+```bash
+security list-keychains -d user -s \
+  ~/Library/Keychains/login.keychain-db \
+  /Library/Keychains/System.keychain \
+  /System/Library/Keychains/SystemRootCertificates.keychain
+
+security find-certificate -c "Developer ID Certification Authority" -p \
+  /Library/Keychains/System.keychain > /tmp/dev-id-ca.pem
+security remove-trusted-cert -d /tmp/dev-id-ca.pem
+```
+
 ## Architecture
 
 ```

--- a/build/entitlements.mac.inherit.plist
+++ b/build/entitlements.mac.inherit.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.inherit</key>
+    <true/>
+  </dict>
+</plist>

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -14,12 +14,16 @@ extraResources:
       - "*.ico"
       - "*.icns"
 mac:
-  icon: build/icon.png
+  icon: build/icon.icns
   target:
     - dmg
     - zip
   category: public.app-category.medical
   hardenedRuntime: true
+  gatekeeperAssess: false
+  entitlements: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.inherit.plist
+  notarize: true
 win:
   target:
     - nsis

--- a/src/renderer/components/icons.tsx
+++ b/src/renderer/components/icons.tsx
@@ -712,15 +712,16 @@ export function IconRedo(props: IconProps) {
 export function IconSettings(props: IconProps) {
   return (
     <svg {...defaults(props)}>
-      <circle cx="8" cy="8" r="2.2" />
-      <path d="M8 1.8 V3.1" />
-      <path d="M8 12.9 V14.2" />
-      <path d="M1.8 8 H3.1" />
-      <path d="M12.9 8 H14.2" />
-      <path d="M3.3 3.3 L4.2 4.2" />
-      <path d="M11.8 11.8 L12.7 12.7" />
-      <path d="M3.3 12.7 L4.2 11.8" />
-      <path d="M11.8 4.2 L12.7 3.3" />
+      <circle cx="8" cy="8" r="4.1" />
+      <circle cx="8" cy="8" r="1.8" />
+      <path d="M8 0.9 V2.5" />
+      <path d="M8 13.5 V15.1" />
+      <path d="M0.9 8 H2.5" />
+      <path d="M13.5 8 H15.1" />
+      <path d="M2.9 2.9 L4 4" />
+      <path d="M12 12 L13.1 13.1" />
+      <path d="M2.9 13.1 L4 12" />
+      <path d="M12 4 L13.1 2.9" />
     </svg>
   );
 }

--- a/src/renderer/components/settings/SettingsModal.tsx
+++ b/src/renderer/components/settings/SettingsModal.tsx
@@ -9,8 +9,7 @@ import { DEFAULT_HOTKEY_MAP } from '../../lib/hotkeys/defaultHotkeyMap';
 import { usePreferencesStore } from '../../stores/preferencesStore';
 import { IconClose } from '../icons';
 
-type SettingsTab = 'hotkeys' | 'overlay' | 'annotation';
-type SettingsTab = 'hotkeys' | 'overlay' | 'interpolation';
+type SettingsTab = 'hotkeys' | 'overlay' | 'annotation' | 'interpolation';
 
 interface SettingsModalProps {
   open: boolean;
@@ -160,6 +159,7 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
   const setAnnotationBrushSize = usePreferencesStore((s) => s.setAnnotationBrushSize);
   const setAnnotationContourThickness = usePreferencesStore((s) => s.setAnnotationContourThickness);
   const setAnnotationMaskOutlines = usePreferencesStore((s) => s.setAnnotationMaskOutlines);
+  const setAnnotationAutoDisplay = usePreferencesStore((s) => s.setAnnotationAutoDisplay);
   const setAnnotationSegmentOpacity = usePreferencesStore((s) => s.setAnnotationSegmentOpacity);
   const setAnnotationColorSequence = usePreferencesStore((s) => s.setAnnotationColorSequence);
   const setInterpolationEnabled = usePreferencesStore((s) => s.setInterpolationEnabled);
@@ -563,6 +563,16 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
                     />
                     <span className="text-xs text-zinc-300">Default display mask outlines</span>
                   </label>
+
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={annotationPrefs.autoDisplayAnnotations}
+                      onChange={(e) => setAnnotationAutoDisplay(e.target.checked)}
+                      className="w-3.5 h-3.5 rounded border-zinc-600 bg-zinc-800 accent-blue-500"
+                    />
+                    <span className="text-xs text-zinc-300">Automatically display annotations</span>
+                  </label>
                 </div>
 
                 <div className="rounded-lg border border-zinc-800 bg-zinc-950/40 p-4 space-y-3">
@@ -596,6 +606,10 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
                       Apply Sequence
                     </button>
                   </div>
+                </div>
+              </>
+            )}
+
             {activeTab === 'interpolation' && (
               <>
                 <div className="text-xs text-zinc-400">

--- a/src/renderer/components/viewer/SegmentationPanel.tsx
+++ b/src/renderer/components/viewer/SegmentationPanel.tsx
@@ -256,8 +256,6 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
   const autoSaveEnabled = useSegmentationStore((s) => s.autoSaveEnabled);
   const autoSaveStatus = useSegmentationStore((s) => s.autoSaveStatus);
   const setAutoSaveEnabled = useSegmentationStore((s) => s.setAutoSaveEnabled);
-  const autoLoadSegOnScanClick = useSegmentationStore((s) => s.autoLoadSegOnScanClick);
-  const setAutoLoadSegOnScanClick = useSegmentationStore((s) => s.setAutoLoadSegOnScanClick);
   const xnatOriginMap = useSegmentationStore((s) => s.xnatOriginMap);
   const dicomTypeBySegmentationId = useSegmentationStore((s) => s.dicomTypeBySegmentationId);
   const setDicomType = useSegmentationStore((s) => s.setDicomType);
@@ -1887,16 +1885,6 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
 
       {/* Shared annotation options (outside fixed-size tool section) */}
       <div className="border-t border-zinc-800 px-3 py-2 space-y-2 shrink-0">
-        <label className="flex items-center gap-2 cursor-pointer">
-          <input
-            type="checkbox"
-            checked={autoLoadSegOnScanClick}
-            onChange={(e) => setAutoLoadSegOnScanClick(e.target.checked)}
-            className="w-3 h-3 rounded border-zinc-600 bg-zinc-800 accent-blue-500"
-          />
-          <span className="text-[10px] text-zinc-400">Automatically display annotations</span>
-        </label>
-
         <div className="flex items-center justify-between gap-3">
           <div className="flex items-center gap-4">
             <label className="flex items-center gap-2 cursor-pointer">

--- a/src/renderer/components/viewer/Toolbar.tsx
+++ b/src/renderer/components/viewer/Toolbar.tsx
@@ -509,6 +509,8 @@ export default function Toolbar({ showDicomPanel = false, onToggleDicomPanel, on
   return (
     <>
       <div className="h-10 bg-zinc-900 border-b border-zinc-800 flex items-center px-2 gap-1 shrink-0">
+        <div className="flex-1 min-w-0 overflow-x-auto overflow-y-hidden">
+          <div className="flex items-center gap-1 w-max min-w-full pr-2">
       {/* ─── Left Slot (XNAT logo, connection, etc.) ─── */}
       {leftSlot && (
         <>
@@ -679,14 +681,16 @@ export default function Toolbar({ showDicomPanel = false, onToggleDicomPanel, on
           <DicomTagsToggle active={showDicomPanel} onToggle={onToggleDicomPanel} />
         </>
       )}
-        <div className="ml-auto" />
-        <Separator />
+          </div>
+        </div>
+        <div className="shrink-0 flex items-center gap-1 border-l border-zinc-800 pl-2">
         <IconButton
           icon={<IconSettings className="w-3.5 h-3.5" />}
           active={showSettings}
           onClick={() => setShowSettings((v) => !v)}
           title={showSettings ? 'Close settings' : 'Open settings'}
         />
+        </div>
       </div>
       <SettingsModal open={showSettings} onClose={() => setShowSettings(false)} />
     </>

--- a/src/renderer/lib/preferences/applyPreferences.ts
+++ b/src/renderer/lib/preferences/applyPreferences.ts
@@ -28,6 +28,10 @@ export function applyPreferences(preferences: PreferencesV1): void {
   const brushSize = clamp(Math.round(annotationPrefs.defaultBrushSize), 1, 100);
   const contourThickness = clamp(Math.round(annotationPrefs.defaultContourThickness), 1, 8);
   const segmentOpacity = clamp(annotationPrefs.defaultSegmentOpacity, 0, 1);
+  const autoDisplayAnnotations =
+    typeof annotationPrefs.autoDisplayAnnotations === 'boolean'
+      ? annotationPrefs.autoDisplayAnnotations
+      : DEFAULT_PREFERENCES.annotation.autoDisplayAnnotations;
   const colorSequence = (annotationPrefs.defaultColorSequence ?? DEFAULT_PREFERENCES.annotation.defaultColorSequence)
     .map((hex) => hexToRgba(hex))
     .filter((color): color is [number, number, number, number] => color !== null);
@@ -40,6 +44,7 @@ export function applyPreferences(preferences: PreferencesV1): void {
   segmentationState.setBrushSize(brushSize);
   segmentationState.setContourLineWidth(contourThickness);
   segmentationState.setRenderOutline(annotationPrefs.defaultMaskOutlines);
+  segmentationState.setAutoLoadSegOnScanClick(autoDisplayAnnotations);
   segmentationState.setFillAlpha(segmentOpacity);
 
   segmentationService.setDefaultColorSequence(colorSequence);

--- a/src/renderer/stores/preferencesStore.ts
+++ b/src/renderer/stores/preferencesStore.ts
@@ -30,6 +30,7 @@ interface PreferencesStore {
   setAnnotationBrushSize: (size: number) => void;
   setAnnotationContourThickness: (size: number) => void;
   setAnnotationMaskOutlines: (enabled: boolean) => void;
+  setAnnotationAutoDisplay: (enabled: boolean) => void;
   setAnnotationSegmentOpacity: (opacity: number) => void;
   setAnnotationColorSequence: (colors: string[]) => void;
   // ─── Interpolation ─────────────────────────────────────
@@ -97,6 +98,7 @@ function makeDefaultPreferences(): PreferencesV1 {
       defaultBrushSize: DEFAULT_PREFERENCES.annotation.defaultBrushSize,
       defaultContourThickness: DEFAULT_PREFERENCES.annotation.defaultContourThickness,
       defaultMaskOutlines: DEFAULT_PREFERENCES.annotation.defaultMaskOutlines,
+      autoDisplayAnnotations: DEFAULT_PREFERENCES.annotation.autoDisplayAnnotations,
       defaultSegmentOpacity: DEFAULT_PREFERENCES.annotation.defaultSegmentOpacity,
       defaultColorSequence: cloneDefaultColorSequence(),
     },
@@ -193,6 +195,10 @@ function mergeAnnotationPreferences(current: AnnotationToolPreferences, incoming
       typeof candidate.defaultMaskOutlines === 'boolean'
         ? candidate.defaultMaskOutlines
         : current.defaultMaskOutlines,
+    autoDisplayAnnotations:
+      typeof candidate.autoDisplayAnnotations === 'boolean'
+        ? candidate.autoDisplayAnnotations
+        : current.autoDisplayAnnotations,
     defaultSegmentOpacity:
       typeof candidate.defaultSegmentOpacity === 'number' && Number.isFinite(candidate.defaultSegmentOpacity)
         ? clampNumber(candidate.defaultSegmentOpacity, 0, 1)
@@ -347,6 +353,17 @@ export const usePreferencesStore = create<PreferencesStore>()(
           },
         })),
 
+      setAnnotationAutoDisplay: (enabled) =>
+        set((state) => ({
+          preferences: {
+            ...state.preferences,
+            annotation: {
+              ...state.preferences.annotation,
+              autoDisplayAnnotations: enabled,
+            },
+          },
+        })),
+
       setAnnotationSegmentOpacity: (opacity) =>
         set((state) => ({
           preferences: {
@@ -365,6 +382,10 @@ export const usePreferencesStore = create<PreferencesStore>()(
             annotation: {
               ...state.preferences.annotation,
               defaultColorSequence: sanitizeColorSequence(colors),
+            },
+          },
+        })),
+
       // ─── Interpolation ────────────────────────────────────
 
       setInterpolationEnabled: (enabled) =>

--- a/src/shared/types/preferences.ts
+++ b/src/shared/types/preferences.ts
@@ -36,6 +36,7 @@ export interface AnnotationToolPreferences {
   defaultBrushSize: number;
   defaultContourThickness: number;
   defaultMaskOutlines: boolean;
+  autoDisplayAnnotations: boolean;
   defaultSegmentOpacity: number;
   defaultColorSequence: HexColor[];
 }
@@ -141,6 +142,7 @@ export const DEFAULT_PREFERENCES: PreferencesV1 = {
     defaultBrushSize: 5,
     defaultContourThickness: 2,
     defaultMaskOutlines: true,
+    autoDisplayAnnotations: true,
     defaultSegmentOpacity: 0.5,
     defaultColorSequence: DEFAULT_SEGMENT_COLOR_SEQUENCE,
   },


### PR DESCRIPTION
## Summary
- add macOS packaging signing/notarization config and tracked entitlements files
- add signed mac packaging/troubleshooting docs in README
- move "Automatically display annotations" into Preferences > Annotation and persist it in preferences schema/store/apply flow
- update the settings icon to a clearer gear style
- restructure toolbar so the settings button stays visible while other controls reflow/scroll
- remove the old auto-display checkbox from the segmentation panel footer

## Validation
- npm run build