### PR TITLE
Add local file backup cache for annotation auto-save

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,9 +1,11 @@
-import { app, BrowserWindow, Menu, nativeImage } from 'electron';
+import { app, BrowserWindow, Menu, nativeImage, ipcMain, shell } from 'electron';
 import path from 'path';
 import { registerAuthHandlers } from './ipc/authHandlers';
 import { registerProxyHandlers } from './ipc/proxyHandlers';
 import { registerExportHandlers } from './ipc/exportHandlers';
 import { registerUploadHandlers } from './ipc/uploadHandlers';
+import { registerBackupHandlers } from './ipc/backupHandlers';
+import { IPC } from '../shared/ipcChannels';
 
 // Suppress EPIPE errors from console.log when stdout/stderr pipe is broken.
 // This is common when Electron is launched from a terminal that disconnects.
@@ -178,6 +180,17 @@ app.whenReady().then(() => {
   registerProxyHandlers();
   registerExportHandlers();
   registerUploadHandlers();
+  registerBackupHandlers();
+
+  // Shell: open URL in system browser
+  ipcMain.handle(IPC.SHELL_OPEN_EXTERNAL, async (_event, url: string) => {
+    // Only allow http(s) URLs
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      await shell.openExternal(url);
+      return { ok: true };
+    }
+    return { ok: false, error: 'invalid_url' };
+  });
 
   // Set the macOS dock icon (dev mode only — packaged app uses Info.plist).
   // In dev mode we can only use PNG; macOS won't apply the rounded-square

--- a/src/main/ipc/backupHandlers.ts
+++ b/src/main/ipc/backupHandlers.ts
@@ -1,0 +1,255 @@
+/**
+ * IPC handlers for local backup cache operations.
+ *
+ * Manages a per-session backup directory under Electron's userData path:
+ *   <userData>/backups/<sessionId>/manifest.json
+ *   <userData>/backups/<sessionId>/<segId>_<timestamp>.dcm
+ *
+ * All file I/O is async via fs/promises.
+ */
+import { ipcMain, app } from 'electron';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { IPC } from '../../shared/ipcChannels';
+import type { BackupManifest, BackupSessionSummary } from '../../shared/types/backup';
+
+let backupRoot: string | null = null;
+
+function getBackupRoot(): string {
+  if (!backupRoot) {
+    backupRoot = path.join(app.getPath('userData'), 'backups');
+  }
+  return backupRoot;
+}
+
+function sessionDir(sessionId: string): string {
+  // Sanitize sessionId to prevent path traversal
+  const safe = sessionId.replace(/[^a-zA-Z0-9_\-\.]/g, '_');
+  return path.join(getBackupRoot(), safe);
+}
+
+async function ensureDir(dir: string): Promise<void> {
+  await fs.mkdir(dir, { recursive: true });
+}
+
+export function registerBackupHandlers(): void {
+  // ─── Write a backup file ─────────────────────────────────────
+  ipcMain.handle(
+    IPC.BACKUP_WRITE_FILE,
+    async (
+      _event: Electron.IpcMainInvokeEvent,
+      sessionId: string,
+      filename: string,
+      base64Data: string,
+    ) => {
+      try {
+        const dir = sessionDir(sessionId);
+        await ensureDir(dir);
+        const filePath = path.join(dir, filename);
+        const buffer = Buffer.from(base64Data, 'base64');
+        await fs.writeFile(filePath, buffer);
+        return { ok: true, path: filePath, sizeBytes: buffer.length };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[backupHandlers] writeFile error:', msg);
+        return { ok: false, error: msg };
+      }
+    },
+  );
+
+  // ─── Read a backup file ──────────────────────────────────────
+  ipcMain.handle(
+    IPC.BACKUP_READ_FILE,
+    async (
+      _event: Electron.IpcMainInvokeEvent,
+      sessionId: string,
+      filename: string,
+    ) => {
+      try {
+        const filePath = path.join(sessionDir(sessionId), filename);
+        const buffer = await fs.readFile(filePath);
+        return { ok: true, data: buffer.toString('base64') };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[backupHandlers] readFile error:', msg);
+        return { ok: false, error: msg };
+      }
+    },
+  );
+
+  // ─── Delete a backup file ────────────────────────────────────
+  ipcMain.handle(
+    IPC.BACKUP_DELETE_FILE,
+    async (
+      _event: Electron.IpcMainInvokeEvent,
+      sessionId: string,
+      filename: string,
+    ) => {
+      try {
+        const filePath = path.join(sessionDir(sessionId), filename);
+        await fs.unlink(filePath).catch(() => {}); // ignore if already gone
+        return { ok: true };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[backupHandlers] deleteFile error:', msg);
+        return { ok: false, error: msg };
+      }
+    },
+  );
+
+  // ─── List files in a session's backup directory ──────────────
+  ipcMain.handle(
+    IPC.BACKUP_LIST_SESSION,
+    async (
+      _event: Electron.IpcMainInvokeEvent,
+      sessionId: string,
+    ) => {
+      try {
+        const dir = sessionDir(sessionId);
+        let fileNames: string[];
+        try {
+          fileNames = await fs.readdir(dir);
+        } catch {
+          return { ok: true, files: [] }; // directory doesn't exist yet
+        }
+        const files: Array<{ name: string; sizeBytes: number; modifiedAt: string }> = [];
+        for (const name of fileNames) {
+          if (!name.endsWith('.dcm')) continue;
+          try {
+            const stat = await fs.stat(path.join(dir, name));
+            if (!stat.isFile()) continue;
+            files.push({
+              name,
+              sizeBytes: stat.size,
+              modifiedAt: stat.mtime.toISOString(),
+            });
+          } catch { /* skip */ }
+        }
+        return { ok: true, files };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[backupHandlers] listSession error:', msg);
+        return { ok: false, error: msg };
+      }
+    },
+  );
+
+  // ─── Read manifest.json ──────────────────────────────────────
+  ipcMain.handle(
+    IPC.BACKUP_READ_MANIFEST,
+    async (
+      _event: Electron.IpcMainInvokeEvent,
+      sessionId: string,
+    ) => {
+      try {
+        const manifestPath = path.join(sessionDir(sessionId), 'manifest.json');
+        const raw = await fs.readFile(manifestPath, 'utf-8');
+        const manifest: BackupManifest = JSON.parse(raw);
+        return { ok: true, manifest };
+      } catch (err: any) {
+        if (err?.code === 'ENOENT') {
+          return { ok: false, error: 'not_found' };
+        }
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[backupHandlers] readManifest error:', msg);
+        return { ok: false, error: msg };
+      }
+    },
+  );
+
+  // ─── Write manifest.json (atomic: write to .tmp then rename) ─
+  ipcMain.handle(
+    IPC.BACKUP_WRITE_MANIFEST,
+    async (
+      _event: Electron.IpcMainInvokeEvent,
+      sessionId: string,
+      manifestJson: string,
+    ) => {
+      try {
+        const dir = sessionDir(sessionId);
+        await ensureDir(dir);
+        const manifestPath = path.join(dir, 'manifest.json');
+        const tmpPath = manifestPath + '.tmp';
+        await fs.writeFile(tmpPath, manifestJson, 'utf-8');
+        await fs.rename(tmpPath, manifestPath);
+        return { ok: true };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[backupHandlers] writeManifest error:', msg);
+        return { ok: false, error: msg };
+      }
+    },
+  );
+
+  // ─── Delete entire session backup directory ──────────────────
+  ipcMain.handle(
+    IPC.BACKUP_DELETE_SESSION,
+    async (
+      _event: Electron.IpcMainInvokeEvent,
+      sessionId: string,
+    ) => {
+      try {
+        const dir = sessionDir(sessionId);
+        await fs.rm(dir, { recursive: true, force: true });
+        return { ok: true };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[backupHandlers] deleteSession error:', msg);
+        return { ok: false, error: msg };
+      }
+    },
+  );
+
+  // ─── List all session backup directories with summaries ──────
+  ipcMain.handle(
+    IPC.BACKUP_LIST_ALL_SESSIONS,
+    async () => {
+      try {
+        const root = getBackupRoot();
+        let dirNames: string[];
+        try {
+          dirNames = await fs.readdir(root);
+        } catch {
+          return { ok: true, sessions: [] }; // root doesn't exist yet
+        }
+
+        const sessions: BackupSessionSummary[] = [];
+        for (const dirName of dirNames) {
+          const manifestPath = path.join(root, dirName, 'manifest.json');
+          try {
+            const raw = await fs.readFile(manifestPath, 'utf-8');
+            const manifest: BackupManifest = JSON.parse(raw);
+            const totalSize = manifest.entries.reduce((sum, e) => sum + e.sizeBytes, 0);
+            sessions.push({
+              sessionId: manifest.sessionId,
+              serverUrl: manifest.serverUrl,
+              entryCount: manifest.entries.length,
+              totalSizeBytes: totalSize,
+              lastUpdated: manifest.lastUpdated,
+              projectId: manifest.projectId ?? '',
+              subjectId: manifest.subjectId ?? '',
+              subjectLabel: manifest.subjectLabel ?? '',
+              sessionLabel: manifest.sessionLabel ?? manifest.sessionId,
+            });
+          } catch {
+            // No manifest or invalid — skip
+          }
+        }
+
+        return { ok: true, sessions };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[backupHandlers] listAllSessions error:', msg);
+        return { ok: false, error: msg };
+      }
+    },
+  );
+
+  // ─── Get the backup cache root path ──────────────────────────
+  ipcMain.handle(
+    IPC.BACKUP_GET_CACHE_PATH,
+    async () => {
+      return { ok: true, path: getBackupRoot() };
+    },
+  );
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -136,6 +136,32 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke(IPC.EXPORT_SAVE_VIEWPORT_CAPTURE, bounds, defaultName),
   },
 
+  shell: {
+    openExternal: (url: string) =>
+      ipcRenderer.invoke(IPC.SHELL_OPEN_EXTERNAL, url),
+  },
+
+  backup: {
+    writeFile: (sessionId: string, filename: string, base64Data: string) =>
+      ipcRenderer.invoke(IPC.BACKUP_WRITE_FILE, sessionId, filename, base64Data),
+    readFile: (sessionId: string, filename: string) =>
+      ipcRenderer.invoke(IPC.BACKUP_READ_FILE, sessionId, filename),
+    deleteFile: (sessionId: string, filename: string) =>
+      ipcRenderer.invoke(IPC.BACKUP_DELETE_FILE, sessionId, filename),
+    listSession: (sessionId: string) =>
+      ipcRenderer.invoke(IPC.BACKUP_LIST_SESSION, sessionId),
+    readManifest: (sessionId: string) =>
+      ipcRenderer.invoke(IPC.BACKUP_READ_MANIFEST, sessionId),
+    writeManifest: (sessionId: string, manifestJson: string) =>
+      ipcRenderer.invoke(IPC.BACKUP_WRITE_MANIFEST, sessionId, manifestJson),
+    deleteSession: (sessionId: string) =>
+      ipcRenderer.invoke(IPC.BACKUP_DELETE_SESSION, sessionId),
+    listAllSessions: () =>
+      ipcRenderer.invoke(IPC.BACKUP_LIST_ALL_SESSIONS),
+    getCachePath: () =>
+      ipcRenderer.invoke(IPC.BACKUP_GET_CACHE_PATH),
+  },
+
   on: (channel: string, callback: (...args: unknown[]) => void) => {
     const allowedChannels = [IPC.XNAT_SESSION_EXPIRED];
     if (!allowedChannels.includes(channel as any)) {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -40,6 +40,8 @@ import { useSegmentationManagerStore } from './stores/segmentationManagerStore';
 import { segmentationManager } from './lib/segmentation/segmentationManagerSingleton';
 import { getSegReferenceInfo } from './lib/dicom/segReferencedSeriesUid';
 import { applyPreferences } from './lib/preferences/applyPreferences';
+import { backupService } from './lib/backup/backupService';
+import { segmentationService } from './lib/cornerstone/segmentationService';
 
 /** DICOM SEG SOP Class UID */
 const SEG_SOP_CLASS_UID = '1.2.840.10008.5.1.4.1.1.66.4';
@@ -81,6 +83,15 @@ interface UnsavedNavigationDialogState {
   open: boolean;
 }
 
+/** State for the styled recovery confirm dialog (replaces window.confirm). */
+interface RecoveryConfirmDialogState {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel: string;
+  cancelLabel: string;
+}
+
 // isSegScan, isRtStructScan, isDerivedScan imported from sessionDerivedIndexStore
 // getSegReferenceInfo imported from lib/dicom/segReferencedSeriesUid
 
@@ -110,29 +121,225 @@ function releaseSegLock(scanId: string): void {
 }
 
 /**
- * Check for auto-saved temp files on the XNAT session and prompt recovery.
+ * Check for auto-saved files and prompt recovery.
+ *
+ * Checks two sources in order:
+ *   1. Local filesystem backup cache (via backupService)
+ *   2. Legacy XNAT temp resource files (backward compatibility)
+ *
  * Called after all scans are loaded in loadSessionFromXnat().
  */
 async function checkForAutoSaveRecovery(
   sessionId: string,
   scanIdToPanelInfo: Map<string, { pid: string; ids: string[] }>,
+  confirm: (title: string, message: string, confirmLabel?: string, cancelLabel?: string) => Promise<boolean>,
 ): Promise<void> {
   // Only check once per session to avoid repeated dialog prompts
   if (recoveredSessions.has(sessionId)) return;
 
+  const loadedPanelsById: Record<string, string[]> = {};
+  for (const panelInfo of scanIdToPanelInfo.values()) {
+    loadedPanelsById[panelInfo.pid] = panelInfo.ids;
+  }
+
+  // ─── Phase 1: Check local filesystem backup cache ───────────────
+  try {
+    const manifest = await backupService.getManifestForSession(sessionId);
+    console.log(`[App] Local backup check for ${sessionId}: ${manifest ? manifest.entries.length + ' entries' : 'no manifest'}`);
+    if (manifest && manifest.entries.length > 0) {
+      for (const entry of manifest.entries) {
+        const isRtStruct = entry.format === 'RTSTRUCT';
+
+        // ── Step 1: Match backup to a loaded panel ──
+        // Primary: use the manifest's sourceScanId to look up in scanIdToPanelInfo
+        // (This is reliable even before Cornerstone metadata is loaded)
+        let targetPanelInfo: { panelId: string; imageIds: string[] } | null = null;
+        let refLabel = '';
+        let earlyArrayBuffer: ArrayBuffer | null = null;
+
+        const panelBySourceScan = scanIdToPanelInfo.get(entry.sourceScanId);
+        if (panelBySourceScan) {
+          targetPanelInfo = { panelId: panelBySourceScan.pid, imageIds: panelBySourceScan.ids };
+          refLabel = `source scan #${entry.sourceScanId}`;
+          console.log(`[App] Matched backup "${entry.filename}" to panel ${panelBySourceScan.pid} via sourceScanId ${entry.sourceScanId}`);
+        }
+
+        // Fallback: parse the DICOM backup and match by series/SOP UIDs
+        // (Only needed if sourceScanId doesn't match — e.g. legacy backups)
+        if (!targetPanelInfo) {
+          try {
+            const base64 = await backupService.readSegmentation(sessionId, entry.filename);
+            const binaryString = atob(base64);
+            const bytes = new Uint8Array(binaryString.length);
+            for (let i = 0; i < binaryString.length; i++) {
+              bytes[i] = binaryString.charCodeAt(i);
+            }
+            earlyArrayBuffer = bytes.buffer;
+          } catch (err) {
+            console.error(`[App] Failed to read local backup "${entry.filename}":`, err);
+            continue;
+          }
+
+          try {
+            if (isRtStruct) {
+              const parsedRt = rtStructService.parseRtStruct(earlyArrayBuffer);
+              if (parsedRt.referencedSeriesUID) {
+                targetPanelInfo = findPanelBySeriesUID(parsedRt.referencedSeriesUID, loadedPanelsById);
+                if (targetPanelInfo) refLabel = `SeriesInstanceUID ${parsedRt.referencedSeriesUID}`;
+              }
+              if (!targetPanelInfo) {
+                const referencedSops = new Set<string>();
+                for (const roi of parsedRt.rois) {
+                  for (const contour of roi.contours) {
+                    if (contour.referencedSOPInstanceUID) {
+                      referencedSops.add(contour.referencedSOPInstanceUID);
+                    }
+                  }
+                }
+                if (referencedSops.size > 0) {
+                  targetPanelInfo = findPanelByReferencedSopInstanceUIDs(
+                    Array.from(referencedSops),
+                    loadedPanelsById,
+                  );
+                  if (targetPanelInfo) refLabel = `${referencedSops.size} referenced SOP UID(s)`;
+                }
+              }
+            } else {
+              const refInfo = getSegReferenceInfo(earlyArrayBuffer);
+              if (refInfo.referencedSeriesUID) {
+                targetPanelInfo = findPanelBySeriesUID(refInfo.referencedSeriesUID, loadedPanelsById);
+                if (targetPanelInfo) refLabel = `SeriesInstanceUID ${refInfo.referencedSeriesUID}`;
+              }
+              if (!targetPanelInfo && refInfo.referencedSOPInstanceUIDs.length > 0) {
+                targetPanelInfo = findPanelByReferencedSopInstanceUIDs(
+                  refInfo.referencedSOPInstanceUIDs,
+                  loadedPanelsById,
+                );
+                if (targetPanelInfo) refLabel = `${refInfo.referencedSOPInstanceUIDs.length} referenced SOP UID(s)`;
+              }
+            }
+          } catch (err) {
+            console.error(`[App] Failed to parse local backup "${entry.filename}":`, err);
+          }
+        }
+
+        if (!targetPanelInfo) {
+          console.warn(
+            `[App] Local backup recovery: could not resolve loaded source for ${entry.filename}`
+            + ` (sourceScanId: ${entry.sourceScanId})`,
+          );
+          continue;
+        }
+
+        // ── Step 2: Read the backup file (if not already read in fallback) ──
+        let arrayBuffer: ArrayBuffer;
+        if (earlyArrayBuffer) {
+          arrayBuffer = earlyArrayBuffer;
+        } else {
+          try {
+            const base64 = await backupService.readSegmentation(sessionId, entry.filename);
+            const binaryString = atob(base64);
+            const bytes = new Uint8Array(binaryString.length);
+            for (let i = 0; i < binaryString.length; i++) {
+              bytes[i] = binaryString.charCodeAt(i);
+            }
+            arrayBuffer = bytes.buffer;
+          } catch (err) {
+            console.error(`[App] Failed to read local backup "${entry.filename}":`, err);
+            continue;
+          }
+        }
+
+        // ── Step 3: Prompt the user for recovery ──
+        const recover = await confirm(
+          'Recover backup',
+          `A recovered annotation was identified for Scan #${entry.sourceScanId}.`,
+          'Recover',
+          'Skip',
+        );
+
+        if (recover) {
+          try {
+            await preloadImages(targetPanelInfo.imageIds);
+
+            let recoveredSegId: string;
+            if (isRtStruct) {
+              const { segmentationId, firstReferencedImageId } =
+                await segmentationManager.loadRtStructFromArrayBuffer(
+                  targetPanelInfo.panelId,
+                  arrayBuffer,
+                  targetPanelInfo.imageIds,
+                );
+              recoveredSegId = segmentationId;
+              await jumpViewportToReferencedImage(targetPanelInfo.panelId, firstReferencedImageId);
+            } else {
+              const { segmentationId, firstNonZeroReferencedImageId } =
+                await segmentationManager.loadSegFromArrayBuffer(
+                  targetPanelInfo.panelId,
+                  arrayBuffer,
+                  targetPanelInfo.imageIds,
+                );
+              recoveredSegId = segmentationId;
+              await jumpViewportToReferencedImage(targetPanelInfo.panelId, firstNonZeroReferencedImageId);
+            }
+
+            // Register in tracking store so SegmentationPanel includes this in its filter
+            const panelContext = useViewerStore.getState().panelXnatContextMap[targetPanelInfo.panelId];
+            if (panelContext?.projectId) {
+              const compositeKey = `${panelContext.projectId}/${sessionId}/${entry.sourceScanId}`;
+              useSegmentationManagerStore.getState().setLocalOrigin(recoveredSegId, compositeKey);
+            }
+
+            // Delete the recovered backup entry
+            await backupService.deleteBackupEntry(sessionId, entry.filename).catch(() => {});
+
+            console.log(
+              `[App] Recovered local backup ${isRtStruct ? 'RTSTRUCT' : 'SEG'} "${entry.filename}" `
+              + `on ${targetPanelInfo.panelId} as ${recoveredSegId}`,
+            );
+
+            segmentationService.sync();
+            const segStore = useSegmentationStore.getState();
+            if (!segStore.showPanel) segStore.togglePanel();
+          } catch (err) {
+            console.error(`[App] Failed to load recovered local backup "${entry.filename}":`, err);
+          }
+        } else {
+          const deleteIt = await confirm(
+            'Delete backup',
+            'Delete this backed-up file? This cannot be undone.',
+            'Delete',
+            'Keep',
+          );
+          if (deleteIt) {
+            await backupService.deleteBackupEntry(sessionId, entry.filename).catch(() => {});
+          }
+        }
+      }
+    }
+  } catch (err) {
+    console.error('[App] Local backup recovery check failed:', err);
+    // Non-fatal — fall through to XNAT temp check
+  }
+
+  // Mark recovery as checked — always do this regardless of Phase 2 outcome
+  recoveredSessions.add(sessionId);
+
+  // ─── Phase 2: Check legacy XNAT temp resource files ─────────────
   try {
     const result = await window.electronAPI.xnat.listTempFiles(sessionId);
-    if (!result.ok || !result.files || result.files.length === 0) return;
+    if (!result.ok || !result.files || result.files.length === 0) {
+      recoveredSessions.add(sessionId);
+      return;
+    }
 
     // Find auto-save files (both SEG and RTSTRUCT)
     const autoSaveFiles = result.files.filter(
       (f) => (f.name.startsWith('autosave_seg_') || f.name.startsWith('autosave_rtstruct_')) && f.name.endsWith('.dcm'),
     );
-    if (autoSaveFiles.length === 0) return;
-
-    const loadedPanelsById: Record<string, string[]> = {};
-    for (const panelInfo of scanIdToPanelInfo.values()) {
-      loadedPanelsById[panelInfo.pid] = panelInfo.ids;
+    if (autoSaveFiles.length === 0) {
+      recoveredSessions.add(sessionId);
+      return;
     }
 
     for (const file of autoSaveFiles) {
@@ -209,12 +416,12 @@ async function checkForAutoSaveRecovery(
         continue;
       }
 
-      const typeLabel = isRtStruct ? 'contour (RTSTRUCT)' : 'segmentation';
-      const recover = window.confirm(
-        `An auto-saved ${typeLabel} was found.\n\n` +
-        `${refLabel ? `Linked by ${refLabel}.\n\n` : ''}` +
-        `This may be from an editing session that was not saved.\n\n` +
-        `Would you like to recover it?`,
+      const scanLabel = sourceScanHint ?? 'unknown';
+      const recover = await confirm(
+        'Recover backup',
+        `A recovered annotation was identified for Scan #${scanLabel}.`,
+        'Recover',
+        'Skip',
       );
 
       if (recover) {
@@ -242,20 +449,34 @@ async function checkForAutoSaveRecovery(
             await jumpViewportToReferencedImage(targetPanelInfo.panelId, firstNonZeroReferencedImageId);
           }
 
+          // Register in tracking store so SegmentationPanel includes this in its filter
+          const panelContext2 = useViewerStore.getState().panelXnatContextMap[targetPanelInfo.panelId];
+          const sourceScan2 = sourceScanHint ?? useViewerStore.getState().panelScanMap[targetPanelInfo.panelId];
+          if (panelContext2?.projectId && sourceScan2) {
+            const compositeKey = `${panelContext2.projectId}/${sessionId}/${sourceScan2}`;
+            useSegmentationManagerStore.getState().setLocalOrigin(recoveredSegId, compositeKey);
+          }
+
           await window.electronAPI.xnat.deleteTempFile(sessionId, file.name).catch(() => {});
 
           console.log(
-            `[App] Recovered ${isRtStruct ? 'RTSTRUCT' : 'SEG'} auto-save "${file.name}" `
+            `[App] Recovered ${isRtStruct ? 'RTSTRUCT' : 'SEG'} XNAT temp auto-save "${file.name}" `
             + `on ${targetPanelInfo.panelId} as ${recoveredSegId}`,
           );
 
+          segmentationService.sync();
           const segStore = useSegmentationStore.getState();
           if (!segStore.showPanel) segStore.togglePanel();
         } catch (err) {
           console.error(`[App] Failed to load recovered auto-save file "${file.name}":`, err);
         }
       } else {
-        const deleteIt = window.confirm('Delete this auto-saved file?');
+        const deleteIt = await confirm(
+          'Delete backup',
+          'Delete this auto-saved file? This cannot be undone.',
+          'Delete',
+          'Keep',
+        );
         if (deleteIt) {
           await window.electronAPI.xnat.deleteTempFile(sessionId, file.name).catch(() => {});
         }
@@ -604,11 +825,42 @@ export default function App() {
   });
   const [unsavedNavigationDialog, setUnsavedNavigationDialog] = useState<UnsavedNavigationDialogState>({ open: false });
   const unsavedNavigationResolverRef = useRef<((proceed: boolean) => void) | null>(null);
+
+  // ─── Recovery confirm dialog (replaces native window.confirm) ───
+  const [recoveryConfirmDialog, setRecoveryConfirmDialog] = useState<RecoveryConfirmDialogState>({
+    open: false, title: '', message: '', confirmLabel: 'OK', cancelLabel: 'Cancel',
+  });
+  const recoveryConfirmResolverRef = useRef<((result: boolean) => void) | null>(null);
+
+  const resolveRecoveryConfirmDialog = useCallback((result: boolean) => {
+    const resolver = recoveryConfirmResolverRef.current;
+    recoveryConfirmResolverRef.current = null;
+    setRecoveryConfirmDialog((prev) => ({ ...prev, open: false }));
+    resolver?.(result);
+  }, []);
+
+  const promptRecoveryConfirm = useCallback(
+    async (title: string, message: string, confirmLabel = 'OK', cancelLabel = 'Cancel'): Promise<boolean> => {
+      if (recoveryConfirmResolverRef.current) {
+        recoveryConfirmResolverRef.current(false);
+        recoveryConfirmResolverRef.current = null;
+      }
+      return new Promise<boolean>((resolve) => {
+        recoveryConfirmResolverRef.current = resolve;
+        setRecoveryConfirmDialog({ open: true, title, message, confirmLabel, cancelLabel });
+      });
+    },
+    [],
+  );
+
   const [showBrowser, setShowBrowser] = useState(true);
   const [browserWidth, setBrowserWidth] = useState(288);
   const browserWidthRef = useRef(288); // persists width when collapsed
   const isResizingRef = useRef(false);
   const preferences = usePreferencesStore((s) => s.preferences);
+  const [backupBannerCount, setBackupBannerCount] = useState(0);
+  const [backupBannerDismissed, setBackupBannerDismissed] = useState(false);
+  const [openSettingsToBackup, setOpenSettingsToBackup] = useState(false);
 
   const setBrowserStatusMessage = useCallback(
     (message: string, tone: BrowserStatusTone = 'info', detail = '') => {
@@ -745,6 +997,10 @@ export default function App() {
         unsavedNavigationResolverRef.current(false);
         unsavedNavigationResolverRef.current = null;
       }
+      if (recoveryConfirmResolverRef.current) {
+        recoveryConfirmResolverRef.current(false);
+        recoveryConfirmResolverRef.current = null;
+      }
     };
   }, []);
 
@@ -793,6 +1049,25 @@ export default function App() {
         setInitError(err instanceof Error ? err.message : String(err));
       });
   }, []);
+
+  // ─── Check for local backup files when connected server changes ──
+  const connectedServerUrl = useConnectionStore((s) => s.connection?.serverUrl ?? '');
+  useEffect(() => {
+    if (!connectedServerUrl) {
+      setBackupBannerCount(0);
+      return;
+    }
+    backupService.listAllBackups().then((sessions) => {
+      // Only count entries for the currently connected server
+      const matching = sessions.filter((s) => s.serverUrl === connectedServerUrl);
+      const totalEntries = matching.reduce((sum, s) => sum + s.entryCount, 0);
+      setBackupBannerCount(totalEntries);
+      setBackupBannerDismissed(false);
+      if (totalEntries > 0) {
+        console.log(`[App] Found ${totalEntries} backed-up annotation(s) for ${connectedServerUrl}`);
+      }
+    }).catch(() => { /* ignore */ });
+  }, [connectedServerUrl]);
 
   // ─── Initialize SegmentationManager once Cornerstone is ready ──
   useEffect(() => {
@@ -2290,7 +2565,7 @@ export default function App() {
         }
 
         // ─── Check for auto-save recovery (temp resource files) ──────
-        await checkForAutoSaveRecovery(sessionId, scanIdToPanelInfo);
+        await checkForAutoSaveRecovery(sessionId, scanIdToPanelInfo, promptRecoveryConfirm);
         setBrowserStatusMessage(
           'Session ready',
           'success',
@@ -2306,7 +2581,7 @@ export default function App() {
         setLoading(false);
       }
     },
-    [isConnected, refreshBookmarks, promptToSaveUnsavedAnnotations, setBrowserStatusMessage],
+    [isConnected, refreshBookmarks, promptToSaveUnsavedAnnotations, promptRecoveryConfirm, setBrowserStatusMessage],
   );
 
   /**
@@ -2490,6 +2765,151 @@ export default function App() {
     }
   }
 
+  // ─── Recover backup from Settings → File Backup ─────────────────
+  const handleRecoverBackup = useCallback(async (sessionId: string) => {
+    try {
+      const manifest = await backupService.getManifestForSession(sessionId);
+      if (!manifest || manifest.entries.length === 0) {
+        console.warn('[App] No backup entries to recover for', sessionId);
+        return;
+      }
+
+      // Build scanId → panelId + imageIds mapping from viewerStore
+      let store = useViewerStore.getState();
+
+      // If the matching session isn't loaded, auto-load it from XNAT first
+      if (store.sessionId !== sessionId) {
+        const subjectId = manifest.subjectId;
+        const projectId = manifest.projectId;
+        if (!subjectId || !projectId) {
+          await promptRecoveryConfirm(
+            'Session not loaded',
+            'Load this session in the XNAT browser first, then click Recover again.',
+            'OK',
+            'OK',
+          );
+          return;
+        }
+
+        // Fetch scans from XNAT and load the session
+        const scans = await window.electronAPI.xnat.getScans(sessionId);
+        if (!scans || scans.length === 0) {
+          await promptRecoveryConfirm(
+            'No scans found',
+            'Could not fetch scans for this session from XNAT.',
+            'OK',
+            'OK',
+          );
+          return;
+        }
+
+        // Pre-mark as recovered so checkForAutoSaveRecovery (called at end of
+        // loadSessionFromXnat) doesn't double-prompt for the same entries.
+        recoveredSessions.add(sessionId);
+
+        await loadSessionFromXnat(sessionId, scans, {
+          projectId,
+          subjectId,
+          sessionLabel: manifest.sessionLabel ?? sessionId,
+          subjectLabel: manifest.subjectLabel,
+        });
+
+        // Re-read store after session load
+        store = useViewerStore.getState();
+        if (store.sessionId !== sessionId) {
+          console.warn('[App] Session load did not complete for', sessionId);
+          return;
+        }
+      }
+
+      const scanToPanelMap = new Map<string, { pid: string; ids: string[] }>();
+      for (const [pid, scanId] of Object.entries(store.panelScanMap)) {
+        const ids = store.panelImageIdsMap[pid] ?? [];
+        if (ids.length > 0) {
+          scanToPanelMap.set(scanId, { pid, ids });
+        }
+      }
+
+      let recoveredCount = 0;
+      for (const entry of manifest.entries) {
+        const isRtStruct = entry.format === 'RTSTRUCT';
+
+        // Match by sourceScanId
+        const panel = scanToPanelMap.get(entry.sourceScanId);
+        if (!panel) {
+          console.warn(`[App] Recovery: no panel found for sourceScanId ${entry.sourceScanId} (${entry.filename})`);
+          continue;
+        }
+
+        // Read the backup file
+        let arrayBuffer: ArrayBuffer;
+        try {
+          const base64 = await backupService.readSegmentation(sessionId, entry.filename);
+          const binaryString = atob(base64);
+          const bytes = new Uint8Array(binaryString.length);
+          for (let i = 0; i < binaryString.length; i++) {
+            bytes[i] = binaryString.charCodeAt(i);
+          }
+          arrayBuffer = bytes.buffer;
+        } catch (err) {
+          console.error(`[App] Recovery: failed to read "${entry.filename}":`, err);
+          continue;
+        }
+
+        // Load into the panel
+        try {
+          await preloadImages(panel.ids);
+
+          let recoveredSegId: string;
+          if (isRtStruct) {
+            const { segmentationId } = await segmentationManager.loadRtStructFromArrayBuffer(
+              panel.pid, arrayBuffer, panel.ids,
+            );
+            recoveredSegId = segmentationId;
+            console.log(`[App] Recovered RTSTRUCT "${entry.filename}" → ${panel.pid} as ${recoveredSegId}`);
+          } else {
+            const { segmentationId } = await segmentationManager.loadSegFromArrayBuffer(
+              panel.pid, arrayBuffer, panel.ids,
+            );
+            recoveredSegId = segmentationId;
+            console.log(`[App] Recovered SEG "${entry.filename}" → ${panel.pid} as ${recoveredSegId}`);
+          }
+
+          // Register in tracking store so SegmentationPanel includes this in its filter
+          const panelContext = store.panelXnatContextMap[panel.pid];
+          if (panelContext?.projectId) {
+            const compositeKey = `${panelContext.projectId}/${panelContext.sessionId}/${entry.sourceScanId}`;
+            useSegmentationManagerStore.getState().setLocalOrigin(recoveredSegId, compositeKey);
+          }
+
+          // Delete the recovered backup entry
+          await backupService.deleteBackupEntry(sessionId, entry.filename).catch(() => {});
+          recoveredCount++;
+        } catch (err) {
+          console.error(`[App] Recovery: failed to load "${entry.filename}":`, err);
+        }
+      }
+
+      if (recoveredCount > 0) {
+        // Show the segmentation panel first, then sync after a tick
+        // so the panel component is mounted before the store updates.
+        const segStore = useSegmentationStore.getState();
+        if (!segStore.showPanel) segStore.togglePanel();
+
+        // Dismiss the backup banner since we recovered
+        setBackupBannerDismissed(true);
+
+        // Force re-sync after a microtask to ensure the panel is rendered
+        await new Promise((r) => setTimeout(r, 100));
+        segmentationService.sync();
+      }
+
+      console.log(`[App] Settings recovery: ${recoveredCount}/${manifest.entries.length} entries recovered`);
+    } catch (err) {
+      console.error('[App] Settings recovery failed:', err);
+    }
+  }, [promptRecoveryConfirm, loadSessionFromXnat]);
+
   // ─── Error state ───────────────────────────────────────────────
 
   if (initError) {
@@ -2536,11 +2956,44 @@ export default function App() {
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
     >
+      {/* Backup recovery notification banner */}
+      {backupBannerCount > 0 && !backupBannerDismissed && (
+        <div className="shrink-0 bg-blue-950/60 border-b border-blue-800/50 px-3 py-1.5 flex items-center gap-2">
+          <svg className="w-3.5 h-3.5 text-blue-400 shrink-0" viewBox="0 0 20 20" fill="currentColor">
+            <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z" clipRule="evenodd" />
+          </svg>
+          <span className="text-[11px] text-blue-200">
+            Found {backupBannerCount} backed-up annotation{backupBannerCount !== 1 ? 's' : ''} from a previous session.{' '}
+            <button
+              type="button"
+              onClick={() => setOpenSettingsToBackup(true)}
+              className="underline text-blue-300 hover:text-blue-100 transition-colors"
+            >
+              Open File Backup settings
+            </button>
+            {' '}to review or recover.
+          </span>
+          <button
+            type="button"
+            onClick={() => setBackupBannerDismissed(true)}
+            className="ml-auto text-blue-400 hover:text-blue-200 transition-colors"
+            title="Dismiss"
+          >
+            <svg className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+            </svg>
+          </button>
+        </div>
+      )}
+
       {/* Full-width toolbar at top, then browser + viewer below */}
       <ViewerPage
         panelImageIds={panelImageIds}
         onApplyProtocol={handleApplyProtocol}
         onToggleMPR={handleToggleMPR}
+        onRecoverBackup={handleRecoverBackup}
+        openSettingsToBackup={openSettingsToBackup}
+        onSettingsToBackupConsumed={() => setOpenSettingsToBackup(false)}
         mprSourceImageIds={mprSourceImageIds}
         leftSlot={
           <>
@@ -2825,6 +3278,32 @@ export default function App() {
                 className="w-full text-left text-xs px-3 py-2 rounded border border-zinc-700 bg-zinc-800 text-zinc-200 hover:bg-zinc-700 transition-colors"
               >
                 Return to session.
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Recovery confirm dialog (styled replacement for window.confirm) */}
+      {recoveryConfirmDialog.open && (
+        <div className="absolute inset-0 z-[130] bg-zinc-950/70 flex items-center justify-center p-4">
+          <div className="w-full max-w-sm rounded-lg border border-zinc-700 bg-zinc-900 shadow-xl">
+            <div className="px-4 py-3 border-b border-zinc-800">
+              <h3 className="text-sm font-semibold text-zinc-100">{recoveryConfirmDialog.title}</h3>
+              <p className="text-xs text-zinc-400 mt-1">{recoveryConfirmDialog.message}</p>
+            </div>
+            <div className="px-4 py-3 flex items-center justify-end gap-2">
+              <button
+                onClick={() => resolveRecoveryConfirmDialog(false)}
+                className="px-3 py-1.5 rounded text-xs bg-zinc-800 text-zinc-300 hover:bg-zinc-700 transition-colors"
+              >
+                {recoveryConfirmDialog.cancelLabel}
+              </button>
+              <button
+                onClick={() => resolveRecoveryConfirmDialog(true)}
+                className="px-3 py-1.5 rounded text-xs bg-blue-600 text-white hover:bg-blue-500 transition-colors"
+              >
+                {recoveryConfirmDialog.confirmLabel}
               </button>
             </div>
           </div>

--- a/src/renderer/components/settings/SettingsModal.tsx
+++ b/src/renderer/components/settings/SettingsModal.tsx
@@ -7,14 +7,20 @@ import {
 } from '@shared/types/preferences';
 import { DEFAULT_HOTKEY_MAP } from '../../lib/hotkeys/defaultHotkeyMap';
 import { usePreferencesStore } from '../../stores/preferencesStore';
+import { useViewerStore } from '../../stores/viewerStore';
+import { backupService } from '../../lib/backup/backupService';
+import type { BackupSessionSummary } from '@shared/types/backup';
 import { IconClose } from '../icons';
 
-type SettingsTab = 'hotkeys' | 'overlay' | 'annotation';
-type SettingsTab = 'hotkeys' | 'overlay' | 'interpolation';
+type SettingsTab = 'hotkeys' | 'overlay' | 'annotation' | 'interpolation' | 'backup';
 
 interface SettingsModalProps {
   open: boolean;
   onClose: () => void;
+  /** Called when the user clicks "Recover" for a backup session. Returns a Promise that resolves when recovery is complete. */
+  onRecover?: (sessionId: string) => Promise<void> | void;
+  /** Initial tab to open when the modal opens (e.g. 'backup'). */
+  initialTab?: string;
 }
 
 const TAB_ITEMS: Array<{ id: SettingsTab; label: string }> = [
@@ -22,6 +28,7 @@ const TAB_ITEMS: Array<{ id: SettingsTab; label: string }> = [
   { id: 'overlay', label: 'Overlay' },
   { id: 'annotation', label: 'Annotation' },
   { id: 'interpolation', label: 'Interpolation' },
+  { id: 'backup', label: 'File Backup' },
 ];
 
 const CORNER_OPTIONS: Array<{
@@ -113,6 +120,14 @@ function normalizeKeyInput(input: string): string {
   return trimmed;
 }
 
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
+}
+
 function normalizeHexColor(value: string): string | null {
   const match = value.trim().match(/^#?([0-9a-fA-F]{6})$/);
   if (!match) return null;
@@ -144,7 +159,7 @@ function bindingToDraft(binding: HotkeyBinding): { key: string; modifiers: Requi
   };
 }
 
-export default function SettingsModal({ open, onClose }: SettingsModalProps) {
+export default function SettingsModal({ open, onClose, onRecover, initialTab }: SettingsModalProps) {
   const overrides = usePreferencesStore((s) => s.preferences.hotkeys.overrides);
   const overlayPrefs = usePreferencesStore((s) => s.preferences.overlay);
   const annotationPrefs = usePreferencesStore((s) => s.preferences.annotation);
@@ -165,7 +180,17 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
   const setInterpolationEnabled = usePreferencesStore((s) => s.setInterpolationEnabled);
   const setInterpolationAlgorithm = usePreferencesStore((s) => s.setInterpolationAlgorithm);
   const setLinearThreshold = usePreferencesStore((s) => s.setLinearThreshold);
+  const backupPrefs = usePreferencesStore((s) => s.preferences.backup);
+  const setBackupEnabled = usePreferencesStore((s) => s.setBackupEnabled);
+  const setBackupIntervalSeconds = usePreferencesStore((s) => s.setBackupIntervalSeconds);
   const resetAll = usePreferencesStore((s) => s.resetAll);
+
+  // ─── Backup tab state ──────────────────────────────────────
+  const [backupSessions, setBackupSessions] = useState<BackupSessionSummary[]>([]);
+  const [backupCachePath, setBackupCachePath] = useState<string>('');
+  const [backupLoading, setBackupLoading] = useState(false);
+  const [recoveringSession, setRecoveringSession] = useState<string | null>(null);
+  const currentSessionId = useViewerStore((s) => s.sessionId);
 
   const actionOptions = useMemo(() => {
     const all = new Set<HotkeyAction>(Object.keys(DEFAULT_HOTKEY_MAP) as HotkeyAction[]);
@@ -176,6 +201,14 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
   }, [overrides]);
 
   const [activeTab, setActiveTab] = useState<SettingsTab>('hotkeys');
+
+  // Switch to initialTab when it changes (e.g. banner link opens to 'backup')
+  useEffect(() => {
+    if (initialTab && open) {
+      setActiveTab(initialTab as SettingsTab);
+    }
+  }, [initialTab, open]);
+
   const [selectedAction, setSelectedAction] = useState<HotkeyAction | null>(null);
   const [draftKey, setDraftKey] = useState('');
   const [draftModifiers, setDraftModifiers] = useState<Required<HotkeyModifiers>>({
@@ -186,10 +219,19 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
   });
   const [colorSequenceDraft, setColorSequenceDraft] = useState('');
 
+  // Confirm-delete dialog state (replaces native window.confirm)
+  const [confirmDeleteSession, setConfirmDeleteSession] = useState<{ sessionId: string; label: string } | null>(null);
+
   useEffect(() => {
     if (!open) return;
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape') {
+        if (confirmDeleteSession) {
+          setConfirmDeleteSession(null);
+        } else {
+          onClose();
+        }
+      }
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
@@ -220,6 +262,27 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
   useEffect(() => {
     setColorSequenceDraft(annotationPrefs.defaultColorSequence.join(', '));
   }, [annotationPrefs.defaultColorSequence]);
+
+  // Load backup sessions and cache path when the backup tab is activated
+  useEffect(() => {
+    if (activeTab !== 'backup' || !open) return;
+    let cancelled = false;
+    setBackupLoading(true);
+    Promise.all([
+      backupService.listAllBackups(),
+      window.electronAPI.backup.getCachePath(),
+    ]).then(([sessions, pathResult]) => {
+      if (cancelled) return;
+      setBackupSessions(sessions);
+      setBackupCachePath(pathResult.ok ? (pathResult.path ?? '') : '');
+      console.log('[Settings] Backup sessions:', sessions.map((s) => s.sessionId), 'currentSessionId:', useViewerStore.getState().sessionId);
+    }).catch(() => {
+      if (!cancelled) setBackupSessions([]);
+    }).finally(() => {
+      if (!cancelled) setBackupLoading(false);
+    });
+    return () => { cancelled = true; };
+  }, [activeTab, open]);
 
   const overrideEntries = useMemo(
     () => Object.entries(overrides) as Array<[HotkeyAction, HotkeyBinding[]]>,
@@ -596,6 +659,10 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
                       Apply Sequence
                     </button>
                   </div>
+                </div>
+              </>
+            )}
+
             {activeTab === 'interpolation' && (
               <>
                 <div className="text-xs text-zinc-400">
@@ -667,6 +734,186 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
                 </div>
               </>
             )}
+
+            {activeTab === 'backup' && (
+              <>
+                <div className="text-xs text-zinc-400">
+                  Configure local file backup for segmentations. When enabled, all unsaved
+                  segmentation changes are periodically written to a local cache, allowing
+                  recovery if the app closes unexpectedly.
+                </div>
+
+                <div className="rounded-lg border border-zinc-800 bg-zinc-950/40 p-4 space-y-4">
+                  {/* Enable toggle */}
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={backupPrefs.enabled}
+                      onChange={(e) => setBackupEnabled(e.target.checked)}
+                      className="w-3.5 h-3.5 rounded border-zinc-600 bg-zinc-800 accent-blue-500"
+                    />
+                    <span className="text-xs text-zinc-300">Enable local file backup</span>
+                  </label>
+
+                  {/* Frequency slider */}
+                  <div>
+                    <div className="flex items-center justify-between mb-1">
+                      <label className="text-xs text-zinc-300">Backup frequency</label>
+                      <span className="text-[11px] text-zinc-400 tabular-nums">
+                        {backupPrefs.intervalSeconds}s
+                      </span>
+                    </div>
+                    <input
+                      type="range"
+                      min={5}
+                      max={120}
+                      step={5}
+                      value={backupPrefs.intervalSeconds}
+                      onChange={(e) => setBackupIntervalSeconds(parseInt(e.target.value, 10))}
+                      disabled={!backupPrefs.enabled}
+                      className="w-full h-1 bg-zinc-700 rounded-full appearance-none cursor-pointer accent-blue-500 disabled:opacity-50"
+                    />
+                    <div className="flex justify-between text-[10px] text-zinc-600 mt-0.5">
+                      <span>5s</span>
+                      <span>120s</span>
+                    </div>
+                  </div>
+
+                  {/* Cache location */}
+                  {backupCachePath && (
+                    <div className="space-y-1">
+                      <div className="text-[11px] text-zinc-500">Cache location</div>
+                      <div className="text-[11px] text-zinc-400 font-mono bg-zinc-900/80 rounded px-2 py-1.5 break-all select-text">
+                        {backupCachePath}
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                {/* Cached backups list — grouped by server */}
+                <div className="rounded-lg border border-zinc-800 bg-zinc-950/40 p-4 space-y-3">
+                  <div className="flex items-center justify-between">
+                    <h3 className="text-xs font-medium text-zinc-300">Cached Backups</h3>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setBackupLoading(true);
+                        backupService.listAllBackups().then(setBackupSessions).catch(() => setBackupSessions([])).finally(() => setBackupLoading(false));
+                      }}
+                      className="px-2 py-1 rounded text-[11px] bg-zinc-800 text-zinc-200 hover:bg-zinc-700 transition-colors"
+                    >
+                      Refresh
+                    </button>
+                  </div>
+
+                  {backupLoading ? (
+                    <div className="text-[11px] text-zinc-500">Loading...</div>
+                  ) : backupSessions.length === 0 ? (
+                    <div className="text-[11px] text-zinc-500">No cached backup files.</div>
+                  ) : (
+                    <div className="space-y-4">
+                      {(() => {
+                        // Group sessions by server URL
+                        const byServer = new Map<string, typeof backupSessions>();
+                        for (const s of backupSessions) {
+                          const key = s.serverUrl || 'Unknown Server';
+                          if (!byServer.has(key)) byServer.set(key, []);
+                          byServer.get(key)!.push(s);
+                        }
+                        return Array.from(byServer.entries()).map(([serverUrl, sessions]) => (
+                          <div key={serverUrl} className="space-y-2">
+                            <div className="text-[11px] text-zinc-400 font-medium truncate" title={serverUrl}>
+                              {serverUrl}
+                            </div>
+                            <div className="space-y-1.5 pl-2 border-l border-zinc-800">
+                              {sessions.map((session) => {
+                                const displayLabel = [
+                                  session.projectId && `Project: ${session.projectId}`,
+                                  session.subjectLabel && `Subject: ${session.subjectLabel}`,
+                                  (session.sessionLabel && session.sessionLabel !== session.sessionId)
+                                    ? `Session: ${session.sessionLabel}`
+                                    : `Session: ${session.sessionId}`,
+                                ].filter(Boolean).join('  \u00B7  ');
+
+                                // Build XNAT web URL for this session
+                                const xnatSessionUrl = serverUrl && serverUrl !== 'Unknown Server'
+                                  ? `${serverUrl.replace(/\/$/, '')}/data/experiments/${session.sessionId}?format=html`
+                                  : null;
+
+                                return (
+                                  <div
+                                    key={session.sessionId}
+                                    className="rounded border border-zinc-800 bg-zinc-900/60 px-2.5 py-2 space-y-1"
+                                  >
+                                    <div className="flex items-start justify-between gap-2">
+                                      <div className="min-w-0">
+                                        <div className="text-[11px] text-zinc-300 leading-relaxed" title={session.sessionId}>
+                                          {displayLabel}
+                                        </div>
+                                        <div className="text-[10px] text-zinc-500 flex flex-wrap gap-x-2 mt-0.5">
+                                          <span>{session.entryCount} file{session.entryCount !== 1 ? 's' : ''}</span>
+                                          <span>{formatBytes(session.totalSizeBytes)}</span>
+                                          <span>Last: {new Date(session.lastUpdated).toLocaleString()}</span>
+                                        </div>
+                                      </div>
+                                      <div className="shrink-0 flex items-center gap-1.5">
+                                        {onRecover && (
+                                          <button
+                                            type="button"
+                                            disabled={recoveringSession === session.sessionId}
+                                            onClick={async () => {
+                                              setRecoveringSession(session.sessionId);
+                                              try {
+                                                await onRecover(session.sessionId);
+                                              } finally {
+                                                setRecoveringSession(null);
+                                                onClose();
+                                              }
+                                            }}
+                                            className="px-2 py-1 rounded text-[11px] bg-green-900/50 text-green-300 hover:bg-green-900/70 transition-colors disabled:opacity-50"
+                                            title="Recover these annotations into the currently loaded session"
+                                          >
+                                            {recoveringSession === session.sessionId ? 'Recovering...' : 'Recover'}
+                                          </button>
+                                        )}
+                                        {xnatSessionUrl && (
+                                          <button
+                                            type="button"
+                                            onClick={() => {
+                                              window.electronAPI.shell.openExternal(xnatSessionUrl);
+                                            }}
+                                            className="px-2 py-1 rounded text-[11px] bg-zinc-800 text-blue-300 hover:bg-zinc-700 hover:text-blue-200 transition-colors"
+                                            title="Open session in XNAT"
+                                          >
+                                            Open
+                                          </button>
+                                        )}
+                                        <button
+                                          type="button"
+                                          onClick={() => {
+                                            const label = session.sessionLabel && session.sessionLabel !== session.sessionId
+                                              ? session.sessionLabel
+                                              : session.sessionId;
+                                            setConfirmDeleteSession({ sessionId: session.sessionId, label });
+                                          }}
+                                          className="px-2 py-1 rounded text-[11px] bg-red-900/40 text-red-300 hover:bg-red-900/60 transition-colors"
+                                        >
+                                          Delete
+                                        </button>
+                                      </div>
+                                    </div>
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          </div>
+                        ));
+                      })()}
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
           </div>
 
           <div className="h-12 shrink-0 border-t border-zinc-800 px-4 flex items-center justify-end">
@@ -680,6 +927,42 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
           </div>
         </div>
       </div>
+
+      {/* Styled confirm-delete dialog (replaces native window.confirm) */}
+      {confirmDeleteSession && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/50 rounded-xl">
+          <div className="bg-zinc-900 border border-zinc-700 rounded-lg shadow-xl p-5 max-w-sm mx-4">
+            <h3 className="text-sm font-semibold text-zinc-100 mb-2">Delete Backup</h3>
+            <p className="text-xs text-zinc-400 mb-4">
+              Delete all backup files for <strong className="text-zinc-200">{confirmDeleteSession.label}</strong>? This cannot be undone.
+            </p>
+            <div className="flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setConfirmDeleteSession(null)}
+                className="px-3 py-1.5 rounded text-xs bg-zinc-800 text-zinc-300 hover:bg-zinc-700 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  const sid = confirmDeleteSession.sessionId;
+                  setConfirmDeleteSession(null);
+                  backupService.deleteSessionBackups(sid).then(() => {
+                    setBackupSessions((prev) => prev.filter((s) => s.sessionId !== sid));
+                  }).catch((err) => {
+                    console.error('[Settings] Failed to delete backup session:', err);
+                  });
+                }}
+                className="px-3 py-1.5 rounded text-xs bg-red-900/60 text-red-200 hover:bg-red-900/80 transition-colors"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/renderer/components/viewer/SegmentationPanel.tsx
+++ b/src/renderer/components/viewer/SegmentationPanel.tsx
@@ -18,6 +18,7 @@ import {
 import { segmentationService } from '../../lib/cornerstone/segmentationService';
 import { rtStructService } from '../../lib/cornerstone/rtStructService';
 import { segmentationManager } from '../../lib/segmentation/segmentationManagerSingleton';
+import { backupService } from '../../lib/backup/backupService';
 import { dicomwebLoader } from '../../lib/cornerstone/dicomwebLoader';
 import { ToolName, TOOL_DISPLAY_NAMES, SEGMENTATION_TOOLS } from '@shared/types/viewer';
 import {
@@ -253,9 +254,8 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
   const splineType = useSegmentationStore((s) => s.splineType);
   const setSplineType = useSegmentationStore((s) => s.setSplineType);
   const defaultColorSequence = usePreferencesStore((s) => s.preferences.annotation.defaultColorSequence);
-  const autoSaveEnabled = useSegmentationStore((s) => s.autoSaveEnabled);
   const autoSaveStatus = useSegmentationStore((s) => s.autoSaveStatus);
-  const setAutoSaveEnabled = useSegmentationStore((s) => s.setAutoSaveEnabled);
+  const backupEnabled = usePreferencesStore((s) => s.preferences.backup.enabled);
   const autoLoadSegOnScanClick = useSegmentationStore((s) => s.autoLoadSegOnScanClick);
   const setAutoLoadSegOnScanClick = useSegmentationStore((s) => s.setAutoLoadSegOnScanClick);
   const xnatOriginMap = useSegmentationStore((s) => s.xnatOriginMap);
@@ -1122,6 +1122,12 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
         if (!mgrStore.hasDirtySegmentations()) {
           useSegmentationStore.getState()._markClean();
         }
+        // Clean up local backup entries for this segmentation
+        try {
+          await backupService.deleteEntriesForSegmentation(panelCtx.sessionId, segmentationId);
+        } catch { /* ignore local backup cleanup errors */ }
+
+        // Clean up legacy XNAT temp files for this source scan
         try {
           const files = await window.electronAPI.xnat.listTempFiles(panelCtx.sessionId);
           const pattern = new RegExp(`^autosave_(?:seg|rtstruct)_${sourceScanId}(?:_\\d{14})?\\.dcm$`);
@@ -1897,56 +1903,37 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
           <span className="text-[10px] text-zinc-400">Automatically display annotations</span>
         </label>
 
-        <div className="flex items-center justify-between gap-3">
-          <div className="flex items-center gap-4">
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={autoSaveEnabled}
-                onChange={(e) => setAutoSaveEnabled(e.target.checked)}
-                disabled={!isXnatConnected || !activePanelXnatContext}
-                className="w-3 h-3 rounded border-zinc-600 bg-zinc-800 accent-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
-              />
-              <span className="text-[10px] text-zinc-400">Auto-Save</span>
-            </label>
+        {backupEnabled && autoSaveStatus !== 'idle' && (
+          <div className="flex items-center gap-1">
+            {autoSaveStatus === 'saving' && (
+              <>
+                <svg className="animate-spin h-2.5 w-2.5 text-blue-400" viewBox="0 0 24 24" fill="none">
+                  <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" className="opacity-25" />
+                  <path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="3" strokeLinecap="round" className="opacity-75" />
+                </svg>
+                <span className="text-[9px] text-blue-400">Backing up...</span>
+              </>
+            )}
+            {autoSaveStatus === 'saved' && (
+              <>
+                <svg className="h-2.5 w-2.5 text-green-400" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2">
+                  <polyline points="3,8 7,12 13,4" />
+                </svg>
+                <span className="text-[9px] text-green-400">Backed up</span>
+              </>
+            )}
+            {autoSaveStatus === 'error' && (
+              <>
+                <svg className="h-2.5 w-2.5 text-red-400" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2">
+                  <circle cx="8" cy="8" r="6" />
+                  <line x1="8" y1="5" x2="8" y2="9" />
+                  <circle cx="8" cy="11.5" r="0.5" fill="currentColor" />
+                </svg>
+                <span className="text-[9px] text-red-400">Backup failed</span>
+              </>
+            )}
           </div>
-          {autoSaveEnabled && (
-            <span className="text-[9px] flex items-center gap-1">
-              {autoSaveStatus === 'saving' && (
-                <>
-                  <svg className="animate-spin h-2.5 w-2.5 text-blue-400" viewBox="0 0 24 24" fill="none">
-                    <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" className="opacity-25" />
-                    <path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="3" strokeLinecap="round" className="opacity-75" />
-                  </svg>
-                  <span className="text-blue-400">Saving...</span>
-                </>
-              )}
-              {autoSaveStatus === 'saved' && (
-                <>
-                  <svg className="h-2.5 w-2.5 text-green-400" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2">
-                    <polyline points="3,8 7,12 13,4" />
-                  </svg>
-                  <span className="text-green-400">Saved</span>
-                </>
-              )}
-              {autoSaveStatus === 'error' && (
-                <>
-                  <svg className="h-2.5 w-2.5 text-red-400" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2">
-                    <circle cx="8" cy="8" r="6" />
-                    <line x1="8" y1="5" x2="8" y2="9" />
-                    <circle cx="8" cy="11.5" r="0.5" fill="currentColor" />
-                  </svg>
-                  <span className="text-red-400">Failed</span>
-                </>
-              )}
-            </span>
-          )}
-        </div>
-        {!isXnatConnected || !activePanelXnatContext ? (
-          <div className="text-[9px] text-zinc-600 -mt-1">
-            Auto-save is available after loading an XNAT scan.
-          </div>
-        ) : null}
+        )}
       </div>
 
       {/* Toast notification */}

--- a/src/renderer/components/viewer/Toolbar.tsx
+++ b/src/renderer/components/viewer/Toolbar.tsx
@@ -484,10 +484,27 @@ interface ToolbarProps {
   hasImages?: boolean;
   /** Optional content rendered at the far left of the toolbar (e.g. XNAT logo, connection status) */
   leftSlot?: React.ReactNode;
+  /** Called when the user clicks "Recover" for a backup session in Settings. */
+  onRecoverBackup?: (sessionId: string) => Promise<void> | void;
+  /** When true, open Settings directly to the File Backup tab. */
+  openSettingsToBackup?: boolean;
+  /** Called after the open-settings-to-backup request has been consumed. */
+  onSettingsToBackupConsumed?: () => void;
 }
 
-export default function Toolbar({ showDicomPanel = false, onToggleDicomPanel, onApplyProtocol, onToggleMPR, hasImages = false, leftSlot }: ToolbarProps) {
+export default function Toolbar({ showDicomPanel = false, onToggleDicomPanel, onApplyProtocol, onToggleMPR, hasImages = false, leftSlot, onRecoverBackup, openSettingsToBackup, onSettingsToBackupConsumed }: ToolbarProps) {
   const [showSettings, setShowSettings] = useState(false);
+  const [settingsInitialTab, setSettingsInitialTab] = useState<string | undefined>(undefined);
+
+  // Open Settings to Backup tab when requested by parent (e.g. banner link)
+  useEffect(() => {
+    if (openSettingsToBackup) {
+      setSettingsInitialTab('backup');
+      setShowSettings(true);
+      onSettingsToBackupConsumed?.();
+    }
+  }, [openSettingsToBackup, onSettingsToBackupConsumed]);
+
   const activeTool = useViewerStore((s) => s.activeTool);
   const mprActive = useViewerStore((s) => s.mprActive);
   const cine = useViewerStore(
@@ -688,7 +705,7 @@ export default function Toolbar({ showDicomPanel = false, onToggleDicomPanel, on
           title={showSettings ? 'Close settings' : 'Open settings'}
         />
       </div>
-      <SettingsModal open={showSettings} onClose={() => setShowSettings(false)} />
+      <SettingsModal open={showSettings} onClose={() => { setShowSettings(false); setSettingsInitialTab(undefined); }} onRecover={onRecoverBackup} initialTab={settingsInitialTab} />
     </>
   );
 }

--- a/src/renderer/lib/backup/backupService.ts
+++ b/src/renderer/lib/backup/backupService.ts
@@ -1,0 +1,351 @@
+/**
+ * Backup Service — renderer-side abstraction for local file backup.
+ *
+ * Provides a strategy-pattern interface (`BackupBackend`) so that the
+ * XNAT temp resource backend can be re-added in the future without
+ * changing the calling code.
+ *
+ * The `backupService` singleton exposes high-level methods used by
+ * segmentationService (auto-save), App.tsx (recovery), and
+ * SegmentationPanel (cleanup).
+ */
+import type {
+  BackupManifest,
+  BackupManifestEntry,
+  BackupSessionSummary,
+} from '@shared/types/backup';
+import { segmentationService } from '../cornerstone/segmentationService';
+import { rtStructService } from '../cornerstone/rtStructService';
+import { useSegmentationStore } from '../../stores/segmentationStore';
+import { useSegmentationManagerStore } from '../../stores/segmentationManagerStore';
+import { useViewerStore } from '../../stores/viewerStore';
+
+// ─── Backend Strategy Interface ─────────────────────────────────
+// Implement this to add alternative backup backends (e.g. XNAT temp).
+
+export interface BackupBackend {
+  writeSegmentation(
+    sessionId: string,
+    segId: string,
+    sourceScanId: string,
+    format: 'SEG' | 'RTSTRUCT',
+    base64: string,
+  ): Promise<{ filename: string; sizeBytes: number }>;
+
+  readSegmentation(sessionId: string, filename: string): Promise<string>;
+  deleteSegmentation(sessionId: string, filename: string): Promise<void>;
+  readManifest(sessionId: string): Promise<BackupManifest | null>;
+  writeManifest(sessionId: string, manifest: BackupManifest): Promise<void>;
+  deleteSession(sessionId: string): Promise<void>;
+  listAllSessions(): Promise<BackupSessionSummary[]>;
+}
+
+// ─── Local Filesystem Backend ───────────────────────────────────
+
+class LocalFilesystemBackend implements BackupBackend {
+  async writeSegmentation(
+    sessionId: string,
+    segId: string,
+    sourceScanId: string,
+    format: 'SEG' | 'RTSTRUCT',
+    base64: string,
+  ): Promise<{ filename: string; sizeBytes: number }> {
+    const ts = formatTimestamp();
+    const prefix = format === 'RTSTRUCT' ? 'rtstruct' : 'seg';
+    // Sanitize segId for filename safety
+    const safeSegId = segId.replace(/[^a-zA-Z0-9_\-]/g, '_').slice(0, 60);
+    const filename = `${prefix}_${safeSegId}_${ts}.dcm`;
+
+    const result = await window.electronAPI.backup.writeFile(sessionId, filename, base64);
+    if (!result.ok) {
+      throw new Error(`Backup write failed: ${result.error}`);
+    }
+    return { filename, sizeBytes: result.sizeBytes ?? 0 };
+  }
+
+  async readSegmentation(sessionId: string, filename: string): Promise<string> {
+    const result = await window.electronAPI.backup.readFile(sessionId, filename);
+    if (!result.ok || !result.data) {
+      throw new Error(`Backup read failed: ${result.error}`);
+    }
+    return result.data;
+  }
+
+  async deleteSegmentation(sessionId: string, filename: string): Promise<void> {
+    await window.electronAPI.backup.deleteFile(sessionId, filename);
+  }
+
+  async readManifest(sessionId: string): Promise<BackupManifest | null> {
+    const result = await window.electronAPI.backup.readManifest(sessionId);
+    if (!result.ok) {
+      if (result.error === 'not_found') return null;
+      throw new Error(`Manifest read failed: ${result.error}`);
+    }
+    return result.manifest ?? null;
+  }
+
+  async writeManifest(sessionId: string, manifest: BackupManifest): Promise<void> {
+    const result = await window.electronAPI.backup.writeManifest(
+      sessionId,
+      JSON.stringify(manifest, null, 2),
+    );
+    if (!result.ok) {
+      throw new Error(`Manifest write failed: ${result.error}`);
+    }
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    await window.electronAPI.backup.deleteSession(sessionId);
+  }
+
+  async listAllSessions(): Promise<BackupSessionSummary[]> {
+    const result = await window.electronAPI.backup.listAllSessions();
+    if (!result.ok) return [];
+    return result.sessions ?? [];
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+function formatTimestamp(): string {
+  const d = new Date();
+  return (
+    d.getFullYear().toString() +
+    String(d.getMonth() + 1).padStart(2, '0') +
+    String(d.getDate()).padStart(2, '0') +
+    String(d.getHours()).padStart(2, '0') +
+    String(d.getMinutes()).padStart(2, '0') +
+    String(d.getSeconds()).padStart(2, '0')
+  );
+}
+
+// ─── Public Backup Service ──────────────────────────────────────
+
+const backend: BackupBackend = new LocalFilesystemBackend();
+
+export const backupService = {
+  /**
+   * Back up ALL dirty segmentations to local cache.
+   *
+   * Iterates every segmentation marked dirty in segmentationManagerStore,
+   * exports each to DICOM SEG or RTSTRUCT, writes to local backup, and
+   * updates the manifest. Returns number of successfully backed-up segs.
+   */
+  async backupAllDirtySegmentations(
+    sessionId: string,
+    serverUrl: string,
+  ): Promise<number> {
+    const mgrStore = useSegmentationManagerStore.getState();
+    const segStore = useSegmentationStore.getState();
+
+    // Collect dirty segmentation IDs
+    const dirtySegIds = Object.entries(mgrStore.dirtySegIds)
+      .filter(([, dirty]) => dirty)
+      .map(([segId]) => segId);
+
+    if (dirtySegIds.length === 0) return 0;
+
+    // Gather XNAT metadata for the manifest from viewer stores
+    const viewerState = useViewerStore.getState();
+    const xnatCtx = viewerState.xnatContext;
+    const activePanel = viewerState.activeViewportId;
+    const projectId = xnatCtx?.projectId ?? '';
+    const subjectId = xnatCtx?.subjectId ?? '';
+    const sessionLabel = xnatCtx?.sessionLabel ?? sessionId;
+    const subjectLabel = activePanel
+      ? (viewerState.panelSubjectLabelMap?.[activePanel] ?? '')
+      : '';
+
+    // Read existing manifest or create a new one
+    let manifest: BackupManifest;
+    try {
+      manifest = (await backend.readManifest(sessionId)) ?? {
+        version: 1,
+        sessionId,
+        serverUrl,
+        lastUpdated: new Date().toISOString(),
+        entries: [],
+        projectId,
+        subjectId,
+        subjectLabel,
+        sessionLabel,
+      };
+    } catch {
+      manifest = {
+        version: 1,
+        sessionId,
+        serverUrl,
+        lastUpdated: new Date().toISOString(),
+        entries: [],
+        projectId,
+        subjectId,
+        subjectLabel,
+        sessionLabel,
+      };
+    }
+
+    // Always update metadata in case labels were resolved after manifest was first created
+    if (projectId) manifest.projectId = projectId;
+    if (subjectId) manifest.subjectId = subjectId;
+    if (subjectLabel) manifest.subjectLabel = subjectLabel;
+    if (sessionLabel && sessionLabel !== sessionId) manifest.sessionLabel = sessionLabel;
+
+    let backed = 0;
+
+    // Process each dirty seg sequentially (Cornerstone exports aren't thread-safe)
+    for (const segId of dirtySegIds) {
+      try {
+        const dicomType = segmentationService.getPreferredDicomType(segId);
+        if (!segmentationService.hasExportableContent(segId, dicomType)) {
+          // No actual data to export — skip silently
+          continue;
+        }
+
+        // Determine sourceScanId
+        const origin = segStore.xnatOriginMap[segId];
+        const xnatContext = useViewerStore.getState().xnatContext;
+        const sourceScanId = origin?.sourceScanId ?? xnatContext?.scanId ?? 'unknown';
+
+        // Export to base64
+        let base64: string;
+        if (dicomType === 'RTSTRUCT') {
+          base64 = await rtStructService.exportToRtStruct(segId);
+        } else {
+          base64 = await segmentationService.exportToDicomSeg(segId);
+        }
+
+        // Remove old entries for this segId from manifest
+        const oldEntries = manifest.entries.filter((e) => e.segmentationId === segId);
+        manifest.entries = manifest.entries.filter((e) => e.segmentationId !== segId);
+
+        // Write the backup file
+        const { filename, sizeBytes } = await backend.writeSegmentation(
+          sessionId,
+          segId,
+          sourceScanId,
+          dicomType,
+          base64,
+        );
+
+        // Delete old backup files for this segId
+        for (const old of oldEntries) {
+          try {
+            await backend.deleteSegmentation(sessionId, old.filename);
+          } catch { /* ignore */ }
+        }
+
+        // Add new manifest entry
+        manifest.entries.push({
+          segmentationId: segId,
+          filename,
+          format: dicomType,
+          sourceScanId,
+          timestamp: new Date().toISOString(),
+          sizeBytes,
+        });
+
+        // Clear dirty flag for this specific segmentation
+        mgrStore.clearDirty(segId);
+        backed++;
+
+        console.log(
+          `[backupService] Backed up ${dicomType} for ${segId} → ${filename} (${sizeBytes} bytes)`,
+        );
+      } catch (err: any) {
+        const msg = err instanceof Error ? err.message : String(err);
+        // "No painted segment data" is not an error — user hasn't painted yet
+        if (
+          msg.includes('No painted segment data') ||
+          msg.includes('no segment-frame pairs') ||
+          msg.includes('Error inserting pixels in PixelData')
+        ) {
+          console.log(`[backupService] Skipped ${segId} — no painted pixels yet`);
+          continue;
+        }
+        console.error(`[backupService] Failed to back up ${segId}:`, err);
+      }
+    }
+
+    // Write updated manifest
+    if (backed > 0) {
+      manifest.lastUpdated = new Date().toISOString();
+      try {
+        await backend.writeManifest(sessionId, manifest);
+      } catch (err) {
+        console.error('[backupService] Failed to write manifest:', err);
+      }
+
+      // If all dirty segs are now clean, update the global flag
+      if (!mgrStore.hasDirtySegmentations()) {
+        useSegmentationStore.getState()._markClean();
+      }
+    }
+
+    return backed;
+  },
+
+  /** Read the backup manifest for a specific XNAT session. */
+  async getManifestForSession(sessionId: string): Promise<BackupManifest | null> {
+    return backend.readManifest(sessionId);
+  },
+
+  /** Read a backed-up segmentation file (returns base64). */
+  async readSegmentation(sessionId: string, filename: string): Promise<string> {
+    return backend.readSegmentation(sessionId, filename);
+  },
+
+  /** Delete a specific backup entry and update the manifest. */
+  async deleteBackupEntry(sessionId: string, filename: string): Promise<void> {
+    try {
+      await backend.deleteSegmentation(sessionId, filename);
+    } catch { /* ignore if already gone */ }
+
+    // Update manifest
+    try {
+      const manifest = await backend.readManifest(sessionId);
+      if (manifest) {
+        manifest.entries = manifest.entries.filter((e) => e.filename !== filename);
+        manifest.lastUpdated = new Date().toISOString();
+        if (manifest.entries.length === 0) {
+          // No entries left — delete the entire session directory
+          await backend.deleteSession(sessionId);
+        } else {
+          await backend.writeManifest(sessionId, manifest);
+        }
+      }
+    } catch { /* ignore manifest update errors */ }
+  },
+
+  /** Delete all entries for a specific segmentationId and update the manifest. */
+  async deleteEntriesForSegmentation(sessionId: string, segmentationId: string): Promise<void> {
+    try {
+      const manifest = await backend.readManifest(sessionId);
+      if (!manifest) return;
+
+      const toDelete = manifest.entries.filter((e) => e.segmentationId === segmentationId);
+      for (const entry of toDelete) {
+        try {
+          await backend.deleteSegmentation(sessionId, entry.filename);
+        } catch { /* ignore */ }
+      }
+
+      manifest.entries = manifest.entries.filter((e) => e.segmentationId !== segmentationId);
+      manifest.lastUpdated = new Date().toISOString();
+      if (manifest.entries.length === 0) {
+        await backend.deleteSession(sessionId);
+      } else {
+        await backend.writeManifest(sessionId, manifest);
+      }
+    } catch { /* ignore cleanup errors */ }
+  },
+
+  /** Delete the entire backup directory for a session. */
+  async deleteSessionBackups(sessionId: string): Promise<void> {
+    return backend.deleteSession(sessionId);
+  },
+
+  /** List all backup sessions with summaries (for the settings UI). */
+  async listAllBackups(): Promise<BackupSessionSummary[]> {
+    return backend.listAllSessions();
+  },
+};

--- a/src/renderer/lib/cornerstone/segmentationService.ts
+++ b/src/renderer/lib/cornerstone/segmentationService.ts
@@ -53,8 +53,10 @@ import { usePreferencesStore } from '../../stores/preferencesStore';
 import { useSegmentationStore } from '../../stores/segmentationStore';
 import type { SegmentationSummary, SegmentSummary } from '../../stores/segmentationStore';
 import { useViewerStore } from '../../stores/viewerStore';
+import { useConnectionStore } from '../../stores/connectionStore';
 import { useSegmentationManagerStore } from '../../stores/segmentationManagerStore';
 import { rtStructService } from './rtStructService';
+import { backupService } from '../backup/backupService';
 import { writeDicomDict } from './writeDicomDict';
 // NOTE: We use the tool group ID directly here instead of importing from
 // toolService to avoid a circular dependency (toolService → segmentationService).
@@ -1108,6 +1110,7 @@ let loadInProgressCount = 0;
  * Set via beginManualSave()/endManualSave() from SegmentationPanel.
  */
 let manualSaveInProgress = false;
+let backupInProgress = false;
 let labelmapInterpolationTimer: ReturnType<typeof setTimeout> | null = null;
 let labelmapInterpolationInProgress = false;
 let pendingLabelmapInterpolation: { segmentationId: string; segmentIndex: number | null } | null = null;
@@ -1173,9 +1176,16 @@ function scheduleAutoSave(): void {
   // Don't schedule auto-save while a manual save is in progress
   if (manualSaveInProgress) return;
   if (autoSaveTimer) clearTimeout(autoSaveTimer);
+
+  // Read backup interval from preferences (fallback to AUTO_SAVE_DELAY)
+  const backupPrefs = usePreferencesStore.getState().preferences.backup;
+  const delayMs = backupPrefs.enabled
+    ? backupPrefs.intervalSeconds * 1000
+    : AUTO_SAVE_DELAY;
+
   autoSaveTimer = setTimeout(() => {
     void performAutoSave();
-  }, AUTO_SAVE_DELAY);
+  }, delayMs);
 }
 
 function scheduleLabelmapInterpolation(): void {
@@ -1328,7 +1338,10 @@ function formatTimestamp(): string {
 async function performAutoSave(force = false): Promise<boolean> {
   autoSaveTimer = null;
   const segStore = useSegmentationStore.getState();
-  if (!segStore.autoSaveEnabled && !force) return false;
+  const backupPrefs = usePreferencesStore.getState().preferences.backup;
+
+  // Check backup enabled (from preferences), or force flag (disconnect guard)
+  if (!backupPrefs.enabled && !force) return false;
 
   // Skip if dirty tracking is suppressed (load/creation in progress)
   if (isDirtyTrackingSuppressed()) return false;
@@ -1342,74 +1355,34 @@ async function performAutoSave(force = false): Promise<boolean> {
   // Skip if no actual unsaved changes
   if (!segStore.hasUnsavedChanges) return false;
 
+  // Prevent re-entrancy (Cornerstone exports aren't thread-safe)
+  if (backupInProgress) {
+    console.log('[segmentationService] Auto-save skipped — backup already in progress');
+    return false;
+  }
+
   const xnatContext = useViewerStore.getState().xnatContext;
-  if (!xnatContext) return false; // Not connected to XNAT or no context
-
-  const activeSegId = segStore.activeSegmentationId;
-  if (!activeSegId) return false;
-
-  // Determine source scan: from origin if loaded from XNAT, else from context
-  const origin = segStore.xnatOriginMap[activeSegId];
-  const sourceScanId = origin?.sourceScanId ?? xnatContext.scanId;
-
-  // Determine segmentation type to choose correct export format
-  const segType = getSegmentationType(activeSegId);
+  if (!xnatContext) return false; // No session context
 
   segStore._setAutoSaveStatus('saving');
+  backupInProgress = true;
   try {
-    let base64: string;
-    let tempFilename: string;
-    const ts = formatTimestamp();
-
-    if (segType === 'contour') {
-      if (!segmentationService.hasExportableContent(activeSegId, 'RTSTRUCT')) {
-        segStore._setAutoSaveStatus('idle');
-        return false;
-      }
-      // Contour-only: export as RTSTRUCT
-      base64 = await rtStructService.exportToRtStruct(activeSegId);
-      tempFilename = `autosave_rtstruct_${sourceScanId}_${ts}.dcm`;
-    } else {
-      if (!segmentationService.hasExportableContent(activeSegId, 'SEG')) {
-        segStore._setAutoSaveStatus('idle');
-        return false;
-      }
-      // Labelmap (or both): export as DICOM SEG
-      base64 = await segmentationService.exportToDicomSeg(activeSegId);
-      tempFilename = `autosave_seg_${sourceScanId}_${ts}.dcm`;
-    }
-
-    // Clean up old auto-save files for this source scan before writing new one
-    try {
-      const existingFiles = await window.electronAPI.xnat.listTempFiles(xnatContext.sessionId);
-      const cleanupPattern = new RegExp(`^autosave_(?:seg|rtstruct)_${sourceScanId}(?:_\\d{14})?\\.dcm$`);
-      for (const f of existingFiles.files ?? []) {
-        if (cleanupPattern.test(f.name)) {
-          await window.electronAPI.xnat.deleteTempFile(xnatContext.sessionId, f.name);
-        }
-      }
-    } catch { /* ignore cleanup errors */ }
-
-    const result = await window.electronAPI.xnat.autoSaveTemp(
+    const serverUrl = useConnectionStore.getState().connection?.serverUrl ?? '';
+    const backed = await backupService.backupAllDirtySegmentations(
       xnatContext.sessionId,
-      sourceScanId,
-      base64,
-      tempFilename,
+      serverUrl,
     );
-    if (result.ok) {
+
+    if (backed > 0) {
       segStore._setAutoSaveStatus('saved');
-      segStore._markClean();
-      console.log(`[segmentationService] Auto-saved ${segType} to temp resource for source scan ${sourceScanId} (${tempFilename})`);
+      console.log(`[segmentationService] Local backup: ${backed} segmentation(s) saved`);
       return true;
     } else {
-      console.error('[segmentationService] Auto-save to temp failed:', result.error);
-      segStore._setAutoSaveStatus('error');
+      // No dirty segs with exportable content — return to idle
+      segStore._setAutoSaveStatus('idle');
       return false;
     }
   } catch (err: any) {
-    // "No painted segment data" means the segmentation exists but has no actual
-    // pixel data (user created it but hasn't painted yet). This is not an error —
-    // silently return to idle instead of showing an error status.
     const msg = err instanceof Error ? err.message : String(err);
     if (
       msg.includes('No painted segment data') ||
@@ -1423,8 +1396,83 @@ async function performAutoSave(force = false): Promise<boolean> {
     console.error('[segmentationService] Auto-save failed:', err);
     segStore._setAutoSaveStatus('error');
     return false;
+  } finally {
+    backupInProgress = false;
   }
 }
+
+// ─── Legacy XNAT Temp Auto-Save (preserved for future reintroduction) ────
+//
+// The original auto-save wrote to XNAT's server-side temp resource for a single
+// active segmentation. This has been replaced by the local filesystem backup
+// that backs up ALL dirty segmentations. The code below is kept as reference
+// for adding an optional XNAT temp backend to the backup strategy pattern.
+//
+// async function performAutoSave_xnatTemp(force = false): Promise<boolean> {
+//   autoSaveTimer = null;
+//   const segStore = useSegmentationStore.getState();
+//   if (!segStore.autoSaveEnabled && !force) return false;
+//   if (isDirtyTrackingSuppressed()) return false;
+//   if (loadInProgressCount > 0) return false;
+//   if (!segStore.hasUnsavedChanges) return false;
+//   const xnatContext = useViewerStore.getState().xnatContext;
+//   if (!xnatContext) return false;
+//   const activeSegId = segStore.activeSegmentationId;
+//   if (!activeSegId) return false;
+//   const origin = segStore.xnatOriginMap[activeSegId];
+//   const sourceScanId = origin?.sourceScanId ?? xnatContext.scanId;
+//   const segType = getSegmentationType(activeSegId);
+//   segStore._setAutoSaveStatus('saving');
+//   try {
+//     let base64: string;
+//     let tempFilename: string;
+//     const ts = formatTimestamp();
+//     if (segType === 'contour') {
+//       if (!segmentationService.hasExportableContent(activeSegId, 'RTSTRUCT')) {
+//         segStore._setAutoSaveStatus('idle');
+//         return false;
+//       }
+//       base64 = await rtStructService.exportToRtStruct(activeSegId);
+//       tempFilename = `autosave_rtstruct_${sourceScanId}_${ts}.dcm`;
+//     } else {
+//       if (!segmentationService.hasExportableContent(activeSegId, 'SEG')) {
+//         segStore._setAutoSaveStatus('idle');
+//         return false;
+//       }
+//       base64 = await segmentationService.exportToDicomSeg(activeSegId);
+//       tempFilename = `autosave_seg_${sourceScanId}_${ts}.dcm`;
+//     }
+//     // Clean up old auto-save files
+//     try {
+//       const existingFiles = await window.electronAPI.xnat.listTempFiles(xnatContext.sessionId);
+//       const cleanupPattern = new RegExp(`^autosave_(?:seg|rtstruct)_${sourceScanId}(?:_\\d{14})?\\.dcm$`);
+//       for (const f of existingFiles.files ?? []) {
+//         if (cleanupPattern.test(f.name)) {
+//           await window.electronAPI.xnat.deleteTempFile(xnatContext.sessionId, f.name);
+//         }
+//       }
+//     } catch { /* ignore cleanup errors */ }
+//     const result = await window.electronAPI.xnat.autoSaveTemp(
+//       xnatContext.sessionId, sourceScanId, base64, tempFilename,
+//     );
+//     if (result.ok) {
+//       segStore._setAutoSaveStatus('saved');
+//       segStore._markClean();
+//       return true;
+//     } else {
+//       segStore._setAutoSaveStatus('error');
+//       return false;
+//     }
+//   } catch (err: any) {
+//     const msg = err instanceof Error ? err.message : String(err);
+//     if (msg.includes('No painted segment data') || msg.includes('no segment-frame pairs') || msg.includes('Error inserting pixels in PixelData')) {
+//       segStore._setAutoSaveStatus('idle');
+//       return false;
+//     }
+//     segStore._setAutoSaveStatus('error');
+//     return false;
+//   }
+// }
 
 let initialized = false;
 

--- a/src/renderer/pages/ViewerPage.tsx
+++ b/src/renderer/pages/ViewerPage.tsx
@@ -28,9 +28,15 @@ interface ViewerPageProps {
   leftSlot?: React.ReactNode;
   /** Browser sidebar rendered below toolbar, left of viewport grid */
   browserSlot?: React.ReactNode;
+  /** Called when the user clicks "Recover" for a backup session in Settings. */
+  onRecoverBackup?: (sessionId: string) => Promise<void> | void;
+  /** When true, the Settings modal should open to the File Backup tab. */
+  openSettingsToBackup?: boolean;
+  /** Called after the Settings-to-backup request has been consumed. */
+  onSettingsToBackupConsumed?: () => void;
 }
 
-export default function ViewerPage({ panelImageIds, onApplyProtocol, onToggleMPR, mprSourceImageIds, leftSlot, browserSlot }: ViewerPageProps) {
+export default function ViewerPage({ panelImageIds, onApplyProtocol, onToggleMPR, mprSourceImageIds, leftSlot, browserSlot, onRecoverBackup, openSettingsToBackup, onSettingsToBackupConsumed }: ViewerPageProps) {
   const showAnnotationPanel = useAnnotationStore((s) => s.showPanel);
   const showSegPanel = useSegmentationStore((s) => s.showPanel);
   const [showDicomPanel, setShowDicomPanel] = useState(false);
@@ -70,6 +76,9 @@ export default function ViewerPage({ panelImageIds, onApplyProtocol, onToggleMPR
         onToggleMPR={onToggleMPR}
         hasImages={hasImages}
         leftSlot={leftSlot}
+        onRecoverBackup={onRecoverBackup}
+        openSettingsToBackup={openSettingsToBackup}
+        onSettingsToBackupConsumed={onSettingsToBackupConsumed}
       />
       <div className="flex-1 min-h-0 flex relative">
         {/* Optional browser sidebar (rendered by App) */}

--- a/src/renderer/stores/preferencesStore.ts
+++ b/src/renderer/stores/preferencesStore.ts
@@ -7,6 +7,8 @@ import {
   type AnnotationToolPreferences,
   type HexColor,
   DEFAULT_INTERPOLATION_PREFERENCES,
+  DEFAULT_BACKUP_PREFERENCES,
+  type BackupPreferences,
   type InterpolationAlgorithm,
   type InterpolationPreferences,
   type OverlayCornerId,
@@ -36,6 +38,9 @@ interface PreferencesStore {
   setInterpolationEnabled: (enabled: boolean) => void;
   setInterpolationAlgorithm: (algorithm: InterpolationAlgorithm) => void;
   setLinearThreshold: (threshold: number) => void;
+  // ─── Backup ─────────────────────────────────────────────
+  setBackupEnabled: (enabled: boolean) => void;
+  setBackupIntervalSeconds: (seconds: number) => void;
   resetAll: () => void;
 }
 
@@ -101,6 +106,7 @@ function makeDefaultPreferences(): PreferencesV1 {
       defaultColorSequence: cloneDefaultColorSequence(),
     },
     interpolation: { ...DEFAULT_INTERPOLATION_PREFERENCES },
+    backup: { ...DEFAULT_BACKUP_PREFERENCES },
   };
 }
 
@@ -365,6 +371,10 @@ export const usePreferencesStore = create<PreferencesStore>()(
             annotation: {
               ...state.preferences.annotation,
               defaultColorSequence: sanitizeColorSequence(colors),
+            },
+          },
+        })),
+
       // ─── Interpolation ────────────────────────────────────
 
       setInterpolationEnabled: (enabled) =>
@@ -390,6 +400,27 @@ export const usePreferencesStore = create<PreferencesStore>()(
             interpolation: {
               ...state.preferences.interpolation,
               linearThreshold: Math.max(0, Math.min(1, threshold)),
+            },
+          },
+        })),
+
+      // ─── Backup ──────────────────────────────────────────
+
+      setBackupEnabled: (enabled) =>
+        set((state) => ({
+          preferences: {
+            ...state.preferences,
+            backup: { ...state.preferences.backup, enabled },
+          },
+        })),
+
+      setBackupIntervalSeconds: (seconds) =>
+        set((state) => ({
+          preferences: {
+            ...state.preferences,
+            backup: {
+              ...state.preferences.backup,
+              intervalSeconds: clampNumber(Math.round(seconds), 5, 300),
             },
           },
         })),
@@ -427,6 +458,19 @@ export const usePreferencesStore = create<PreferencesStore>()(
               : base.preferences.interpolation.linearThreshold,
         };
 
+        // Merge backup preferences with defaults as fallback
+        const incomingBackup = (incoming as Partial<PreferencesV1>).backup;
+        const mergedBackup: BackupPreferences = {
+          enabled:
+            typeof incomingBackup?.enabled === 'boolean'
+              ? incomingBackup.enabled
+              : base.preferences.backup.enabled,
+          intervalSeconds:
+            typeof incomingBackup?.intervalSeconds === 'number' && Number.isFinite(incomingBackup.intervalSeconds)
+              ? clampNumber(Math.round(incomingBackup.intervalSeconds), 5, 300)
+              : base.preferences.backup.intervalSeconds,
+        };
+
         return {
           ...base,
           preferences: {
@@ -436,6 +480,7 @@ export const usePreferencesStore = create<PreferencesStore>()(
             overlay: mergeOverlayPreferences(base.preferences.overlay, incoming.overlay),
             annotation: mergeAnnotationPreferences(base.preferences.annotation, incoming.annotation),
             interpolation: mergedInterpolation,
+            backup: mergedBackup,
           },
         };
       },

--- a/src/renderer/stores/segmentationStore.ts
+++ b/src/renderer/stores/segmentationStore.ts
@@ -76,9 +76,6 @@ interface SegmentationStore {
 
   // ─── Auto-Save State ──────────────────────────────────────
 
-  /** Whether auto-save to XNAT is enabled */
-  autoSaveEnabled: boolean;
-
   /** Current auto-save status */
   autoSaveStatus: 'idle' | 'saving' | 'saved' | 'error';
 
@@ -140,9 +137,6 @@ interface SegmentationStore {
   /** Internal: refresh undo/redo availability from HistoryMemo */
   _refreshUndoState: (canUndo: boolean, canRedo: boolean) => void;
 
-  /** Enable or disable auto-save */
-  setAutoSaveEnabled: (enabled: boolean) => void;
-
   /** Internal: update auto-save status */
   _setAutoSaveStatus: (status: 'idle' | 'saving' | 'saved' | 'error') => void;
 
@@ -199,7 +193,6 @@ export const useSegmentationStore = create<SegmentationStore>((set) => ({
   splineType: 'CATMULLROM',
   canUndo: false,
   canRedo: false,
-  autoSaveEnabled: true,
   autoSaveStatus: 'idle',
   lastAutoSaveTime: null,
   xnatOriginMap: {},
@@ -239,8 +232,6 @@ export const useSegmentationStore = create<SegmentationStore>((set) => ({
   togglePanel: () => set((s) => ({ showPanel: !s.showPanel })),
 
   _refreshUndoState: (canUndo, canRedo) => set({ canUndo, canRedo }),
-
-  setAutoSaveEnabled: (enabled) => set({ autoSaveEnabled: enabled }),
 
   _setAutoSaveStatus: (status) =>
     set({

--- a/src/shared/ipcChannels.ts
+++ b/src/shared/ipcChannels.ts
@@ -57,6 +57,20 @@ export const IPC = {
   EXPORT_SAVE_REPORT: 'export:save-report',
   EXPORT_SAVE_DICOM_RTSTRUCT: 'export:save-dicom-rtstruct',
   EXPORT_SAVE_VIEWPORT_CAPTURE: 'export:save-viewport-capture',
+
+  // Shell (renderer → main)
+  SHELL_OPEN_EXTERNAL: 'shell:open-external',
+
+  // Local backup cache (renderer → main)
+  BACKUP_WRITE_FILE: 'backup:write-file',
+  BACKUP_READ_FILE: 'backup:read-file',
+  BACKUP_DELETE_FILE: 'backup:delete-file',
+  BACKUP_LIST_SESSION: 'backup:list-session',
+  BACKUP_READ_MANIFEST: 'backup:read-manifest',
+  BACKUP_WRITE_MANIFEST: 'backup:write-manifest',
+  BACKUP_DELETE_SESSION: 'backup:delete-session',
+  BACKUP_LIST_ALL_SESSIONS: 'backup:list-all-sessions',
+  BACKUP_GET_CACHE_PATH: 'backup:get-cache-path',
 } as const;
 
 export type IpcChannel = (typeof IPC)[keyof typeof IPC];

--- a/src/shared/types/backup.ts
+++ b/src/shared/types/backup.ts
@@ -1,0 +1,47 @@
+// ─── Local Backup Cache Types ────────────────────────────────────
+//
+// These types describe the on-disk manifest and summary structures
+// used by the local file backup system. The backup cache lives under
+// Electron's userData directory at <userData>/backups/<sessionId>/.
+
+export interface BackupManifest {
+  version: 1;
+  sessionId: string;
+  serverUrl: string;
+  lastUpdated: string; // ISO 8601
+  entries: BackupManifestEntry[];
+  /** XNAT project ID (e.g. "MyProject") */
+  projectId?: string;
+  /** XNAT subject ID (e.g. "XNAT_S00123") — needed to auto-load session for recovery */
+  subjectId?: string;
+  /** Human-readable subject label (e.g. "Subject_001") */
+  subjectLabel?: string;
+  /** Human-readable session label (e.g. "Session_001_MR") */
+  sessionLabel?: string;
+}
+
+export interface BackupManifestEntry {
+  segmentationId: string;
+  filename: string; // e.g. "seg1234_20260302143022.dcm"
+  format: 'SEG' | 'RTSTRUCT';
+  sourceScanId: string;
+  timestamp: string; // ISO 8601
+  sizeBytes: number;
+}
+
+/** Lightweight summary returned when listing all backup sessions. */
+export interface BackupSessionSummary {
+  sessionId: string;
+  serverUrl: string;
+  entryCount: number;
+  totalSizeBytes: number;
+  lastUpdated: string; // ISO 8601
+  /** XNAT project ID (e.g. "MyProject") */
+  projectId: string;
+  /** XNAT subject ID (e.g. "XNAT_S00123") */
+  subjectId: string;
+  /** Human-readable subject label (e.g. "Subject_001") */
+  subjectLabel: string;
+  /** Human-readable session label (e.g. "Session_001_MR") */
+  sessionLabel: string;
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -3,6 +3,7 @@ export * from './viewer';
 export * from './dicom';
 export * from './xnat';
 export * from './preferences';
+export * from './backup';
 
 import type {
   XnatLoginResult,
@@ -137,6 +138,39 @@ export interface ElectronAPI {
       bounds: { x: number; y: number; width: number; height: number },
       defaultName?: string,
     ): Promise<{ ok: boolean; path?: string; error?: string }>;
+  };
+  shell: {
+    openExternal(url: string): Promise<{ ok: boolean; error?: string }>;
+  };
+  backup: {
+    writeFile(
+      sessionId: string,
+      filename: string,
+      base64Data: string,
+    ): Promise<{ ok: boolean; path?: string; sizeBytes?: number; error?: string }>;
+    readFile(
+      sessionId: string,
+      filename: string,
+    ): Promise<{ ok: boolean; data?: string; error?: string }>;
+    deleteFile(
+      sessionId: string,
+      filename: string,
+    ): Promise<{ ok: boolean; error?: string }>;
+    listSession(
+      sessionId: string,
+    ): Promise<{ ok: boolean; files?: Array<{ name: string; sizeBytes: number; modifiedAt: string }>; error?: string }>;
+    readManifest(
+      sessionId: string,
+    ): Promise<{ ok: boolean; manifest?: import('./backup').BackupManifest; error?: string }>;
+    writeManifest(
+      sessionId: string,
+      manifestJson: string,
+    ): Promise<{ ok: boolean; error?: string }>;
+    deleteSession(
+      sessionId: string,
+    ): Promise<{ ok: boolean; error?: string }>;
+    listAllSessions(): Promise<{ ok: boolean; sessions?: import('./backup').BackupSessionSummary[]; error?: string }>;
+    getCachePath(): Promise<{ ok: boolean; path?: string; error?: string }>;
   };
   on(channel: string, callback: (...args: unknown[]) => void): () => void;
 }

--- a/src/shared/types/preferences.ts
+++ b/src/shared/types/preferences.ts
@@ -73,6 +73,20 @@ export const INTERPOLATION_ALGORITHM_DESCRIPTIONS: Record<InterpolationAlgorithm
   linear: 'Blends pixel values linearly between anchors. Adjustable threshold controls fill aggressiveness.',
 };
 
+// ─── Backup Preferences ─────────────────────────────────────────
+
+export interface BackupPreferences {
+  /** Whether local file backup is enabled */
+  enabled: boolean;
+  /** Backup interval in seconds (minimum 5, maximum 300) */
+  intervalSeconds: number;
+}
+
+export const DEFAULT_BACKUP_PREFERENCES: BackupPreferences = {
+  enabled: true,
+  intervalSeconds: 10,
+};
+
 // ─── Top-level Preferences ──────────────────────────────────────
 
 export interface PreferencesV1 {
@@ -82,6 +96,7 @@ export interface PreferencesV1 {
   overlay: OverlayPreferences;
   annotation: AnnotationToolPreferences;
   interpolation: InterpolationPreferences;
+  backup: BackupPreferences;
 }
 
 export const DEFAULT_OVERLAY_CORNERS: Record<OverlayCornerId, OverlayFieldKey[]> = {
@@ -145,4 +160,5 @@ export const DEFAULT_PREFERENCES: PreferencesV1 = {
     defaultColorSequence: DEFAULT_SEGMENT_COLOR_SEQUENCE,
   },
   interpolation: { ...DEFAULT_INTERPOLATION_PREFERENCES },
+  backup: { ...DEFAULT_BACKUP_PREFERENCES },
 };


### PR DESCRIPTION
## Summary
- **Local backup system**: Replaces XNAT temp-resource auto-save with a local filesystem cache managed by Electron's main process, so backups work even when the XNAT connection drops
- **All dirty segmentations backed up**: Every dirty segmentation is backed up on a configurable interval (not just the active one), preventing data loss when switching between annotations
- **Recovery UI**: Startup banner notifies users of cached backups; Settings → File Backup tab allows reviewing, recovering, or deleting cached files; Recover button auto-loads the session from XNAT if not already open
- **Backup preferences**: New File Backup settings tab with enable/disable toggle and configurable interval (5–300 seconds)

## Test plan
- [ ] Open Settings → "File Backup" tab is visible with enable toggle, frequency slider, cache path, and cached files list
- [ ] Create a segmentation, paint on slices → after interval, backup appears in settings cache list
- [ ] Create a second segmentation, paint → both are backed up (not just active)
- [ ] Kill the app process unexpectedly → reopen, load same session → recovery prompt appears: "A recovered annotation was identified for Scan #X"
- [ ] Click Recover from Settings when no session is loaded → session auto-loads from XNAT, then annotations recover
- [ ] Manual save to XNAT → corresponding backup entry is cleaned up
- [ ] Change backup interval in preferences → next auto-save uses new interval
- [ ] Disable backup → no more auto-saves occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)