### PR TITLE
Add mac signing setup and UI preferences cleanup

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -40,6 +40,8 @@ import { useSegmentationManagerStore } from './stores/segmentationManagerStore';
 import { segmentationManager } from './lib/segmentation/segmentationManagerSingleton';
 import { getSegReferenceInfo } from './lib/dicom/segReferencedSeriesUid';
 import { applyPreferences } from './lib/preferences/applyPreferences';
+import AppDialogHost from './components/dialog/AppDialogHost';
+import { showConfirmDialog } from './stores/dialogStore';
 
 /** DICOM SEG SOP Class UID */
 const SEG_SOP_CLASS_UID = '1.2.840.10008.5.1.4.1.1.66.4';
@@ -210,12 +212,16 @@ async function checkForAutoSaveRecovery(
       }
 
       const typeLabel = isRtStruct ? 'contour (RTSTRUCT)' : 'segmentation';
-      const recover = window.confirm(
+      const recover = await showConfirmDialog({
+        title: `Recover Auto-Saved ${isRtStruct ? 'RTSTRUCT' : 'Segmentation'}`,
+        confirmLabel: 'Recover',
+        cancelLabel: 'Skip',
+        message:
         `An auto-saved ${typeLabel} was found.\n\n` +
         `${refLabel ? `Linked by ${refLabel}.\n\n` : ''}` +
         `This may be from an editing session that was not saved.\n\n` +
         `Would you like to recover it?`,
-      );
+      });
 
       if (recover) {
         try {
@@ -255,7 +261,13 @@ async function checkForAutoSaveRecovery(
           console.error(`[App] Failed to load recovered auto-save file "${file.name}":`, err);
         }
       } else {
-        const deleteIt = window.confirm('Delete this auto-saved file?');
+        const deleteIt = await showConfirmDialog({
+          title: 'Delete Auto-Saved File',
+          message: 'Delete this auto-saved file?',
+          confirmLabel: 'Delete',
+          cancelLabel: 'Keep',
+          tone: 'danger',
+        });
         if (deleteIt) {
           await window.electronAPI.xnat.deleteTempFile(sessionId, file.name).catch(() => {});
         }
@@ -2830,6 +2842,7 @@ export default function App() {
           </div>
         </div>
       )}
+      <AppDialogHost />
     </div>
   );
 }

--- a/src/renderer/components/connection/ConnectionStatus.tsx
+++ b/src/renderer/components/connection/ConnectionStatus.tsx
@@ -10,6 +10,7 @@ import { useSegmentationStore } from '../../stores/segmentationStore';
 import { segmentationManager } from '../../lib/segmentation/segmentationManagerSingleton';
 import { segmentationService } from '../../lib/cornerstone/segmentationService';
 import { clearServerScopedStorage } from '../../lib/pinnedItems';
