### PR TITLE
Add de-identified issue report panel and diagnostics capture

### DIFF
--- a/src/main/diagnostics/mainLogBuffer.ts
+++ b/src/main/diagnostics/mainLogBuffer.ts
@@ -1,0 +1,110 @@
+import type { DiagnosticsLogEntry, DiagnosticsLogLevel, DiagnosticsLogStream } from '../../shared/types/diagnostics';
+import { deidentifyText } from '../../shared/diagnostics/deidentify';
+
+const MAX_LOG_ENTRIES = 600;
+const stdoutLogs: DiagnosticsLogEntry[] = [];
+const stderrLogs: DiagnosticsLogEntry[] = [];
+
+let captureInstalled = false;
+let stdoutBuffer = '';
+let stderrBuffer = '';
+
+function levelForStream(stream: DiagnosticsLogStream): DiagnosticsLogLevel {
+  return stream === 'stderr' ? 'error' : 'info';
+}
+
+function targetForStream(stream: DiagnosticsLogStream): DiagnosticsLogEntry[] {
+  return stream === 'stderr' ? stderrLogs : stdoutLogs;
+}
+
+function pushLog(stream: DiagnosticsLogStream, message: string): void {
+  const sanitized = deidentifyText(message.trim());
+  if (!sanitized) return;
+
+  const target = targetForStream(stream);
+  target.push({
+    timestamp: new Date().toISOString(),
+    source: 'main',
+    stream,
+    level: levelForStream(stream),
+    message: sanitized,
+  });
+  if (target.length > MAX_LOG_ENTRIES) {
+    target.splice(0, target.length - MAX_LOG_ENTRIES);
+  }
+}
+
+function consumeChunk(stream: DiagnosticsLogStream, chunk: unknown): void {
+  const text =
+    typeof chunk === 'string'
+      ? chunk
+      : Buffer.isBuffer(chunk)
+        ? chunk.toString('utf8')
+        : String(chunk ?? '');
+  if (!text) return;
+
+  if (stream === 'stdout') {
+    stdoutBuffer += text;
+    const lines = stdoutBuffer.split(/\r?\n/);
+    stdoutBuffer = lines.pop() ?? '';
+    for (const line of lines) pushLog('stdout', line);
+    return;
+  }
+
+  stderrBuffer += text;
+  const lines = stderrBuffer.split(/\r?\n/);
+  stderrBuffer = lines.pop() ?? '';
+  for (const line of lines) pushLog('stderr', line);
+}
+
+export function installMainLogCapture(): void {
+  if (captureInstalled) return;
+  captureInstalled = true;
+
+  const stdout = process.stdout as NodeJS.WriteStream & {
+    write: (chunk: unknown, encoding?: unknown, cb?: unknown) => boolean;
+  };
+  const stderr = process.stderr as NodeJS.WriteStream & {
+    write: (chunk: unknown, encoding?: unknown, cb?: unknown) => boolean;
+  };
+
+  if (stdout?.write) {
+    const originalWrite = stdout.write.bind(stdout);
+    stdout.write = ((chunk: unknown, encoding?: unknown, cb?: unknown) => {
+      consumeChunk('stdout', chunk);
+      return originalWrite(chunk, encoding as any, cb as any);
+    }) as typeof stdout.write;
+  }
+
+  if (stderr?.write) {
+    const originalWrite = stderr.write.bind(stderr);
+    stderr.write = ((chunk: unknown, encoding?: unknown, cb?: unknown) => {
+      consumeChunk('stderr', chunk);
+      return originalWrite(chunk, encoding as any, cb as any);
+    }) as typeof stderr.write;
+  }
+
+  process.on('uncaughtException', (err) => {
+    pushLog('stderr', `[uncaughtException] ${err?.stack || String(err)}`);
+  });
+  process.on('unhandledRejection', (reason) => {
+    pushLog('stderr', `[unhandledRejection] ${reason instanceof Error ? reason.stack || reason.message : String(reason)}`);
+  });
+}
+
+export function getMainLogSnapshot(limitPerStream = 200): {
+  stdout: DiagnosticsLogEntry[];
+  stderr: DiagnosticsLogEntry[];
+} {
+  if (stdoutBuffer.trim()) {
+    pushLog('stdout', stdoutBuffer);
+    stdoutBuffer = '';
+  }
+  if (stderrBuffer.trim()) {
+    pushLog('stderr', stderrBuffer);
+    stderrBuffer = '';
+  }
+  const stdout = stdoutLogs.slice(-Math.max(1, limitPerStream));
+  const stderr = stderrLogs.slice(-Math.max(1, limitPerStream));
+  return { stdout, stderr };
+}

--- a/src/main/index.test.ts
+++ b/src/main/index.test.ts
@@ -64,6 +64,8 @@ const mocks = vi.hoisted(() => {
     registerExportHandlers: vi.fn(),
     registerUploadHandlers: vi.fn(),
     registerBackupHandlers: vi.fn(),
+    registerDiagnosticsHandlers: vi.fn(),
+    installMainLogCapture: vi.fn(),
   };
 });
 
@@ -96,6 +98,14 @@ vi.mock('./ipc/backupHandlers', () => ({
   registerBackupHandlers: mocks.registerBackupHandlers,
 }));
 
