### PR TITLE
Detect session expiry via cookie jar instead of response body

### DIFF
--- a/src/main/xnat/xnatClient.ts
+++ b/src/main/xnat/xnatClient.ts
@@ -139,20 +139,20 @@ export class XnatClient {
         method: 'GET',
       });
 
-      const body = await response.text().catch(() => '');
+      await response.text().catch(() => {});
       if (!response.ok) return null;
 
-      // XNAT returns 200 with an HTML login page instead of 401 when the
-      // session has expired. GET /data/JSESSION returns the session ID as
-      // plain text when authenticated, so HTML means expired.
-      if (this.looksLikeHtml(Buffer.from(body))) return null;
-
-      // If the server returned a different session ID, our authenticated
-      // session is gone (e.g., expired during sleep). The JSESSIONID cookie
-      // may include a route prefix (e.g., "host3~ABC123") while the server
-      // returns just the core ID ("ABC123"), so check for containment.
-      const returnedId = body.trim();
-      if (returnedId && !this.jsessionId.includes(returnedId)) return null;
+      // If the session expired (e.g., during sleep), the server creates a
+      // new anonymous session whose Set-Cookie overwrites the jar. Check
+      // that the jar still has our authenticated JSESSIONID.
+      // No race condition: Chromium writes Set-Cookie to the cookie store
+      // before resolving the response (URLRequestHttpJob::
+      // SaveCookiesAndNotifyHeadersComplete).
+      const jarCookies = await electronSession.defaultSession.cookies.get({
+        url: this.baseUrl,
+        name: 'JSESSIONID',
+      });
+      if (!jarCookies.some(c => c.value === this.jsessionId)) return null;
 
       return this.username;
     } catch {

--- a/src/main/xnat/xnatClient.ts
+++ b/src/main/xnat/xnatClient.ts
@@ -148,9 +148,11 @@ export class XnatClient {
       if (this.looksLikeHtml(Buffer.from(body))) return null;
 
       // If the server returned a different session ID, our authenticated
-      // session is gone (e.g., expired during sleep).
+      // session is gone (e.g., expired during sleep). The JSESSIONID cookie
+      // may include a route prefix (e.g., "host3~ABC123") while the server
+      // returns just the core ID ("ABC123"), so check for containment.
       const returnedId = body.trim();
-      if (returnedId && returnedId !== this.jsessionId) return null;
+      if (returnedId && !this.jsessionId.includes(returnedId)) return null;
 
       return this.username;
     } catch {


### PR DESCRIPTION
Replace response-body parsing in `validateSession()` with a cookie-jar check after the keepalive request                                                                                          

The old approach parsed the plain-text response from `GET /data/JSESSION` and used HTML detection to identify expired sessions, fragile heuristics that broke with load-balancer route prefixes stored as part of the `JSESSIONID` cookie. The new approach checks whether Electron's cookie jar still holds the authenticated `JSESSIONID`, which is the actual source of truth for subsequent requests.

**Tests**
- [x] Connect to an XNAT server and verify the session stays alive during normal use                                                                                                                  
- [x] Let the session expire (or delete it with curl) and verify the app detects disconnection
- [x] Test against an XNAT server behind a load balancer with route-prefixed `JSESSIONID` cookies