+import { showConfirmDialog } from '../../stores/dialogStore';
 import { IconDisconnect } from '../icons';
 
 export default function ConnectionStatus() {
@@ -35,24 +36,36 @@ export default function ConnectionStatus() {
       segmentationManager.hasDirtySegmentations();
 
     if (hasUnsaved) {
-      const saveDraft = window.confirm(
-        'You have unsaved annotations.\n\n' +
-        'Press OK to save a recoverable draft before disconnecting.\n' +
-        'Press Cancel to choose whether to discard changes.',
-      );
+      const saveDraft = await showConfirmDialog({
+        title: 'Unsaved Annotations',
+        message:
+          'You have unsaved annotations.\n\n' +
+          'Press Save Draft to keep a recoverable copy before disconnecting.\n' +
+          'Press Discard to choose whether to drop changes.',
+        confirmLabel: 'Save Draft',
+        cancelLabel: 'Discard',
+      });
 
       if (saveDraft) {
         const saved = await segmentationService.flushAutoSaveNow();
         if (!saved) {
-          const discardAfterFailed = window.confirm(
-            'Could not save a draft. Disconnect anyway and discard unsaved changes?',
-          );
+          const discardAfterFailed = await showConfirmDialog({
+            title: 'Draft Save Failed',
+            message: 'Could not save a draft. Disconnect anyway and discard unsaved changes?',
+            confirmLabel: 'Disconnect',
+            cancelLabel: 'Stay Connected',
+            tone: 'danger',
+          });
           if (!discardAfterFailed) return;
         }
       } else {
-        const discard = window.confirm(
-          'Disconnect and discard unsaved annotations?',
-        );
+        const discard = await showConfirmDialog({
+          title: 'Discard Unsaved Annotations',
+          message: 'Disconnect and discard unsaved annotations?',
+          confirmLabel: 'Disconnect',
+          cancelLabel: 'Cancel',
+          tone: 'danger',
+        });
         if (!discard) return;
       }
     }

--- a/src/renderer/components/dialog/AppDialogHost.tsx
+++ b/src/renderer/components/dialog/AppDialogHost.tsx
@@ -1,0 +1,75 @@
+import { useEffect } from 'react';
+import { useDialogStore } from '../../stores/dialogStore';
+
+export default function AppDialogHost() {
+  const active = useDialogStore((s) => s.active);
+  const resolveActive = useDialogStore((s) => s.resolveActive);
+
+  useEffect(() => {
+    if (!active) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        resolveActive(false);
+        return;
+      }
+      if (event.key === 'Enter') {
+        resolveActive(true);
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [active, resolveActive]);
+
+  if (!active) return null;
+
+  const isConfirm = active.kind === 'confirm';
+
+  return (
+    <div className="fixed inset-0 z-[200] flex items-center justify-center p-4">
+      <button
+        type="button"
+        aria-label="Close dialog"
+        className="absolute inset-0 bg-zinc-950/70"
+        onClick={() => resolveActive(false)}
+      />
+
+      <div className="relative w-full max-w-md rounded-xl border border-zinc-700 bg-zinc-900 shadow-2xl">
+        <div className="border-b border-zinc-800 px-4 py-3">
+          <h3 className="text-sm font-semibold text-zinc-100">{active.title}</h3>
+        </div>
+
+        <div className="px-4 py-3">
+          <p className="whitespace-pre-wrap text-xs leading-relaxed text-zinc-300">
+            {active.message}
+          </p>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t border-zinc-800 px-4 py-3">
+          {isConfirm && (
+            <button
+              type="button"
+              onClick={() => resolveActive(false)}
+              className="rounded bg-zinc-800 px-3 py-1.5 text-xs text-zinc-200 transition-colors hover:bg-zinc-700"
+            >
+              {active.cancelLabel}
+            </button>
+          )}
+
+          <button
+            type="button"
+            onClick={() => resolveActive(true)}
+            className={`rounded px-3 py-1.5 text-xs transition-colors ${
+              active.tone === 'danger'
+                ? 'bg-red-600 text-white hover:bg-red-500'
+                : 'bg-blue-600 text-white hover:bg-blue-500'
+            }`}
+          >
+            {active.confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/stores/dialogStore.ts
+++ b/src/renderer/stores/dialogStore.ts
@@ -1,0 +1,100 @@
+import { create } from 'zustand';
+
+type DialogKind = 'confirm' | 'alert';
+type DialogTone = 'default' | 'danger';
+
+interface DialogRequest {
+  id: number;
+  kind: DialogKind;
+  title: string;
+  message: string;
+  confirmLabel: string;
+  cancelLabel: string;
+  tone: DialogTone;
+}
+
+interface DialogStore {
+  active: DialogRequest | null;
+  queue: DialogRequest[];
+  enqueue: (request: DialogRequest) => void;
+  resolveActive: (confirmed: boolean) => void;
+}
+
+interface ConfirmDialogOptions {
+  title?: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  tone?: DialogTone;
+}
+
+interface AlertDialogOptions {
+  title?: string;
+  message: string;
+  confirmLabel?: string;
+}
+
+const resolvers = new Map<number, (result: boolean) => void>();
+let nextDialogId = 1;
+
+export const useDialogStore = create<DialogStore>((set, get) => ({
+  active: null,
+  queue: [],
+
+  enqueue: (request) =>
+    set((state) => {
+      if (!state.active) {
+        return { ...state, active: request };
+      }
+      return { ...state, queue: [...state.queue, request] };
+    }),
+
+  resolveActive: (confirmed) => {
+    const { active, queue } = get();
+    if (!active) return;
+
+    const resolver = resolvers.get(active.id);
+    if (resolver) {
+      resolver(confirmed);
+      resolvers.delete(active.id);
+    }
+
+    const [next, ...rest] = queue;
+    set({
+      active: next ?? null,
+      queue: rest,
+    });
+  },
+}));
+
+export function showConfirmDialog(options: ConfirmDialogOptions): Promise<boolean> {
+  return new Promise((resolve) => {
+    const id = nextDialogId++;
+    resolvers.set(id, resolve);
+    useDialogStore.getState().enqueue({
+      id,
+      kind: 'confirm',
+      title: options.title ?? 'Confirm Action',
+      message: options.message,
+      confirmLabel: options.confirmLabel ?? 'Confirm',
+      cancelLabel: options.cancelLabel ?? 'Cancel',
+      tone: options.tone ?? 'default',
+    });
+  });
+}
+
+export function showAlertDialog(options: AlertDialogOptions): Promise<void> {
+  return new Promise((resolve) => {
+    const id = nextDialogId++;
+    resolvers.set(id, () => resolve());
+    useDialogStore.getState().enqueue({
+      id,
+      kind: 'alert',
+      title: options.title ?? 'Notice',
+      message: options.message,
+      confirmLabel: options.confirmLabel ?? 'OK',
+      cancelLabel: 'Cancel',
+      tone: 'default',
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add macOS packaging signing/notarization config and tracked entitlements files
- add signed mac packaging/troubleshooting docs in README
- move "Automatically display annotations" into Preferences > Annotation and persist it in preferences schema/store/apply flow
- update the settings icon to a clearer gear style
- restructure toolbar so the settings button stays visible while other controls reflow/scroll
- replace native confirm popups with a global in-app styled dialog system

## Validation
- npm run build