+vi.mock('./ipc/diagnosticsHandlers', () => ({
+  registerDiagnosticsHandlers: mocks.registerDiagnosticsHandlers,
+}));
+
+vi.mock('./diagnostics/mainLogBuffer', () => ({
+  installMainLogCapture: mocks.installMainLogCapture,
+}));
+
 async function loadMainEntry(): Promise<void> {
   vi.resetModules();
   await import('./index');
@@ -120,6 +130,8 @@ describe('main/index bootstrap', () => {
     expect(mocks.registerExportHandlers).toHaveBeenCalledTimes(1);
     expect(mocks.registerUploadHandlers).toHaveBeenCalledTimes(1);
     expect(mocks.registerBackupHandlers).toHaveBeenCalledTimes(1);
+    expect(mocks.registerDiagnosticsHandlers).toHaveBeenCalledTimes(1);
+    expect(mocks.installMainLogCapture).toHaveBeenCalledTimes(1);
 
     expect(mocks.app.name).toBe('XNAT');
     expect(mocks.Menu.buildFromTemplate).toHaveBeenCalledTimes(1);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,7 +5,11 @@ import { registerProxyHandlers } from './ipc/proxyHandlers';
 import { registerExportHandlers } from './ipc/exportHandlers';
 import { registerUploadHandlers } from './ipc/uploadHandlers';
 import { registerBackupHandlers } from './ipc/backupHandlers';
+import { registerDiagnosticsHandlers } from './ipc/diagnosticsHandlers';
+import { installMainLogCapture } from './diagnostics/mainLogBuffer';
 import { IPC } from '../shared/ipcChannels';
+
+installMainLogCapture();
 
 // Suppress EPIPE errors from console.log when stdout/stderr pipe is broken.
 // This is common when Electron is launched from a terminal that disconnects.
@@ -181,6 +185,7 @@ app.whenReady().then(() => {
   registerExportHandlers();
   registerUploadHandlers();
   registerBackupHandlers();
+  registerDiagnosticsHandlers();
 
   // Shell: open URL in system browser
   ipcMain.handle(IPC.SHELL_OPEN_EXTERNAL, async (_event, url: string) => {

--- a/src/main/ipc/diagnosticsHandlers.test.ts
+++ b/src/main/ipc/diagnosticsHandlers.test.ts
@@ -1,0 +1,78 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IPC } from '../../shared/ipcChannels';
+import { createIpcMainMock } from '../../test/ipc/ipcMocks';
+
+const ipcMainMock = createIpcMainMock();
+
+const electronMocks = {
+  app: {
+    getName: vi.fn(() => 'XNAT Workstation'),
+    getVersion: vi.fn(() => '0.5.2'),
+    isPackaged: true,
+  },
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => [{}, {}]),
+  },
+};
+
+const getMainLogSnapshotMock = vi.fn(() => ({
+  stdout: [
+    {
+      timestamp: '2026-03-05T00:00:00.000Z',
+      source: 'main' as const,
+      stream: 'stdout' as const,
+      level: 'info' as const,
+      message: 'main stdout',
+    },
+  ],
+  stderr: [
+    {
+      timestamp: '2026-03-05T00:00:01.000Z',
+      source: 'main' as const,
+      stream: 'stderr' as const,
+      level: 'error' as const,
+      message: 'main stderr',
+    },
+  ],
+}));
+
+let registerDiagnosticsHandlers: (typeof import('./diagnosticsHandlers'))['registerDiagnosticsHandlers'];
+
+beforeAll(async () => {
+  vi.doMock('electron', () => ({
+    ipcMain: ipcMainMock.ipcMain,
+    app: electronMocks.app,
+    BrowserWindow: electronMocks.BrowserWindow,
+  }));
+
+  vi.doMock('../diagnostics/mainLogBuffer', () => ({
+    getMainLogSnapshot: getMainLogSnapshotMock,
+  }));
+
+  ({ registerDiagnosticsHandlers } = await import('./diagnosticsHandlers'));
+});
+
+describe('registerDiagnosticsHandlers', () => {
+  beforeEach(() => {
+    ipcMainMock.handlers.clear();
+    ipcMainMock.listeners.clear();
+    ipcMainMock.ipcMain.handle.mockClear();
+    vi.clearAllMocks();
+  });
+
+  it('registers diagnostics snapshot channel and returns structured data', async () => {
+    registerDiagnosticsHandlers();
+
+    const channels = ipcMainMock.ipcMain.handle.mock.calls.map((call) => call[0]);
+    expect(channels).toContain(IPC.DIAGNOSTICS_GET_MAIN_SNAPSHOT);
+
+    const result = await ipcMainMock.invoke(IPC.DIAGNOSTICS_GET_MAIN_SNAPSHOT);
+    expect(result.ok).toBe(true);
+    expect(result.snapshot.app.name).toBe('XNAT Workstation');
+    expect(result.snapshot.app.version).toBe('0.5.2');
+    expect(result.snapshot.app.windowCount).toBe(2);
+    expect(result.snapshot.logs.stdout[0].message).toBe('main stdout');
+    expect(result.snapshot.logs.stderr[0].message).toBe('main stderr');
+    expect(getMainLogSnapshotMock).toHaveBeenCalledWith(220);
+  });
+});

--- a/src/main/ipc/diagnosticsHandlers.ts
+++ b/src/main/ipc/diagnosticsHandlers.ts
@@ -1,0 +1,72 @@
+import os from 'os';
+import crypto from 'crypto';
+import { app, BrowserWindow, ipcMain } from 'electron';
+import { IPC } from '../../shared/ipcChannels';
+import type { MainDiagnosticsSnapshot } from '../../shared/types/diagnostics';
+import { deidentifyText } from '../../shared/diagnostics/deidentify';
+import { getMainLogSnapshot } from '../diagnostics/mainLogBuffer';
+
+function mb(bytes: number): number {
+  return Math.round((bytes / (1024 * 1024)) * 10) / 10;
+}
+
+function hostFingerprint(hostname: string): string {
+  if (!hostname) return 'unknown';
+  return crypto.createHash('sha256').update(hostname).digest('hex').slice(0, 12);
+}
+
+export function registerDiagnosticsHandlers(): void {
+  ipcMain.handle(IPC.DIAGNOSTICS_GET_MAIN_SNAPSHOT, async () => {
+    try {
+      const memory = process.memoryUsage();
+      const cpus = os.cpus();
+      const logs = getMainLogSnapshot(220);
+
+      const snapshot: MainDiagnosticsSnapshot = {
+        generatedAt: new Date().toISOString(),
+        app: {
+          name: app.getName(),
+          version: app.getVersion(),
+          isPackaged: app.isPackaged,
+          pid: process.pid,
+          uptimeSec: Math.round(process.uptime()),
+          windowCount: BrowserWindow.getAllWindows().length,
+        },
+        runtime: {
+          electron: process.versions.electron,
+          chrome: process.versions.chrome,
+          node: process.versions.node,
+          v8: process.versions.v8,
+          platform: process.platform,
+          arch: process.arch,
+        },
+        system: {
+          osType: os.type(),
+          osRelease: os.release(),
+          osVersion: os.version(),
+          cpuModel: deidentifyText(cpus[0]?.model || 'unknown'),
+          cpuCount: cpus.length,
+          totalMemoryMB: mb(os.totalmem()),
+          freeMemoryMB: mb(os.freemem()),
+          loadAverage: os.loadavg().map((v) => Math.round(v * 100) / 100),
+          hostnameFingerprint: hostFingerprint(os.hostname()),
+        },
+        process: {
+          rssMB: mb(memory.rss),
+          heapUsedMB: mb(memory.heapUsed),
+          heapTotalMB: mb(memory.heapTotal),
+          externalMB: mb(memory.external),
+          argv: process.argv.map((arg) => deidentifyText(arg)),
+        },
+        logs,
+      };
+
+      return { ok: true, snapshot } as const;
+    } catch (err) {
+      return {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      } as const;
+    }
+  });
+}

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -83,6 +83,7 @@ describe('preload bridge', () => {
     await api.export.saveDicomSeg('ZmFrZQ==', 'seg.dcm');
     await api.export.saveDicomRtStruct('ZmFrZQ==', 'rtstruct.dcm');
     await api.export.saveViewportCapture({ x: 1, y: 2, width: 3, height: 4 }, 'capture.png');
+    await api.diagnostics.getMainSnapshot();
 
     expect(mocks.invoke).toHaveBeenCalledWith(IPC.XNAT_BROWSER_LOGIN, 'https://xnat.example');
     expect(mocks.invoke).toHaveBeenCalledWith(IPC.XNAT_LOGOUT);
@@ -149,6 +150,7 @@ describe('preload bridge', () => {
       { x: 1, y: 2, width: 3, height: 4 },
       'capture.png',
     );
+    expect(mocks.invoke).toHaveBeenCalledWith(IPC.DIAGNOSTICS_GET_MAIN_SNAPSHOT);
   });
 
   it('allows only whitelisted event channels and unsubscribes listeners', () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -162,6 +162,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke(IPC.BACKUP_GET_CACHE_PATH),
   },
 
+  diagnostics: {
+    getMainSnapshot: () =>
+      ipcRenderer.invoke(IPC.DIAGNOSTICS_GET_MAIN_SNAPSHOT),
+  },
+
   on: (channel: string, callback: (...args: unknown[]) => void) => {
     const allowedChannels = [IPC.XNAT_SESSION_EXPIRED];
     if (!allowedChannels.includes(channel as any)) {

--- a/src/renderer/components/settings/SettingsModal.issueReport.test.tsx
+++ b/src/renderer/components/settings/SettingsModal.issueReport.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SettingsModal from './SettingsModal';
+import { usePreferencesStore } from '../../stores/preferencesStore';
+
+const buildIssueReportMock = vi.fn<(notes: string) => Promise<string>>();
+const clipboardWriteTextMock = vi.fn(async () => undefined);
+
+vi.mock('../../lib/diagnostics/issueReport', () => ({
+  buildIssueReport: (notes: string) => buildIssueReportMock(notes),
+}));
+
+function resetPreferencesStore(): void {
+  usePreferencesStore.setState(usePreferencesStore.getInitialState(), true);
+}
+
+function getIssueTextareas(): { notes: HTMLTextAreaElement; report: HTMLTextAreaElement } {
+  const areas = screen.getAllByRole('textbox') as HTMLTextAreaElement[];
+  return { notes: areas[0], report: areas[areas.length - 1] };
+}
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('SettingsModal issue report panel', () => {
+  beforeEach(() => {
+    resetPreferencesStore();
+    buildIssueReportMock.mockReset();
+    clipboardWriteTextMock.mockClear();
+
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: {} as any,
+    });
+
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      writable: true,
+      value: {
+        writeText: clipboardWriteTextMock,
+      },
+    });
+  });
+
+  it('auto-generates a report on tab open and enables copy once loaded', async () => {
+    const user = userEvent.setup();
+    buildIssueReportMock.mockResolvedValueOnce('AUTO REPORT CONTENT');
+
+    render(<SettingsModal open onClose={() => {}} />);
+    await user.click(screen.getByRole('button', { name: 'Issue Report' }));
+
+    expect(buildIssueReportMock).toHaveBeenCalledWith('');
+    const { report } = getIssueTextareas();
+    await waitFor(() => {
+      expect(report.value).toBe('AUTO REPORT CONTENT');
+    });
+    expect(screen.getByRole('button', { name: 'Copy Report' })).toBeEnabled();
+  });
+
+  it('shows loading state and keeps copy disabled while report is pending', async () => {
+    const user = userEvent.setup();
+    const pending = createDeferred<string>();
+    buildIssueReportMock.mockReturnValueOnce(pending.promise);
+
+    render(<SettingsModal open onClose={() => {}} />);
+    await user.click(screen.getByRole('button', { name: 'Issue Report' }));
+
+    expect(screen.getByRole('button', { name: 'Refreshing...' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Copy Report' })).toBeDisabled();
+
+    pending.resolve('READY');
+    const { report } = getIssueTextareas();
+    await waitFor(() => {
+      expect(report.value).toBe('READY');
+    });
+  });
+
+  it('refreshes report using latest notes value', async () => {
+    const user = userEvent.setup();
+    buildIssueReportMock
+      .mockResolvedValueOnce('INITIAL')
+      .mockResolvedValueOnce('REFRESHED WITH NOTES');
+
+    render(<SettingsModal open onClose={() => {}} />);
+    await user.click(screen.getByRole('button', { name: 'Issue Report' }));
+    await waitFor(() => {
+      expect(getIssueTextareas().report.value).toBe('INITIAL');
+    });
+
+    const { notes, report } = getIssueTextareas();
+    await user.type(notes, 'Repro: click zoom 3 times');
+    await user.click(screen.getByRole('button', { name: 'Refresh Report' }));
+
+    expect(buildIssueReportMock).toHaveBeenLastCalledWith('Repro: click zoom 3 times');
+    await waitFor(() => {
+      expect(report.value).toBe('REFRESHED WITH NOTES');
+    });
+  });
+
+  it('rebuilds on copy and writes latest content to clipboard', async () => {
+    const user = userEvent.setup();
+    buildIssueReportMock
+      .mockResolvedValueOnce('INITIAL REPORT')
+      .mockResolvedValueOnce('LATEST REPORT FOR EMAIL');
+
+    render(<SettingsModal open onClose={() => {}} />);
+    await user.click(screen.getByRole('button', { name: 'Issue Report' }));
+    await waitFor(() => {
+      expect(getIssueTextareas().report.value).toBe('INITIAL REPORT');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Copy Report' }));
+
+    expect(buildIssueReportMock).toHaveBeenNthCalledWith(2, '');
+    await waitFor(() => {
+      expect(getIssueTextareas().report.value).toBe('LATEST REPORT FOR EMAIL');
+    });
+    expect(screen.getByText('Copied')).toBeInTheDocument();
+  });
+
+  it('shows copy failure state when copy-time report generation fails', async () => {
+    const user = userEvent.setup();
+    buildIssueReportMock
+      .mockResolvedValueOnce('INITIAL REPORT')
+      .mockRejectedValueOnce(new Error('copy regeneration failed'));
+
+    render(<SettingsModal open onClose={() => {}} />);
+    await user.click(screen.getByRole('button', { name: 'Issue Report' }));
+    await waitFor(() => {
+      expect(getIssueTextareas().report.value).toBe('INITIAL REPORT');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Copy Report' }));
+    expect(await screen.findByText('Copy failed')).toBeInTheDocument();
+  });
+
+  it('renders a failure message when report generation throws', async () => {
+    const user = userEvent.setup();
+    buildIssueReportMock.mockRejectedValueOnce(new Error('diagnostics unavailable'));
+
+    render(<SettingsModal open onClose={() => {}} />);
+    await user.click(screen.getByRole('button', { name: 'Issue Report' }));
+
+    await waitFor(() => {
+      expect(getIssueTextareas().report.value).toContain(
+        'Failed to generate issue report: diagnostics unavailable',
+      );
+    });
+  });
+});

--- a/src/renderer/components/settings/SettingsModal.test.tsx
+++ b/src/renderer/components/settings/SettingsModal.test.tsx
@@ -1,17 +1,77 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_PREFERENCES } from '@shared/types/preferences';
 import SettingsModal from './SettingsModal';
 import { usePreferencesStore } from '../../stores/preferencesStore';
+import type { MainDiagnosticsSnapshot } from '@shared/types/diagnostics';
 
 function resetPreferencesStore(): void {
   usePreferencesStore.setState(usePreferencesStore.getInitialState(), true);
 }
 
+const clipboardWriteTextMock = vi.fn(async () => undefined);
+
 describe('SettingsModal', () => {
   beforeEach(() => {
     resetPreferencesStore();
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: {
+        diagnostics: {
+          getMainSnapshot: vi.fn(async () => ({
+            ok: true,
+            snapshot: {
+              generatedAt: '2026-03-05T00:00:00.000Z',
+              app: {
+                name: 'XNAT Workstation',
+                version: '0.5.2',
+                isPackaged: false,
+                pid: 100,
+                uptimeSec: 10,
+                windowCount: 1,
+              },
+              runtime: {
+                electron: '40.2.1',
+                chrome: '132.0.0',
+                node: '20.0.0',
+                v8: '12.0',
+                platform: 'darwin',
+                arch: 'arm64',
+              },
+              system: {
+                osType: 'Darwin',
+                osRelease: '24.5.0',
+                osVersion: 'macOS',
+                cpuModel: 'Mock CPU',
+                cpuCount: 8,
+                totalMemoryMB: 16384,
+                freeMemoryMB: 4096,
+                loadAverage: [0.1, 0.2, 0.3],
+                hostnameFingerprint: 'abcdef123456',
+              },
+              process: {
+                rssMB: 350,
+                heapUsedMB: 120,
+                heapTotalMB: 200,
+                externalMB: 4,
+                argv: ['app'],
+              },
+              logs: { stdout: [], stderr: [] },
+            } satisfies MainDiagnosticsSnapshot,
+          })),
+        },
+      },
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      writable: true,
+      value: {
+        writeText: clipboardWriteTextMock,
+      },
+    });
+    (navigator as any).clipboard = { writeText: clipboardWriteTextMock };
+    clipboardWriteTextMock.mockClear();
   });
 
   it('opens, switches tabs, and closes via Escape/backdrop', async () => {
@@ -152,5 +212,24 @@ describe('SettingsModal', () => {
   it('returns null when closed', () => {
     render(<SettingsModal open={false} onClose={() => {}} />);
     expect(screen.queryByText('Preferences')).not.toBeInTheDocument();
+  });
+
+  it('generates and copies issue report content', async () => {
+    const user = userEvent.setup();
+    render(<SettingsModal open onClose={() => {}} />);
+
+    await user.click(screen.getByRole('button', { name: 'Issue Report' }));
+    expect(await screen.findByText('Copy/paste this into an email:')).toBeInTheDocument();
+
+    const textAreas = screen.getAllByRole('textbox') as HTMLTextAreaElement[];
+    const reportArea = textAreas[textAreas.length - 1];
+    await waitFor(() => {
+      expect(reportArea.value).toContain('XNAT Workstation Issue Report (De-identified)');
+    });
+
+    const copyButton = screen.getByRole('button', { name: 'Copy Report' });
+    expect(copyButton).toBeEnabled();
+    await user.click(copyButton);
+    expect(await screen.findByText(/Copied|Copy failed/)).toBeInTheDocument();
   });
 });

--- a/src/renderer/components/settings/SettingsModal.tsx
+++ b/src/renderer/components/settings/SettingsModal.tsx
@@ -10,9 +10,10 @@ import { usePreferencesStore } from '../../stores/preferencesStore';
 import { useViewerStore } from '../../stores/viewerStore';
 import { backupService } from '../../lib/backup/backupService';
 import type { BackupSessionSummary } from '@shared/types/backup';
+import { buildIssueReport } from '../../lib/diagnostics/issueReport';
 import { IconClose } from '../icons';
 
-type SettingsTab = 'hotkeys' | 'overlay' | 'annotation' | 'interpolation' | 'backup';
+type SettingsTab = 'hotkeys' | 'overlay' | 'annotation' | 'interpolation' | 'backup' | 'issue';
 
 interface SettingsModalProps {
   open: boolean;
@@ -29,6 +30,7 @@ const TAB_ITEMS: Array<{ id: SettingsTab; label: string }> = [
   { id: 'annotation', label: 'Annotation' },
   { id: 'interpolation', label: 'Interpolation' },
   { id: 'backup', label: 'File Backup' },
+  { id: 'issue', label: 'Issue Report' },
 ];
 
 const CORNER_OPTIONS: Array<{
@@ -222,6 +224,10 @@ export default function SettingsModal({ open, onClose, onRecover, initialTab }: 
 
   // Confirm-delete dialog state (replaces native window.confirm)
   const [confirmDeleteSession, setConfirmDeleteSession] = useState<{ sessionId: string; label: string } | null>(null);
+  const [issueNotes, setIssueNotes] = useState('');
+  const [issueReport, setIssueReport] = useState('');
+  const [issueLoading, setIssueLoading] = useState(false);
+  const [issueCopyStatus, setIssueCopyStatus] = useState<'idle' | 'copied' | 'error'>('idle');
 
   useEffect(() => {
     if (!open) return;
@@ -237,6 +243,28 @@ export default function SettingsModal({ open, onClose, onRecover, initialTab }: 
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [open, onClose]);
+
+  useEffect(() => {
+    if (activeTab !== 'issue' || !open) return;
+    let cancelled = false;
+    setIssueLoading(true);
+    buildIssueReport(issueNotes)
+      .then((report) => {
+        if (!cancelled) setIssueReport(report);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          const msg = err instanceof Error ? err.message : String(err);
+          setIssueReport(`Failed to generate issue report: ${msg}`);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setIssueLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, open]);
 
   useEffect(() => {
     if (!actionOptions.length) return;
@@ -321,6 +349,33 @@ export default function SettingsModal({ open, onClose, onRecover, initialTab }: 
     const parsed = parseColorSequenceInput(colorSequenceDraft);
     if (parsed.length === 0) return;
     setAnnotationColorSequence(parsed);
+  };
+
+  const refreshIssueReport = async () => {
+    setIssueLoading(true);
+    try {
+      const report = await buildIssueReport(issueNotes);
+      setIssueReport(report);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setIssueReport(`Failed to generate issue report: ${msg}`);
+    } finally {
+      setIssueLoading(false);
+    }
+  };
+
+  const copyIssueReport = async () => {
+    if (!issueReport && !issueNotes.trim()) return;
+    try {
+      const latestReport = await buildIssueReport(issueNotes);
+      setIssueReport(latestReport);
+      await navigator.clipboard.writeText(latestReport);
+      setIssueCopyStatus('copied');
+      window.setTimeout(() => setIssueCopyStatus('idle'), 2000);
+    } catch {
+      setIssueCopyStatus('error');
+      window.setTimeout(() => setIssueCopyStatus('idle'), 3000);
+    }
   };
 
   if (!open) return null;
@@ -922,6 +977,62 @@ export default function SettingsModal({ open, onClose, onRecover, initialTab }: 
                       })()}
                     </div>
                   )}
+                </div>
+              </>
+            )}
+
+            {activeTab === 'issue' && (
+              <>
+                <div className="text-xs text-zinc-400">
+                  Generate a de-identified report for support emails. The report includes app/runtime state,
+                  system details, and recent main/renderer stdout/stderr logs with sensitive values redacted.
+                </div>
+
+                <div className="rounded-lg border border-zinc-800 bg-zinc-950/40 p-4 space-y-3">
+                  <label className="space-y-1 block">
+                    <span className="text-[11px] text-zinc-500">Optional notes for developers</span>
+                    <textarea
+                      value={issueNotes}
+                      onChange={(e) => setIssueNotes(e.target.value)}
+                      placeholder="Describe what happened, expected behavior, and reproduction steps..."
+                      rows={4}
+                      className="w-full bg-zinc-800 border border-zinc-700 rounded px-2 py-1.5 text-xs text-zinc-200 resize-y"
+                    />
+                  </label>
+
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => void refreshIssueReport()}
+                      disabled={issueLoading}
+                      className="px-2.5 py-1.5 rounded bg-zinc-800 text-zinc-200 text-xs hover:bg-zinc-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    >
+                      {issueLoading ? 'Refreshing...' : 'Refresh Report'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => void copyIssueReport()}
+                      disabled={!issueReport}
+                      className="px-2.5 py-1.5 rounded bg-blue-600 text-white text-xs hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    >
+                      Copy Report
+                    </button>
+                    {issueCopyStatus === 'copied' && (
+                      <span className="text-[11px] text-emerald-400">Copied</span>
+                    )}
+                    {issueCopyStatus === 'error' && (
+                      <span className="text-[11px] text-red-400">Copy failed</span>
+                    )}
+                  </div>
+                </div>
+
+                <div className="rounded-lg border border-zinc-800 bg-zinc-950/40 p-3">
+                  <div className="text-[11px] text-zinc-500 mb-2">Copy/paste this into an email:</div>
+                  <textarea
+                    readOnly
+                    value={issueReport}
+                    className="w-full h-72 bg-zinc-900 border border-zinc-800 rounded px-2 py-1.5 text-[11px] text-zinc-300 font-mono leading-relaxed resize-y"
+                  />
                 </div>
               </>
             )}

--- a/src/renderer/lib/diagnostics/issueReport.test.ts
+++ b/src/renderer/lib/diagnostics/issueReport.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MainDiagnosticsSnapshot } from '@shared/types/diagnostics';
+import { useConnectionStore } from '../../stores/connectionStore';
+import { usePreferencesStore } from '../../stores/preferencesStore';
+import { useSegmentationStore } from '../../stores/segmentationStore';
+import { useViewerStore } from '../../stores/viewerStore';
+import { buildIssueReport } from './issueReport';
+import { getRendererLogEntries } from './rendererLogBuffer';
+
+vi.mock('./rendererLogBuffer', () => ({
+  getRendererLogEntries: vi.fn(),
+}));
+
+const mockedGetRendererLogEntries = vi.mocked(getRendererLogEntries);
+
+const baseMainSnapshot: MainDiagnosticsSnapshot = {
+  generatedAt: '2026-03-06T12:00:00.000Z',
+  app: {
+    name: 'XNAT Workstation',
+    version: '0.5.2',
+    isPackaged: false,
+    pid: 120,
+    uptimeSec: 22,
+    windowCount: 1,
+  },
+  runtime: {
+    electron: '40.2.1',
+    chrome: '132.0.0',
+    node: '20.0.0',
+    v8: '12.0',
+    platform: 'darwin',
+    arch: 'arm64',
+  },
+  system: {
+    osType: 'Darwin',
+    osRelease: '24.4.0',
+    osVersion: 'macOS',
+    cpuModel: 'Mock CPU',
+    cpuCount: 8,
+    totalMemoryMB: 16384,
+    freeMemoryMB: 4096,
+    loadAverage: [0.1, 0.2, 0.3],
+    hostnameFingerprint: 'abc123def456',
+  },
+  process: {
+    rssMB: 320,
+    heapUsedMB: 128,
+    heapTotalMB: 256,
+    externalMB: 8,
+    argv: ['xnat'],
+  },
+  logs: {
+    stdout: [
+      {
+        timestamp: '2026-03-06T11:59:58.000Z',
+        source: 'main',
+        stream: 'stdout',
+        level: 'info',
+        message: 'main started',
+      },
+    ],
+    stderr: [
+      {
+        timestamp: '2026-03-06T11:59:59.000Z',
+        source: 'main',
+        stream: 'stderr',
+        level: 'error',
+        message: 'main warning',
+      },
+    ],
+  },
+};
+
+function resetStores(): void {
+  useConnectionStore.setState(useConnectionStore.getInitialState(), true);
+  useViewerStore.setState(useViewerStore.getInitialState(), true);
+  useSegmentationStore.setState(useSegmentationStore.getInitialState(), true);
+  usePreferencesStore.setState(usePreferencesStore.getInitialState(), true);
+}
+
+describe('buildIssueReport', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-06T12:00:00.000Z'));
+    resetStores();
+    mockedGetRendererLogEntries.mockReset();
+    mockedGetRendererLogEntries.mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('builds a de-identified report with store summaries and log sections', async () => {
+    useConnectionStore.setState({
+      status: 'connected',
+      connection: { connectedAt: Date.now() - 12000 } as any,
+      error: null,
+    });
+    useViewerStore.setState({
+      activeViewportId: 'panel_0',
+      layout: '2x1',
+      mprActive: true,
+      panelImageIdsMap: { panel_0: ['img:1', 'img:2'], panel_1: [] },
+    });
+    useSegmentationStore.setState({
+      segmentations: [
+        { segmentationId: 'seg-1', label: 'Seg 1', segments: [], isActive: true },
+      ],
+      activeSegmentationId: 'seg-1',
+      hasUnsavedChanges: true,
+    });
+    usePreferencesStore.setState((state) => ({
+      preferences: {
+        ...state.preferences,
+        overlay: {
+          ...state.preferences.overlay,
+          showViewportContextOverlay: false,
+          showHorizontalRuler: false,
+          showVerticalRuler: true,
+          showOrientationMarkers: false,
+        },
+      },
+    }));
+
+    mockedGetRendererLogEntries.mockReturnValue([
+      {
+        timestamp: '2026-03-06T11:59:56.000Z',
+        source: 'renderer',
+        stream: 'stdout',
+        level: 'info',
+        message: 'renderer loaded',
+      },
+      {
+        timestamp: '2026-03-06T11:59:57.000Z',
+        source: 'renderer',
+        stream: 'stderr',
+        level: 'error',
+        message: 'renderer warning',
+      },
+    ]);
+
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: {
+        diagnostics: {
+          getMainSnapshot: vi.fn(async () => ({ ok: true as const, snapshot: baseMainSnapshot })),
+        },
+      } as any,
+    });
+
+    const report = await buildIssueReport(
+      'Contact me: dev@example.com Authorization: Bearer super-secret-token',
+    );
+
+    expect(report).toContain('XNAT Workstation Issue Report (De-identified)');
+    expect(report).toContain('Connection status: connected');
+    expect(report).toContain('Connected duration: 12s');
+    expect(report).toContain('Loaded panels: 1');
+    expect(report).toContain('- panel_0: 2');
+    expect(report).not.toContain('panel_1:');
+    expect(report).toContain('<email-redacted>');
+    expect(report).toContain('Authorization: Bearer <token-redacted>');
+    expect(report).toContain('Main stdout (recent):');
+    expect(report).toContain('main started');
+    expect(report).toContain('Renderer stderr (recent):');
+    expect(report).toContain('renderer warning');
+    expect(report).toContain('"visible": false');
+    expect(report).toContain('End of Report');
+  });
+
+  it('handles unavailable diagnostics bridge without throwing', async () => {
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: {} as any,
+    });
+
+    const report = await buildIssueReport('');
+
+    expect(report).toContain('Main Process Snapshot:');
+    expect(report).toContain('- failed to collect: diagnostics bridge unavailable');
+    expect(report).toContain('Renderer stdout (recent): (none)');
+    expect(report).toContain('Renderer stderr (recent): (none)');
+  });
+
+  it('redacts thrown diagnostics errors from main bridge calls', async () => {
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: {
+        diagnostics: {
+          getMainSnapshot: vi.fn(async () => {
+            throw new Error('fetch failed at https://xnat.example.org/data/archive?auth=abc123');
+          }),
+        },
+      } as any,
+    });
+
+    const report = await buildIssueReport('notes');
+
+    expect(report).toContain('failed to collect: fetch failed at');
+    expect(report).toContain('https://<host-redacted>/data/archive/...?<query-redacted>');
+    expect(report).not.toContain('xnat.example.org');
+    expect(report).not.toContain('auth=abc123');
+  });
+
+  it('redacts returned error payloads when diagnostics call fails cleanly', async () => {
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: {
+        diagnostics: {
+          getMainSnapshot: vi.fn(async () => ({
+            ok: false as const,
+            error: 'failure for user john@example.com at /Users/dan/secret',
+          })),
+        },
+      } as any,
+    });
+
+    const report = await buildIssueReport('notes');
+
+    expect(report).toContain('failed to collect:');
+    expect(report).toContain('<email-redacted>');
+    expect(report).toContain('/Users/<user>/secret');
+    expect(report).not.toContain('john@example.com');
+    expect(report).not.toContain('/Users/dan/secret');
+  });
+});

--- a/src/renderer/lib/diagnostics/issueReport.ts
+++ b/src/renderer/lib/diagnostics/issueReport.ts
@@ -1,0 +1,127 @@
+import { deidentifyText } from '@shared/diagnostics/deidentify';
+import type { DiagnosticsLogEntry, MainDiagnosticsSnapshotResult } from '@shared/types/diagnostics';
+import { useConnectionStore } from '../../stores/connectionStore';
+import { usePreferencesStore } from '../../stores/preferencesStore';
+import { useSegmentationStore } from '../../stores/segmentationStore';
+import { useViewerStore } from '../../stores/viewerStore';
+import { getRendererLogEntries } from './rendererLogBuffer';
+
+function formatLogLines(label: string, entries: DiagnosticsLogEntry[]): string[] {
+  if (entries.length === 0) return [`${label}: (none)`];
+  return [
+    `${label}:`,
+    ...entries.map((entry) => `- [${entry.timestamp}] [${entry.level.toUpperCase()}] ${entry.message}`),
+  ];
+}
+
+function formatConnectionAge(connectedAt?: number): string {
+  if (!connectedAt) return 'n/a';
+  const elapsedSec = Math.max(0, Math.floor((Date.now() - connectedAt) / 1000));
+  return `${elapsedSec}s`;
+}
+
+function formatJson(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+export async function buildIssueReport(userNotes: string): Promise<string> {
+  let mainSnapshot: MainDiagnosticsSnapshotResult;
+  try {
+    if (!window.electronAPI.diagnostics?.getMainSnapshot) {
+      mainSnapshot = { ok: false, error: 'diagnostics bridge unavailable' };
+    } else {
+      mainSnapshot = await window.electronAPI.diagnostics.getMainSnapshot();
+    }
+  } catch (err) {
+    mainSnapshot = { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+
+  const connection = useConnectionStore.getState();
+  const viewer = useViewerStore.getState();
+  const segmentation = useSegmentationStore.getState();
+  const preferences = usePreferencesStore.getState().preferences;
+
+  const loadedPanels = Object.entries(viewer.panelImageIdsMap)
+    .filter(([, ids]) => ids.length > 0)
+    .map(([panelId, ids]) => ({ panelId, imageCount: ids.length }));
+
+  const rendererLogs = getRendererLogEntries(160);
+  const rendererStdout = rendererLogs.filter((entry) => entry.stream === 'stdout');
+  const rendererStderr = rendererLogs.filter((entry) => entry.stream === 'stderr');
+
+  const lines: string[] = [
+    'XNAT Workstation Issue Report (De-identified)',
+    `Generated: ${new Date().toISOString()}`,
+    '',
+    'Reporter Notes:',
+    userNotes.trim() ? deidentifyText(userNotes.trim()) : '(none provided)',
+    '',
+    'App State Summary:',
+    `- Connection status: ${connection.status}`,
+    `- Connected duration: ${formatConnectionAge(connection.connection?.connectedAt)}`,
+    `- Active viewport: ${viewer.activeViewportId}`,
+    `- Layout: ${viewer.layout}`,
+    `- MPR active: ${viewer.mprActive}`,
+    `- Loaded panels: ${loadedPanels.length}`,
+    `- Segmentations loaded: ${segmentation.segmentations.length}`,
+    `- Active segmentation present: ${segmentation.activeSegmentationId ? 'yes' : 'no'}`,
+    `- Unsaved changes flag: ${segmentation.hasUnsavedChanges}`,
+    '',
+    'Loaded Panel Image Counts:',
+    ...(loadedPanels.length > 0
+      ? loadedPanels.map((panel) => `- ${panel.panelId}: ${panel.imageCount}`)
+      : ['(none)']),
+    '',
+    'Preferences Snapshot (safe subset):',
+    formatJson({
+      overlay: {
+        visible: preferences.overlay.showViewportContextOverlay,
+        horizontalRuler: preferences.overlay.showHorizontalRuler,
+        verticalRuler: preferences.overlay.showVerticalRuler,
+        orientationMarkers: preferences.overlay.showOrientationMarkers,
+      },
+      annotation: {
+        brushSize: preferences.annotation.defaultBrushSize,
+        contourThickness: preferences.annotation.defaultContourThickness,
+        maskOutlines: preferences.annotation.defaultMaskOutlines,
+        autoDisplay: preferences.annotation.autoDisplayAnnotations,
+        segmentOpacity: preferences.annotation.defaultSegmentOpacity,
+        colorCount: preferences.annotation.defaultColorSequence.length,
+      },
+      interpolation: preferences.interpolation,
+      backup: preferences.backup,
+    }),
+    '',
+  ];
+
+  if (mainSnapshot.ok) {
+    lines.push(
+      'Main Process Snapshot:',
+      formatJson(mainSnapshot.snapshot.app),
+      formatJson(mainSnapshot.snapshot.runtime),
+      formatJson(mainSnapshot.snapshot.system),
+      formatJson(mainSnapshot.snapshot.process),
+      '',
+      ...formatLogLines('Main stdout (recent)', mainSnapshot.snapshot.logs.stdout),
+      '',
+      ...formatLogLines('Main stderr (recent)', mainSnapshot.snapshot.logs.stderr),
+      '',
+    );
+  } else {
+    lines.push(
+      'Main Process Snapshot:',
+      `- failed to collect: ${deidentifyText(mainSnapshot.error)}`,
+      '',
+    );
+  }
+
+  lines.push(
+    ...formatLogLines('Renderer stdout (recent)', rendererStdout),
+    '',
+    ...formatLogLines('Renderer stderr (recent)', rendererStderr),
+    '',
+    'End of Report',
+  );
+
+  return lines.flat().join('\n');
+}

--- a/src/renderer/lib/diagnostics/rendererLogBuffer.test.ts
+++ b/src/renderer/lib/diagnostics/rendererLogBuffer.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const originalConsole = {
+  log: console.log,
+  info: console.info,
+  warn: console.warn,
+  error: console.error,
+};
+
+async function loadModule() {
+  return import('./rendererLogBuffer');
+}
+
+describe('rendererLogBuffer', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete (window as any).__xnatRendererLogCaptureInstalled__;
+    console.log = originalConsole.log;
+    console.info = originalConsole.info;
+    console.warn = originalConsole.warn;
+    console.error = originalConsole.error;
+  });
+
+  afterEach(() => {
+    console.log = originalConsole.log;
+    console.info = originalConsole.info;
+    console.warn = originalConsole.warn;
+    console.error = originalConsole.error;
+  });
+
+  it('captures console output and global error events with de-identification', async () => {
+    const { installRendererLogCapture, getRendererLogEntries } = await loadModule();
+    installRendererLogCapture();
+
+    console.log('user email', 'dev@example.com');
+    console.warn('token', 'Authorization: Bearer secret-123');
+    console.error('path', '/Users/dan/Documents/private');
+    window.dispatchEvent(
+      new ErrorEvent('error', {
+        message: 'boom',
+        filename: '/Users/dan/app.ts',
+        lineno: 10,
+        colno: 5,
+      }),
+    );
+
+    const unhandled = new Event('unhandledrejection') as Event & { reason?: unknown };
+    unhandled.reason = new Error('rejection from https://xnat.example.org/data?token=abc');
+    window.dispatchEvent(unhandled);
+
+    const logs = getRendererLogEntries(20);
+    const joined = logs.map((entry) => entry.message).join('\n');
+
+    expect(logs.length).toBeGreaterThanOrEqual(5);
+    expect(logs.some((entry) => entry.stream === 'stdout')).toBe(true);
+    expect(logs.some((entry) => entry.stream === 'stderr')).toBe(true);
+    expect(joined).toContain('<email-redacted>');
+    expect(joined).toContain('Authorization: Bearer <token-redacted>');
+    expect(joined).toContain('/Users/<user>');
+    expect(joined).toContain('[window.error]');
+    expect(joined).toContain('[unhandledrejection]');
+    expect(joined).not.toContain('xnat.example.org');
+  });
+
+  it('does not double-install listeners and wrappers', async () => {
+    const { installRendererLogCapture, getRendererLogEntries } = await loadModule();
+
+    installRendererLogCapture();
+    installRendererLogCapture();
+    console.error('single error line');
+
+    const logs = getRendererLogEntries(10).filter((entry) => entry.message.includes('single error line'));
+    expect(logs).toHaveLength(1);
+  });
+
+  it('returns only the requested tail window from log history', async () => {
+    const { installRendererLogCapture, getRendererLogEntries } = await loadModule();
+    installRendererLogCapture();
+
+    console.log('line 1');
+    console.log('line 2');
+    console.log('line 3');
+
+    const tail = getRendererLogEntries(2);
+    expect(tail).toHaveLength(2);
+    expect(tail[0].message).toContain('line 2');
+    expect(tail[1].message).toContain('line 3');
+  });
+});

--- a/src/renderer/lib/diagnostics/rendererLogBuffer.ts
+++ b/src/renderer/lib/diagnostics/rendererLogBuffer.ts
@@ -1,0 +1,84 @@
+import type { DiagnosticsLogEntry, DiagnosticsLogLevel, DiagnosticsLogStream } from '@shared/types/diagnostics';
+import { deidentifyText } from '@shared/diagnostics/deidentify';
+
+const MAX_LOG_ENTRIES = 500;
+const logs: DiagnosticsLogEntry[] = [];
+const INSTALL_MARKER = '__xnatRendererLogCaptureInstalled__';
+
+function streamForLevel(level: DiagnosticsLogLevel): DiagnosticsLogStream {
+  return level === 'warn' || level === 'error' ? 'stderr' : 'stdout';
+}
+
+function stringifyArg(arg: unknown): string {
+  if (typeof arg === 'string') return arg;
+  if (arg instanceof Error) return arg.stack || arg.message;
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
+}
+
+function pushLog(level: DiagnosticsLogLevel, args: unknown[]): void {
+  const message = deidentifyText(args.map((arg) => stringifyArg(arg)).join(' ')).trim();
+  if (!message) return;
+  logs.push({
+    timestamp: new Date().toISOString(),
+    source: 'renderer',
+    level,
+    stream: streamForLevel(level),
+    message,
+  });
+  if (logs.length > MAX_LOG_ENTRIES) {
+    logs.splice(0, logs.length - MAX_LOG_ENTRIES);
+  }
+}
+
+export function installRendererLogCapture(): void {
+  if (typeof window === 'undefined') return;
+  if ((window as any)[INSTALL_MARKER]) return;
+  (window as any)[INSTALL_MARKER] = true;
+
+  const original = {
+    log: console.log.bind(console),
+    info: console.info.bind(console),
+    warn: console.warn.bind(console),
+    error: console.error.bind(console),
+  };
+
+  console.log = (...args: unknown[]) => {
+    pushLog('log', args);
+    original.log(...args);
+  };
+  console.info = (...args: unknown[]) => {
+    pushLog('info', args);
+    original.info(...args);
+  };
+  console.warn = (...args: unknown[]) => {
+    pushLog('warn', args);
+    original.warn(...args);
+  };
+  console.error = (...args: unknown[]) => {
+    pushLog('error', args);
+    original.error(...args);
+  };
+
+  window.addEventListener('error', (event) => {
+    pushLog('error', [
+      '[window.error]',
+      event.message,
+      event.filename,
+      `line=${event.lineno}`,
+      `col=${event.colno}`,
+    ]);
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    const reason = event.reason instanceof Error ? event.reason.stack || event.reason.message : String(event.reason);
+    pushLog('error', ['[unhandledrejection]', reason]);
+  });
+}
+
+export function getRendererLogEntries(limit = 200): DiagnosticsLogEntry[] {
+  return logs.slice(-Math.max(1, limit));
+}

--- a/src/renderer/main.test.tsx
+++ b/src/renderer/main.test.tsx
@@ -14,6 +14,10 @@ vi.mock('./App', () => ({
   default: () => <div data-testid="mock-app">Mock App</div>,
 }));
 
+vi.mock('./lib/diagnostics/rendererLogBuffer', () => ({
+  installRendererLogCapture: vi.fn(),
+}));
+
 describe('renderer entrypoint', () => {
   beforeEach(() => {
     vi.resetModules();

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './styles/globals.css';
+import { installRendererLogCapture } from './lib/diagnostics/rendererLogBuffer';
+
+installRendererLogCapture();
 
 const rootElement = document.getElementById('root');
 

--- a/src/shared/diagnostics/deidentify.test.ts
+++ b/src/shared/diagnostics/deidentify.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { deidentifyText } from './deidentify';
+
+describe('deidentifyText', () => {
+  it('redacts URL host and query parameters', () => {
+    const input = 'fetch https://xnat.example.org/data/archive/experiments?token=abc123';
+    const output = deidentifyText(input);
+    expect(output).toContain('https://<host-redacted>/data/archive/...?<query-redacted>');
+    expect(output).not.toContain('xnat.example.org');
+    expect(output).not.toContain('token=abc123');
+  });
+
+  it('redacts tokens, emails, user paths, ids, and IP addresses', () => {
+    const input = [
+      'email=dev@example.com',
+      'Authorization: Bearer top-secret',
+      'JSESSIONID=abc123',
+      'csrfToken=abcdef',
+      '/Users/dan/Documents/private',
+      'C:\\Users\\dan\\Desktop\\file',
+      'uuid=123e4567-e89b-12d3-a456-426614174000',
+      'dicom=1.2.840.10008.5.1.4.1.1.2',
+      'xnatExp=PROJECT1_E123',
+      'xnatGen=XNAT_E9999',
+      'ip=192.168.1.55',
+    ].join(' | ');
+
+    const output = deidentifyText(input);
+
+    expect(output).toContain('<email-redacted>');
+    expect(output).toContain('Authorization: Bearer <token-redacted>');
+    expect(output).toContain('JSESSIONID=<token-redacted>');
+    expect(output).toContain('csrfToken=<token-redacted>');
+    expect(output).toContain('/Users/<user>/Documents/private');
+    expect(output).toContain('C:\\Users\\<user>\\Desktop\\file');
+    expect(output).toContain('<uuid-redacted>');
+    expect(output).toContain('<dicom-uid-redacted>');
+    expect(output).toContain('<xnat-experiment-id>');
+    expect(output).toContain('XNAT_<id>');
+    expect(output).toContain('<ip-redacted>');
+
+    expect(output).not.toContain('dev@example.com');
+    expect(output).not.toContain('top-secret');
+    expect(output).not.toContain('192.168.1.55');
+  });
+
+  it('leaves benign text unchanged', () => {
+    const input = 'viewer loaded successfully with 3 panels';
+    expect(deidentifyText(input)).toBe(input);
+  });
+});

--- a/src/shared/diagnostics/deidentify.ts
+++ b/src/shared/diagnostics/deidentify.ts
@@ -1,0 +1,43 @@
+const DICOM_UID_RE = /\b\d+(?:\.\d+){5,}\b/g;
+const UUID_RE = /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi;
+const EMAIL_RE = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const IPV4_RE = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g;
+const XNAT_EXPERIMENT_RE = /\b[A-Z]{2,}\d+_E\d+\b/g;
+const XNAT_GENERIC_ID_RE = /\bXNAT_[A-Z]\d+\b/g;
+
+const USER_PATH_RE = /\/Users\/[^/\s]+/g;
+const WINDOWS_USER_PATH_RE = /[A-Za-z]:\\Users\\[^\\\s]+/g;
+
+const URL_RE = /\bhttps?:\/\/[^\s'"<>]+/gi;
+const COOKIE_TOKEN_RE = /(JSESSIONID=)[^;,\s]+/gi;
+const BEARER_RE = /(Authorization:\s*Bearer\s+)[A-Za-z0-9._-]+/gi;
+const CSRF_RE = /((?:csrf(?:Token)?|XNAT_CSRF)\s*[=:]\s*)[A-Za-z0-9._-]+/gi;
+
+function deidentifyUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const path = parsed.pathname ? parsed.pathname.split('/').filter(Boolean).slice(0, 2).join('/') : '';
+    const normalizedPath = path ? `/${path}/...` : '';
+    return `${parsed.protocol}//<host-redacted>${normalizedPath}${parsed.search ? '?<query-redacted>' : ''}`;
+  } catch {
+    return '<url-redacted>';
+  }
+}
+
+export function deidentifyText(input: string): string {
+  if (!input) return input;
+
+  return input
+    .replace(URL_RE, (url) => deidentifyUrl(url))
+    .replace(EMAIL_RE, '<email-redacted>')
+    .replace(COOKIE_TOKEN_RE, '$1<token-redacted>')
+    .replace(BEARER_RE, '$1<token-redacted>')
+    .replace(CSRF_RE, '$1<token-redacted>')
+    .replace(USER_PATH_RE, '/Users/<user>')
+    .replace(WINDOWS_USER_PATH_RE, 'C:\\Users\\<user>')
+    .replace(UUID_RE, '<uuid-redacted>')
+    .replace(DICOM_UID_RE, '<dicom-uid-redacted>')
+    .replace(XNAT_EXPERIMENT_RE, '<xnat-experiment-id>')
+    .replace(XNAT_GENERIC_ID_RE, 'XNAT_<id>')
+    .replace(IPV4_RE, '<ip-redacted>');
+}

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -1,5 +1,6 @@
 import { IPC } from '../ipcChannels';
 import type { XnatLoginResult, ProxiedFetchResult } from '../types/xnat';
+import type { MainDiagnosticsSnapshotResult } from '../types/diagnostics';
 
 export interface ViewportBounds {
   x: number;
@@ -37,6 +38,10 @@ export interface IpcInvokeContracts {
     request: { bounds: ViewportBounds; defaultName?: string };
     response: ExportResult;
   };
+  [IPC.DIAGNOSTICS_GET_MAIN_SNAPSHOT]: {
+    request: Record<string, never>;
+    response: MainDiagnosticsSnapshotResult;
+  };
 }
 
 export type IpcInvokeChannel = keyof IpcInvokeContracts;
@@ -52,5 +57,6 @@ export const IPC_CHANNELS = {
   dicomwebFetch: IPC.XNAT_DICOMWEB_FETCH,
   downloadScanFile: IPC.XNAT_DOWNLOAD_SCAN_FILE,
   saveViewportCapture: IPC.EXPORT_SAVE_VIEWPORT_CAPTURE,
+  getMainDiagnosticsSnapshot: IPC.DIAGNOSTICS_GET_MAIN_SNAPSHOT,
   sessionExpired: IPC.XNAT_SESSION_EXPIRED,
 } as const;

--- a/src/shared/ipcChannels.ts
+++ b/src/shared/ipcChannels.ts
@@ -71,6 +71,9 @@ export const IPC = {
   BACKUP_DELETE_SESSION: 'backup:delete-session',
   BACKUP_LIST_ALL_SESSIONS: 'backup:list-all-sessions',
   BACKUP_GET_CACHE_PATH: 'backup:get-cache-path',
+
+  // Diagnostics (renderer → main)
+  DIAGNOSTICS_GET_MAIN_SNAPSHOT: 'diagnostics:get-main-snapshot',
 } as const;
 
 export type IpcChannel = (typeof IPC)[keyof typeof IPC];

--- a/src/shared/types/diagnostics.ts
+++ b/src/shared/types/diagnostics.ts
@@ -1,0 +1,57 @@
+export type DiagnosticsLogLevel = 'log' | 'info' | 'warn' | 'error';
+export type DiagnosticsLogStream = 'stdout' | 'stderr';
+export type DiagnosticsLogSource = 'main' | 'renderer';
+
+export interface DiagnosticsLogEntry {
+  timestamp: string;
+  source: DiagnosticsLogSource;
+  level: DiagnosticsLogLevel;
+  stream: DiagnosticsLogStream;
+  message: string;
+}
+
+export interface MainDiagnosticsSnapshot {
+  generatedAt: string;
+  app: {
+    name: string;
+    version: string;
+    isPackaged: boolean;
+    pid: number;
+    uptimeSec: number;
+    windowCount: number;
+  };
+  runtime: {
+    electron?: string;
+    chrome?: string;
+    node?: string;
+    v8?: string;
+    platform: string;
+    arch: string;
+  };
+  system: {
+    osType: string;
+    osRelease: string;
+    osVersion: string;
+    cpuModel: string;
+    cpuCount: number;
+    totalMemoryMB: number;
+    freeMemoryMB: number;
+    loadAverage: number[];
+    hostnameFingerprint: string;
+  };
+  process: {
+    rssMB: number;
+    heapUsedMB: number;
+    heapTotalMB: number;
+    externalMB: number;
+    argv: string[];
+  };
+  logs: {
+    stdout: DiagnosticsLogEntry[];
+    stderr: DiagnosticsLogEntry[];
+  };
+}
+
+export type MainDiagnosticsSnapshotResult =
+  | { ok: true; snapshot: MainDiagnosticsSnapshot }
+  | { ok: false; error: string };

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -4,6 +4,7 @@ export * from './dicom';
 export * from './xnat';
 export * from './preferences';
 export * from './backup';
+export * from './diagnostics';
 
 import type {
   XnatLoginResult,
@@ -16,6 +17,7 @@ import type {
   XnatScan,
   XnatUploadResult,
 } from './xnat';
+import type { MainDiagnosticsSnapshotResult } from './diagnostics';
 
 export interface ElectronAPI {
   platform: string;
@@ -171,6 +173,9 @@ export interface ElectronAPI {
     ): Promise<{ ok: boolean; error?: string }>;
     listAllSessions(): Promise<{ ok: boolean; sessions?: import('./backup').BackupSessionSummary[]; error?: string }>;
     getCachePath(): Promise<{ ok: boolean; path?: string; error?: string }>;
+  };
+  diagnostics?: {
+    getMainSnapshot(): Promise<MainDiagnosticsSnapshotResult>;
   };
   on(channel: string, callback: (...args: unknown[]) => void): () => void;
 }


### PR DESCRIPTION
## Summary
- add a new **Issue Report** tab in Settings with copy/paste-friendly support output
- capture and de-identify recent main-process stdout/stderr, runtime/system snapshot, and renderer logs
- expose diagnostics snapshot via preload + IPC contract updates
- add de-identification utility for URLs, emails, tokens, user paths, UUIDs, DICOM UIDs, and IPs
- add comprehensive tests for panel behavior, report generation, renderer log buffering, and de-identification

## Testing
- npm test
- npm run build