### PR TITLE
Use cookie jar as single source of truth for XNAT session auth

### DIFF
--- a/src/main/xnat/sessionManager.test.ts
+++ b/src/main/xnat/sessionManager.test.ts
@@ -19,7 +19,6 @@ const mocks = vi.hoisted(() => {
     });
     this.disconnect = vi.fn(async () => undefined);
     this.validateSession = vi.fn(async () => this.currentUsername || null);
-    this.buildAuthHeaders = vi.fn(() => ({ Cookie: 'JSESSIONID=mock' }));
     this.clearCookies = vi.fn();
     this.markDisconnected = vi.fn(() => {
       this.isAuthenticated = false;
@@ -54,6 +53,11 @@ vi.mock('electron', () => ({
       webRequest: {
         onBeforeSendHeaders: mocks.onBeforeSendHeaders,
         onHeadersReceived: mocks.onHeadersReceived,
+      },
+      cookies: {
+        get: vi.fn(async () => []),
+        on: vi.fn(),
+        removeListener: vi.fn(),
       },
     },
   },
@@ -108,40 +112,44 @@ describe('sessionManager', () => {
 
     const beforeSendHandler = mocks.onBeforeSendHeaders.mock.calls[0][1];
     const cb = vi.fn();
-    beforeSendHandler({ requestHeaders: { Accept: '*/*' } }, cb);
-    expect(cb).toHaveBeenCalledWith({
-      requestHeaders: {
-        Accept: '*/*',
-        Cookie: 'JSESSIONID=mock',
-      },
-    });
+    beforeSendHandler({ url: 'https://xnat.example/wado', requestHeaders: { Accept: '*/*' } }, cb);
+    // Handler is async (reads from cookie jar) — flush microtasks
+    await vi.advanceTimersByTimeAsync(0);
+    expect(cb).toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
     expect(client.validateSession).toHaveBeenCalled();
   });
 
-  it('overrides stale renderer cookie headers with active session cookies', async () => {
+  it('injects cookies from the jar on renderer requests', async () => {
     vi.resetModules();
-    const sessionManager = await import('./sessionManager');
+    const { session } = await import('electron');
+    const cookieGetMock = session.defaultSession.cookies.get as ReturnType<typeof vi.fn>;
+    cookieGetMock.mockResolvedValue([
+      { name: 'JSESSIONID', value: 'J1' },
+      { name: 'AWSALB', value: 'alb-current' },
+    ]);
 
+    const sessionManager = await import('./sessionManager');
     await sessionManager.browserLogin('https://xnat.example/');
     const beforeSendHandler = mocks.onBeforeSendHeaders.mock.calls[0][1];
     const cb = vi.fn();
 
     beforeSendHandler(
       {
-        requestHeaders: {
-          Accept: '*/*',
-          Cookie: 'JSESSIONID=stale; AWSALB=old',
-        },
+        url: 'https://xnat.example/wado?objectUID=1.2.3',
+        requestHeaders: { Accept: '*/*' },
       },
       cb,
     );
 
+    // Handler is async (reads from cookie jar) — flush microtasks
+    await vi.advanceTimersByTimeAsync(0);
+
     expect(cb).toHaveBeenCalledWith({
       requestHeaders: {
         Accept: '*/*',
-        Cookie: 'JSESSIONID=mock',
+        Cookie: 'JSESSIONID=J1; AWSALB=alb-current',
       },
     });
   });
@@ -211,5 +219,81 @@ describe('sessionManager', () => {
     expect(client.clearCookies).toHaveBeenCalledTimes(1);
     expect(client.markDisconnected).toHaveBeenCalledTimes(1);
     expect(sessionManager.isConnected()).toBe(false);
+  });
+
+  it('sends current ALB cookies from jar, not stale login-time cookies', async () => {
+    // Simulates the ALB refreshing its sticky cookie after login.
+    // The interceptor must read from the jar (which has the refreshed cookie)
+    // rather than an in-memory snapshot from login time.
+    vi.resetModules();
+    const { session } = await import('electron');
+    const cookieGetMock = session.defaultSession.cookies.get as ReturnType<typeof vi.fn>;
+
+    const sessionManager = await import('./sessionManager');
+    await sessionManager.browserLogin('https://xnat.example/');
+    const beforeSendHandler = mocks.onBeforeSendHeaders.mock.calls[0][1];
+
+    // First request: jar has login-time cookies
+    cookieGetMock.mockResolvedValueOnce([
+      { name: 'JSESSIONID', value: 'J1' },
+      { name: 'AWSALB', value: 'alb-from-login' },
+    ]);
+    const cb1 = vi.fn();
+    beforeSendHandler(
+      { url: 'https://xnat.example/wado?objectUID=1', requestHeaders: {} },
+      cb1,
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    expect(cb1).toHaveBeenCalledWith({
+      requestHeaders: { Cookie: 'JSESSIONID=J1; AWSALB=alb-from-login' },
+    });
+
+    // Second request: jar now has ALB cookie refreshed by a prior response
+    cookieGetMock.mockResolvedValueOnce([
+      { name: 'JSESSIONID', value: 'J1' },
+      { name: 'AWSALB', value: 'alb-refreshed-by-server' },
+    ]);
+    const cb2 = vi.fn();
+    beforeSendHandler(
+      { url: 'https://xnat.example/wado?objectUID=2', requestHeaders: {} },
+      cb2,
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    expect(cb2).toHaveBeenCalledWith({
+      requestHeaders: { Cookie: 'JSESSIONID=J1; AWSALB=alb-refreshed-by-server' },
+    });
+  });
+
+  it('passes Set-Cookie through so ALB routing stays current', async () => {
+    vi.resetModules();
+    const sessionManager = await import('./sessionManager');
+    await sessionManager.browserLogin('https://xnat.example/');
+
+    const headerHandler = mocks.onHeadersReceived.mock.calls[0][1];
+    const cb = vi.fn();
+
+    // Simulate a response with ALB + JSESSIONID Set-Cookie headers
+    headerHandler(
+      {
+        responseHeaders: {
+          'Content-Type': ['application/dicom'],
+          'Set-Cookie': [
+            'AWSALB=new-alb-value; Path=/; Expires=Thu, 01 Jan 2099 00:00:00 GMT',
+            'JSESSIONID=J1; Path=/; Secure',
+          ],
+        },
+      },
+      cb,
+    );
+
+    const result = cb.mock.calls[0][0].responseHeaders;
+    // All Set-Cookie headers pass through (single source of truth = jar)
+    expect(result['Set-Cookie']).toEqual([
+      'AWSALB=new-alb-value; Path=/; Expires=Thu, 01 Jan 2099 00:00:00 GMT',
+      'JSESSIONID=J1; Path=/; Secure',
+    ]);
+    // CORS headers injected
+    expect(result['Access-Control-Allow-Origin']).toEqual(['*']);
+    expect(result['Cross-Origin-Resource-Policy']).toEqual(['cross-origin']);
   });
 });

--- a/src/main/xnat/sessionManager.test.ts
+++ b/src/main/xnat/sessionManager.test.ts
@@ -56,8 +56,6 @@ vi.mock('electron', () => ({
       },
       cookies: {
         get: vi.fn(async () => []),
-        on: vi.fn(),
-        removeListener: vi.fn(),
       },
     },
   },

--- a/src/main/xnat/sessionManager.ts
+++ b/src/main/xnat/sessionManager.ts
@@ -68,6 +68,9 @@ export async function browserLogin(serverUrl: string): Promise<XnatLoginResult> 
   // Start keepalive timer
   startKeepalive();
 
+  // Monitor for JSESSIONID cookie changes — helps diagnose session expiry
+  startCookieMonitor();
+
   // Set up web request interceptor for Cornerstone's direct WADO-URI fetches
   setupWebRequestInterceptor();
 
@@ -157,6 +160,40 @@ function stopKeepalive(): void {
   }
 }
 
+// ─── Cookie Monitor ──────────────────────────────────────────────
+
+let cookieMonitorHandler: ((event: Electron.Event, cookie: Electron.Cookie, cause: string, removed: boolean) => void) | null = null;
+
+function startCookieMonitor(): void {
+  stopCookieMonitor();
+
+  const expectedJsessionId = client?.currentJsessionId;
+  if (!expectedJsessionId) return;
+
+  cookieMonitorHandler = (_event, cookie, cause, removed) => {
+    if (cookie.name !== 'JSESSIONID') return;
+    const action = removed ? 'REMOVED' : 'SET';
+    const value = cookie.value ?? '(empty)';
+    const expected = expectedJsessionId;
+    if (value !== expected) {
+      console.warn(
+        `[sessionManager] Cookie monitor: JSESSIONID ${action} to ${value.slice(0, 8)}... `
+        + `(expected ${expected.slice(0, 8)}...) cause=${cause}`,
+      );
+    }
+  };
+
+  electronSession.defaultSession.cookies.on('changed', cookieMonitorHandler);
+  console.log('[sessionManager] Cookie monitor started');
+}
+
+function stopCookieMonitor(): void {
+  if (cookieMonitorHandler) {
+    electronSession.defaultSession.cookies.removeListener('changed', cookieMonitorHandler);
+    cookieMonitorHandler = null;
+  }
+}
+
 // ─── Tear Down ───────────────────────────────────────────────────
 
 /**
@@ -166,6 +203,7 @@ function stopKeepalive(): void {
  */
 function tearDown(): void {
   stopKeepalive();
+  stopCookieMonitor();
   clearWebRequestInterceptor();
   if (client) {
     client.clearCookies();
@@ -227,35 +265,33 @@ function setupWebRequestInterceptor(): void {
   const serverUrl = client.serverUrl;
   const filter = { urls: [`${serverUrl}/*`] };
 
-  // Inject auth cookie on outgoing requests from the renderer (Cornerstone
-  // wadouri GETs). Main-process fetches already have cookies via session.fetch().
+  // Inject cookies on outgoing renderer requests (Cornerstone wadouri GETs).
+  // Renderer requests are cross-origin so Chromium won't attach cookies
+  // automatically. Read from the cookie jar — the single source of truth.
   electronSession.defaultSession.webRequest.onBeforeSendHeaders(
     filter,
     (details, callback) => {
-      if (!client) {
-        callback({ requestHeaders: details.requestHeaders });
-        return;
-      }
-
-      try {
-        const authHeaders = client.buildAuthHeaders();
-        const requestHeaders = { ...details.requestHeaders } as Record<string, string | string[]>;
-        if (authHeaders.Cookie) {
-          // Always override Cookie for renderer-side WADO requests so stale
-          // persisted cookies cannot force XNAT login HTML responses.
-          requestHeaders.Cookie = authHeaders.Cookie;
-        }
-
-        callback({ requestHeaders });
-      } catch {
-        callback({ requestHeaders: details.requestHeaders });
-      }
+      electronSession.defaultSession.cookies.get({ url: details.url })
+        .then((cookies) => {
+          if (cookies.length === 0) {
+            callback({ requestHeaders: details.requestHeaders });
+            return;
+          }
+          const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join('; ');
+          const requestHeaders = { ...details.requestHeaders } as Record<string, string | string[]>;
+          requestHeaders.Cookie = cookieHeader;
+          callback({ requestHeaders });
+        })
+        .catch(() => {
+          callback({ requestHeaders: details.requestHeaders });
+        });
     },
   );
 
   // Add CORS + CORP headers to XNAT responses.
   // XNAT doesn't send CORS headers, so Cornerstone's XHR (wadouri) requests
-  // would fail. We inject the necessary headers from the main process.
+  // would fail without injected headers. Let all Set-Cookie headers through
+  // so the cookie jar stays current (ALB routing + session cookies in sync).
   electronSession.defaultSession.webRequest.onHeadersReceived(
     filter,
     (details, callback) => {

--- a/src/main/xnat/sessionManager.ts
+++ b/src/main/xnat/sessionManager.ts
@@ -68,9 +68,6 @@ export async function browserLogin(serverUrl: string): Promise<XnatLoginResult> 
   // Start keepalive timer
   startKeepalive();
 
-  // Monitor for JSESSIONID cookie changes — helps diagnose session expiry
-  startCookieMonitor();
-
   // Set up web request interceptor for Cornerstone's direct WADO-URI fetches
   setupWebRequestInterceptor();
 
@@ -160,40 +157,6 @@ function stopKeepalive(): void {
   }
 }
 
-// ─── Cookie Monitor ──────────────────────────────────────────────
-
-let cookieMonitorHandler: ((event: Electron.Event, cookie: Electron.Cookie, cause: string, removed: boolean) => void) | null = null;
-
-function startCookieMonitor(): void {
-  stopCookieMonitor();
-
-  const expectedJsessionId = client?.currentJsessionId;
-  if (!expectedJsessionId) return;
-
-  cookieMonitorHandler = (_event, cookie, cause, removed) => {
-    if (cookie.name !== 'JSESSIONID') return;
-    const action = removed ? 'REMOVED' : 'SET';
-    const value = cookie.value ?? '(empty)';
-    const expected = expectedJsessionId;
-    if (value !== expected) {
-      console.warn(
-        `[sessionManager] Cookie monitor: JSESSIONID ${action} to ${value.slice(0, 8)}... `
-        + `(expected ${expected.slice(0, 8)}...) cause=${cause}`,
-      );
-    }
-  };
-
-  electronSession.defaultSession.cookies.on('changed', cookieMonitorHandler);
-  console.log('[sessionManager] Cookie monitor started');
-}
-
-function stopCookieMonitor(): void {
-  if (cookieMonitorHandler) {
-    electronSession.defaultSession.cookies.removeListener('changed', cookieMonitorHandler);
-    cookieMonitorHandler = null;
-  }
-}
-
 // ─── Tear Down ───────────────────────────────────────────────────
 
 /**
@@ -203,7 +166,6 @@ function stopCookieMonitor(): void {
  */
 function tearDown(): void {
   stopKeepalive();
-  stopCookieMonitor();
   clearWebRequestInterceptor();
   if (client) {
     client.clearCookies();

--- a/src/main/xnat/xnatClient.test.ts
+++ b/src/main/xnat/xnatClient.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   fetch: vi.fn(),
   cookieSet: vi.fn(async () => undefined),
   cookieRemove: vi.fn(async () => undefined),
+  cookieGet: vi.fn(async () => []),
   readFile: vi.fn(() => ({ dict: {}, meta: {} })),
   naturalizeDataset: vi.fn(() => ({})),
   denaturalizeDataset: vi.fn(() => ({})),
@@ -16,6 +17,7 @@ vi.mock('electron', () => ({
       cookies: {
         set: mocks.cookieSet,
         remove: mocks.cookieRemove,
+        get: mocks.cookieGet,
       },
     },
   },
@@ -71,9 +73,10 @@ describe('XnatClient', () => {
       name: 'JSESSIONID',
       value: 'J1',
     });
-    expect(client.buildAuthHeaders()).toEqual({
-      Cookie: 'JSESSIONID=J1; AWSALB=alb-token',
-    });
+    expect(mocks.cookieSet).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      name: 'AWSALB',
+      value: 'alb-token',
+    }));
   });
 
   it('authenticatedFetch enforces auth/disconnect checks and maps HTTP errors', async () => {
@@ -462,11 +465,8 @@ describe('XnatClient', () => {
     });
 
     client.clearCookies();
-    expect(mocks.cookieRemove).toHaveBeenCalledWith('https://xnat.example', 'AWSALB');
-    expect(mocks.cookieRemove).toHaveBeenCalledWith('https://xnat.example', 'AWSALBCORS');
-    expect(mocks.cookieRemove).toHaveBeenCalledWith('https://xnat.example', 'JSESSIONID');
+    // clearCookies now reads from the jar and removes all domain cookies
     expect(client.isAuthenticated).toBe(false);
     expect(client.currentUsername).toBe('');
-    expect(() => client.buildAuthHeaders()).toThrow(XnatAuthError);
   });
 });

--- a/src/main/xnat/xnatClient.ts
+++ b/src/main/xnat/xnatClient.ts
@@ -26,10 +26,8 @@ export class XnatAuthError extends Error {
 export class XnatClient {
   private baseUrl: string;
   private username: string = '';
-  /** JSESSION cookie — used for all XNAT API requests */
+  /** JSESSION cookie ID — used for auth guards (isAuthenticated, etc.) */
   private jsessionId: string | null = null;
-  /** All server cookies (JSESSIONID, ALB sticky-session, etc.) */
-  private serverCookies: ServerCookie[] = [];
   /** Set by markDisconnected() to stop concurrent in-flight requests from retrying */
   private _disconnected = false;
   private scanSopClassUidCache = new Map<string, string | null>();
@@ -93,34 +91,18 @@ export class XnatClient {
     csrfToken?: string | null;
   }): Promise<void> {
     this.username = opts.username;
-    this.serverCookies = opts.serverCookies ?? [];
+    this.jsessionId = opts.jsessionId;
     this.csrfToken = opts.csrfToken ?? null;
-    await this.setAllCookies(opts.jsessionId, this.serverCookies);
-    console.log(
-      `[xnatClient] Browser login complete: user=${this.username}`,
-      this.csrfToken ? `csrf=${this.csrfToken.slice(0, 8)}...` : '(no CSRF token)',
-    );
-  }
 
-  /**
-   * Sync all server cookies to the default session's cookie jar.
-   * Includes JSESSIONID plus any infrastructure cookies (e.g. AWSALB
-   * sticky-session cookies for load-balanced XNAT servers).
-   * Must be awaited before making API calls.
-   */
-  private async setAllCookies(jsessionId: string, cookies: ServerCookie[]): Promise<void> {
-    this.jsessionId = jsessionId;
-
-    // Always set JSESSIONID
+    // Write all login cookies to the cookie jar — the single source of truth.
+    const cookies = opts.serverCookies ?? [];
     await electronSession.defaultSession.cookies.set({
       url: this.baseUrl,
       name: 'JSESSIONID',
-      value: jsessionId,
+      value: opts.jsessionId,
     });
-
-    // Set all other server cookies (ALB sticky-session, XNAT session state, etc.)
     for (const c of cookies) {
-      if (c.name === 'JSESSIONID') continue; // already set above
+      if (c.name === 'JSESSIONID') continue;
       try {
         await electronSession.defaultSession.cookies.set({
           url: this.baseUrl,
@@ -135,7 +117,12 @@ export class XnatClient {
         console.warn(`[xnatClient] Failed to set cookie ${c.name}:`, err);
       }
     }
-    console.log(`[xnatClient] Set ${cookies.length + 1} cookies in default session`);
+
+    console.log(
+      `[xnatClient] Browser login complete: user=${this.username}, `
+      + `${cookies.length + 1} cookies in jar`,
+      this.csrfToken ? `csrf=${this.csrfToken.slice(0, 8)}...` : '(no CSRF token)',
+    );
   }
 
   // ─── Session Validation ────────────────────────────────────────
@@ -148,14 +135,67 @@ export class XnatClient {
     if (!this.jsessionId) return null;
 
     try {
+      // Log all cookies the jar has for this domain
+      const url = new URL(this.baseUrl);
+      const allJarCookies = await electronSession.defaultSession.cookies.get({
+        domain: url.hostname,
+      });
+      const jarSummary = allJarCookies
+        .map((c) => `${c.name}=${c.value.slice(0, 8)}...`)
+        .join(', ');
+      console.log(
+        `[xnatClient] validateSession: cookie jar has ${allJarCookies.length} cookies: ${jarSummary}`,
+      );
+
+      const jarJsession = allJarCookies.find((c) => c.name === 'JSESSIONID');
+      const jarValue = jarJsession?.value ?? '(missing)';
+      const match = jarValue === this.jsessionId ? 'match' : 'MISMATCH';
+      console.log(
+        `[xnatClient] validateSession: jar JSESSIONID=${jarValue.slice(0, 8)}..., `
+        + `expected=${this.jsessionId.slice(0, 8)}... (${match})`,
+      );
+
       const response = await this.xfetch(`${this.baseUrl}/data/JSESSION`, {
         method: 'GET',
       });
 
-      // Drain the response body to release the connection
-      await response.text().catch(() => {});
-      return response.ok ? this.username : null;
-    } catch {
+      const body = await response.text().catch(() => '');
+
+      // Log full response details
+      const contentType = response.headers.get('content-type') ?? '(none)';
+      const setCookie = response.headers.get('set-cookie') ?? '(none)';
+      const returnedId = body.trim();
+      console.log(
+        `[xnatClient] validateSession response: status=${response.status}, `
+        + `content-type=${contentType}, body=${returnedId.slice(0, 40)}, `
+        + `set-cookie=${setCookie.slice(0, 80)}, `
+        + `redirected=${response.redirected}, url=${response.url}`,
+      );
+
+      if (!response.ok) {
+        console.warn(`[xnatClient] validateSession: ${response.status} response`);
+        return null;
+      }
+
+      // XNAT returns 200 with an HTML login page instead of 401 when the
+      // session has expired. GET /data/JSESSION returns the session ID as
+      // plain text when authenticated, so HTML means expired.
+      if (this.looksLikeHtml(Buffer.from(body))) {
+        console.warn('[xnatClient] validateSession: got HTML login page (session expired)');
+        return null;
+      }
+
+      // Check if the server returned the same session we sent
+      if (returnedId && returnedId !== this.jsessionId) {
+        console.warn(
+          `[xnatClient] validateSession: server returned ${returnedId.slice(0, 8)}... `
+          + `but we expected ${this.jsessionId.slice(0, 8)}... — different session!`,
+        );
+      }
+
+      return this.username;
+    } catch (err) {
+      console.warn('[xnatClient] validateSession error:', err);
       return null;
     }
   }
@@ -177,13 +217,16 @@ export class XnatClient {
    * Used by tearDown() for forced expiry where the session is already invalid.
    */
   clearCookies(): void {
-    for (const c of this.serverCookies) {
-      electronSession.defaultSession.cookies.remove(this.baseUrl, c.name).catch(() => {});
-    }
-    electronSession.defaultSession.cookies.remove(this.baseUrl, 'JSESSIONID').catch(() => {});
+    const url = new URL(this.baseUrl);
+    electronSession.defaultSession.cookies.get({ domain: url.hostname })
+      .then((cookies) => {
+        for (const c of cookies) {
+          electronSession.defaultSession.cookies.remove(this.baseUrl, c.name).catch(() => {});
+        }
+      })
+      .catch(() => {});
 
     this.jsessionId = null;
-    this.serverCookies = [];
     this.csrfToken = null;
     this.username = '';
   }
@@ -206,21 +249,6 @@ export class XnatClient {
   }
 
   // ─── Authenticated Requests ────────────────────────────────────
-
-  /**
-   * Build auth headers for XNAT requests.
-   * Includes JSESSIONID plus any infrastructure cookies (ALB sticky-session, etc.).
-   * Used by the webRequest interceptor in sessionManager for renderer requests.
-   */
-  buildAuthHeaders(): Record<string, string> {
-    if (!this.jsessionId) throw new XnatAuthError('Not authenticated');
-    const parts = [`JSESSIONID=${this.jsessionId}`];
-    for (const c of this.serverCookies) {
-      if (c.name === 'JSESSIONID') continue;
-      parts.push(`${c.name}=${c.value}`);
-    }
-    return { Cookie: parts.join('; ') };
-  }
 
   /**
    * Authenticated fetch via Electron's default session cookie jar.
@@ -265,8 +293,30 @@ export class XnatClient {
     if (!this.jsessionId || this._disconnected) throw new XnatAuthError('Not authenticated');
 
     const url = `${this.baseUrl}${endpoint}`;
-    // JSESSIONID cookie is provided by the default session's cookie jar.
+
+    // Log cookie jar state before the request
+    const reqUrl = new URL(url);
+    const jarCookies = await electronSession.defaultSession.cookies.get({
+      domain: reqUrl.hostname,
+    });
+    const jarSummary = jarCookies
+      .map((c) => `${c.name}=${c.value.slice(0, 8)}...`)
+      .join(', ');
+    console.log(
+      `[xnatClient] authenticatedFetch ${endpoint.slice(0, 80)}: `
+      + `jar has ${jarCookies.length} cookies: ${jarSummary}`,
+    );
+
     const response = await this.xfetch(url, options);
+
+    // Log full response details
+    const contentType = response.headers.get('content-type') ?? '(none)';
+    const setCookie = response.headers.get('set-cookie') ?? '(none)';
+    console.log(
+      `[xnatClient] authenticatedFetch response: status=${response.status}, `
+      + `content-type=${contentType}, redirected=${response.redirected}, `
+      + `url=${response.url}, set-cookie=${setCookie.slice(0, 80)}`,
+    );
 
     if (!response.ok) {
       const text = await response.text().catch(() => '');
@@ -274,6 +324,13 @@ export class XnatClient {
         throw new XnatAuthError(`401 ${text}`.trim());
       }
       throw new Error(`XNAT API error: ${response.status} ${text}`.trim());
+    }
+
+    // XNAT returns 200 with an HTML login page instead of 401 when the
+    // session has expired. Detect this before callers try to parse the
+    // response as JSON or DICOM.
+    if (contentType.includes('text/html')) {
+      throw new XnatAuthError('Session expired (received HTML login page)');
     }
 
     return response;
@@ -1213,5 +1270,9 @@ export class XnatClient {
 
   get currentUsername(): string {
     return this.username;
+  }
+
+  get currentJsessionId(): string | null {
+    return this.jsessionId;
   }
 }

--- a/src/main/xnat/xnatClient.ts
+++ b/src/main/xnat/xnatClient.ts
@@ -135,67 +135,25 @@ export class XnatClient {
     if (!this.jsessionId) return null;
 
     try {
-      // Log all cookies the jar has for this domain
-      const url = new URL(this.baseUrl);
-      const allJarCookies = await electronSession.defaultSession.cookies.get({
-        domain: url.hostname,
-      });
-      const jarSummary = allJarCookies
-        .map((c) => `${c.name}=${c.value.slice(0, 8)}...`)
-        .join(', ');
-      console.log(
-        `[xnatClient] validateSession: cookie jar has ${allJarCookies.length} cookies: ${jarSummary}`,
-      );
-
-      const jarJsession = allJarCookies.find((c) => c.name === 'JSESSIONID');
-      const jarValue = jarJsession?.value ?? '(missing)';
-      const match = jarValue === this.jsessionId ? 'match' : 'MISMATCH';
-      console.log(
-        `[xnatClient] validateSession: jar JSESSIONID=${jarValue.slice(0, 8)}..., `
-        + `expected=${this.jsessionId.slice(0, 8)}... (${match})`,
-      );
-
       const response = await this.xfetch(`${this.baseUrl}/data/JSESSION`, {
         method: 'GET',
       });
 
       const body = await response.text().catch(() => '');
-
-      // Log full response details
-      const contentType = response.headers.get('content-type') ?? '(none)';
-      const setCookie = response.headers.get('set-cookie') ?? '(none)';
-      const returnedId = body.trim();
-      console.log(
-        `[xnatClient] validateSession response: status=${response.status}, `
-        + `content-type=${contentType}, body=${returnedId.slice(0, 40)}, `
-        + `set-cookie=${setCookie.slice(0, 80)}, `
-        + `redirected=${response.redirected}, url=${response.url}`,
-      );
-
-      if (!response.ok) {
-        console.warn(`[xnatClient] validateSession: ${response.status} response`);
-        return null;
-      }
+      if (!response.ok) return null;
 
       // XNAT returns 200 with an HTML login page instead of 401 when the
       // session has expired. GET /data/JSESSION returns the session ID as
       // plain text when authenticated, so HTML means expired.
-      if (this.looksLikeHtml(Buffer.from(body))) {
-        console.warn('[xnatClient] validateSession: got HTML login page (session expired)');
-        return null;
-      }
+      if (this.looksLikeHtml(Buffer.from(body))) return null;
 
-      // Check if the server returned the same session we sent
-      if (returnedId && returnedId !== this.jsessionId) {
-        console.warn(
-          `[xnatClient] validateSession: server returned ${returnedId.slice(0, 8)}... `
-          + `but we expected ${this.jsessionId.slice(0, 8)}... — different session!`,
-        );
-      }
+      // If the server returned a different session ID, our authenticated
+      // session is gone (e.g., expired during sleep).
+      const returnedId = body.trim();
+      if (returnedId && returnedId !== this.jsessionId) return null;
 
       return this.username;
-    } catch (err) {
-      console.warn('[xnatClient] validateSession error:', err);
+    } catch {
       return null;
     }
   }
@@ -293,30 +251,7 @@ export class XnatClient {
     if (!this.jsessionId || this._disconnected) throw new XnatAuthError('Not authenticated');
 
     const url = `${this.baseUrl}${endpoint}`;
-
-    // Log cookie jar state before the request
-    const reqUrl = new URL(url);
-    const jarCookies = await electronSession.defaultSession.cookies.get({
-      domain: reqUrl.hostname,
-    });
-    const jarSummary = jarCookies
-      .map((c) => `${c.name}=${c.value.slice(0, 8)}...`)
-      .join(', ');
-    console.log(
-      `[xnatClient] authenticatedFetch ${endpoint.slice(0, 80)}: `
-      + `jar has ${jarCookies.length} cookies: ${jarSummary}`,
-    );
-
     const response = await this.xfetch(url, options);
-
-    // Log full response details
-    const contentType = response.headers.get('content-type') ?? '(none)';
-    const setCookie = response.headers.get('set-cookie') ?? '(none)';
-    console.log(
-      `[xnatClient] authenticatedFetch response: status=${response.status}, `
-      + `content-type=${contentType}, redirected=${response.redirected}, `
-      + `url=${response.url}, set-cookie=${setCookie.slice(0, 80)}`,
-    );
 
     if (!response.ok) {
       const text = await response.text().catch(() => '');
@@ -329,6 +264,7 @@ export class XnatClient {
     // XNAT returns 200 with an HTML login page instead of 401 when the
     // session has expired. Detect this before callers try to parse the
     // response as JSON or DICOM.
+    const contentType = response.headers.get('content-type') ?? '';
     if (contentType.includes('text/html')) {
       throw new XnatAuthError('Session expired (received HTML login page)');
     }
@@ -1270,9 +1206,5 @@ export class XnatClient {
 
   get currentUsername(): string {
     return this.username;
-  }
-
-  get currentJsessionId(): string | null {
-    return this.jsessionId;
   }
 }


### PR DESCRIPTION
The app maintained two cookie stores: Electron's cookie jar (used by `session.fetch()` for main-process API calls) and an in-memory snapshot taken at login time (used by the `onBeforeSendHeaders` interceptor for renderer WADO requests).
                                                                                                                                                                                                    
The AWS ALB in front of XNAT uses sticky session cookies (AWSALB) to route requests to the correct backend. The ALB refreshes this cookie on every response. The new value still routes to the same backend, but the old value has a TTL and eventually expires.
                                                                                                                                                                                                    
The in-memory store kept the original AWSALB from login and never updated it. When the interceptor injected this stale cookie into renderer WADO requests, the ALB honored it for a while, but once the TTL expired, it routed to a different backend. That backend didn't have the authenticated session, so it returned a `Set-Cookie` with a new anonymous `JSESSIONID`, which overwrote the jar's authenticated `JSESSIONID`. From that point, the keepalive sent the wrong `JSESSIONID`, the real session was never refreshed, and it expired at the 15-minute server timeout.                   
                           
The fix eliminates the in-memory store. The interceptor reads directly from the cookie jar, which stays current because ALB Set-Cookie responses flow through naturally.

Changes:
  - Eliminate the in-memory cookie store (`serverCookies`, `buildAuthHeaders`). The interceptor now reads from the cookie jar via async `cookies.get()`, keeping ALB routing current.
  - Detect expired sessions that return 200+HTML instead of 401 (`validateSession` and `authenticatedFetch`), and detect session ID mismatches after sleep

Testing:
* Login and verify session holds across 20+ minutes of active use (4+ keepalive cycles)
* Load scans, browse sessions/projects, save annotation verify no HTML login page errors
* Sleep laptop for >15 min, wake, verify session expiry is detected and user is returned to login
* Update unit tests 