### PR TITLE
Fix crosshair viewport sync for stack viewports

### DIFF
--- a/src/renderer/components/viewer/CornerstoneViewport.tsx
+++ b/src/renderer/components/viewer/CornerstoneViewport.tsx
@@ -55,6 +55,7 @@ export default function CornerstoneViewport({ panelId, imageIds }: CornerstoneVi
     if (!containerRef.current || imageIds.length === 0) return;
 
     let cancelled = false;
+    let disposeEvents: (() => void) | null = null;
     const element = containerRef.current;
 
     async function setup() {
@@ -87,7 +88,7 @@ export default function CornerstoneViewport({ panelId, imageIds }: CornerstoneVi
         if (cancelled) return;
 
         // Wire Cornerstone events to stores (scoped by panelId)
-        wireEvents(element, panelId);
+        disposeEvents = wireEvents(element, panelId);
 
         // Load images
         setStatus(`Loading ${imageIds.length} images...`);
@@ -180,6 +181,7 @@ export default function CornerstoneViewport({ panelId, imageIds }: CornerstoneVi
     return () => {
       cancelled = true;
       resizeObserver.disconnect();
+      disposeEvents?.();
 
       // Stop cine if playing for this panel
       useViewerStore.getState().stopCine(panelId);
@@ -250,7 +252,7 @@ export default function CornerstoneViewport({ panelId, imageIds }: CornerstoneVi
 
 // ─── Event Wiring ──────────────────────────────────────────────
 
-function wireEvents(element: HTMLDivElement, panelId: string): void {
+function wireEvents(element: HTMLDivElement, panelId: string): () => void {
   const Events = Enums.Events;
 
   // VOI changed (user dragged W/L or preset applied)
@@ -330,10 +332,12 @@ function wireEvents(element: HTMLDivElement, panelId: string): void {
     }
   }, { passive: false });
 
-  wireCrosshairPointerHandlers({
+  const disposeCrosshair = wireCrosshairPointerHandlers({
     element,
     panelId,
     isCrosshairActive: () => useViewerStore.getState().activeTool === ToolName.Crosshairs,
     onWorldPoint: (point) => crosshairSyncService.syncFromViewport(panelId, point),
   });
+
+  return disposeCrosshair;
 }

--- a/src/renderer/components/viewer/MPRViewport.tsx
+++ b/src/renderer/components/viewer/MPRViewport.tsx
@@ -66,6 +66,7 @@ export default function MPRViewport({ panelId, volumeId, plane }: MPRViewportPro
     if (!containerRef.current) return;
 
     let cancelled = false;
+    let disposeEvents: (() => void) | null = null;
     const element = containerRef.current;
 
     async function setup() {
@@ -91,7 +92,7 @@ export default function MPRViewport({ panelId, volumeId, plane }: MPRViewportPro
         if (cancelled) return;
 
         // Wire events
-        wireEvents(element, panelId);
+        disposeEvents = wireEvents(element, panelId);
 
         // Set the volume on this viewport
         await mprService.setVolume(panelId, volumeId);
@@ -139,6 +140,7 @@ export default function MPRViewport({ panelId, volumeId, plane }: MPRViewportPro
     return () => {
       cancelled = true;
       resizeObserver.disconnect();
+      disposeEvents?.();
 
       // Remove from tool group before destroying viewport
       mprToolService.removeViewport(panelId);
@@ -223,7 +225,7 @@ export default function MPRViewport({ panelId, volumeId, plane }: MPRViewportPro
 
 // ─── Event Wiring ──────────────────────────────────────────────
 
-function wireEvents(element: HTMLDivElement, panelId: string): void {
+function wireEvents(element: HTMLDivElement, panelId: string): () => void {
   const Events = Enums.Events;
 
   // VOI changed (user dragged W/L)
@@ -265,10 +267,12 @@ function wireEvents(element: HTMLDivElement, panelId: string): void {
     }
   }, { passive: false });
 
-  wireCrosshairPointerHandlers({
+  const disposeCrosshair = wireCrosshairPointerHandlers({
     element,
     panelId,
     isCrosshairActive: () => useViewerStore.getState().activeTool === ToolName.Crosshairs,
     onWorldPoint: (point) => crosshairSyncService.syncFromViewport(panelId, point),
   });
+
+  return disposeCrosshair;
 }

--- a/src/renderer/components/viewer/OrientedViewport.tsx
+++ b/src/renderer/components/viewer/OrientedViewport.tsx
@@ -47,6 +47,7 @@ export default function OrientedViewport({ panelId, imageIds, plane }: OrientedV
     if (!containerRef.current || imageIds.length === 0) return;
 
     let cancelled = false;
+    let disposeEvents: (() => void) | null = null;
     const element = containerRef.current;
 
     async function setup() {
@@ -70,7 +71,7 @@ export default function OrientedViewport({ panelId, imageIds, plane }: OrientedV
 
         mprService.createViewport(panelId, element, plane);
         toolService.addViewport(panelId);
-        wireEvents(element, panelId);
+        disposeEvents = wireEvents(element, panelId);
 
         setStatus(`Loading ${imageIds.length} images...`);
         await mprService.setVolume(panelId, volumeId);
@@ -118,6 +119,7 @@ export default function OrientedViewport({ panelId, imageIds, plane }: OrientedV
     return () => {
       cancelled = true;
       resizeObserver.disconnect();
+      disposeEvents?.();
 
       useViewerStore.getState().stopCine(panelId);
       toolService.removeViewport(panelId);
@@ -180,7 +182,7 @@ function syncSliceState(panelId: string): void {
   }
 }
 
-function wireEvents(element: HTMLDivElement, panelId: string): void {
+function wireEvents(element: HTMLDivElement, panelId: string): () => void {
   const Events = Enums.Events;
 
   element.addEventListener(Events.VOI_MODIFIED, ((e: Event) => {
@@ -212,10 +214,12 @@ function wireEvents(element: HTMLDivElement, panelId: string): void {
     }
   }, { passive: false });
 
-  wireCrosshairPointerHandlers({
+  const disposeCrosshair = wireCrosshairPointerHandlers({
     element,
     panelId,
     isCrosshairActive: () => useViewerStore.getState().activeTool === ToolName.Crosshairs,
     onWorldPoint: (point) => crosshairSyncService.syncFromViewport(panelId, point),
   });
+
+  return disposeCrosshair;
 }

--- a/src/renderer/lib/cornerstone/__tests__/crosshairSyncService.test.ts
+++ b/src/renderer/lib/cornerstone/__tests__/crosshairSyncService.test.ts
@@ -226,4 +226,362 @@ describe('crosshairSyncService', () => {
     crosshairSyncService.syncFromViewport('panel_0', [3, 2, 1]);
     expect(targetViewport.jumpToWorld).toHaveBeenCalledWith([3, 2, 1]);
   });
+
+  describe('multi-scan same-session sync', () => {
+    it('syncs two different scans sharing the same FrameOfReferenceUID to the same world point', () => {
+      // Simulate two scans from the same session: T1 (scan 1) and T2 (scan 2),
+      // different series UIDs but same frame of reference (same patient position).
+      viewerStoreMock.setState({
+        panelImageIdsMap: {
+          panel_0: ['scan1-slice0', 'scan1-slice1', 'scan1-slice2'],
+          panel_1: ['scan2-slice0', 'scan2-slice1', 'scan2-slice2', 'scan2-slice3'],
+        },
+      });
+
+      setMetadata({
+        'imagePlaneModule|scan1-slice0': { frameOfReferenceUID: 'FOR-SESSION-1' },
+        'generalSeriesModule|scan1-slice0': { seriesInstanceUID: 'SER-T1' },
+        'imagePlaneModule|scan2-slice0': { frameOfReferenceUID: 'FOR-SESSION-1' },
+        'generalSeriesModule|scan2-slice0': { seriesInstanceUID: 'SER-T2' },
+      });
+
+      const targetViewport = {
+        jumpToWorld: vi.fn(() => true),
+        getCurrentImageIdIndex: vi.fn(() => 1),
+        render: vi.fn(),
+      };
+      getViewportForPanelMock.mockImplementation((panelId: string) =>
+        panelId === 'panel_1' ? targetViewport : null,
+      );
+
+      crosshairSyncService.syncFromViewport('panel_0', [50, 60, 70]);
+
+      expect(targetViewport.jumpToWorld).toHaveBeenCalledWith([50, 60, 70]);
+      expect(targetViewport.render).toHaveBeenCalled();
+      const state = viewerStoreMock.getState();
+      expect(state.crosshairWorldPoint).toEqual([50, 60, 70]);
+      expect(state.crosshairSourcePanelId).toBe('panel_0');
+      expect(state.viewports.panel_1?.requestedImageIndex).toBe(1);
+    });
+
+    it('syncs bidirectionally: clicking in either panel navigates the other', () => {
+      viewerStoreMock.setState({
+        panelImageIdsMap: {
+          panel_0: ['scanA-0', 'scanA-1', 'scanA-2'],
+          panel_1: ['scanB-0', 'scanB-1', 'scanB-2'],
+        },
+      });
+
+      setMetadata({
+        'imagePlaneModule|scanA-0': { frameOfReferenceUID: 'FOR-1' },
+        'generalSeriesModule|scanA-0': { seriesInstanceUID: 'SER-A' },
+        'imagePlaneModule|scanB-0': { frameOfReferenceUID: 'FOR-1' },
+        'generalSeriesModule|scanB-0': { seriesInstanceUID: 'SER-B' },
+      });
+
+      const viewportA = {
+        jumpToWorld: vi.fn(() => true),
+        getCurrentImageIdIndex: vi.fn(() => 0),
+        render: vi.fn(),
+      };
+      const viewportB = {
+        jumpToWorld: vi.fn(() => true),
+        getCurrentImageIdIndex: vi.fn(() => 2),
+        render: vi.fn(),
+      };
+      getViewportForPanelMock.mockImplementation((panelId: string) => {
+        if (panelId === 'panel_0') return viewportA;
+        if (panelId === 'panel_1') return viewportB;
+        return null;
+      });
+
+      // Click in panel_0 → panel_1 should sync
+      crosshairSyncService.syncFromViewport('panel_0', [10, 20, 30]);
+      expect(viewportB.jumpToWorld).toHaveBeenCalledWith([10, 20, 30]);
+      expect(viewportA.jumpToWorld).not.toHaveBeenCalled();
+
+      vi.clearAllMocks();
+
+      // Click in panel_1 → panel_0 should sync
+      crosshairSyncService.syncFromViewport('panel_1', [40, 50, 60]);
+      expect(viewportA.jumpToWorld).toHaveBeenCalledWith([40, 50, 60]);
+      expect(viewportB.jumpToWorld).not.toHaveBeenCalled();
+    });
+
+    it('syncs across three panels from different scans in the same session', () => {
+      viewerStoreMock.setState({
+        panelImageIdsMap: {
+          panel_0: ['t1-0'],
+          panel_1: ['t2-0'],
+          panel_2: ['flair-0'],
+        },
+      });
+
+      setMetadata({
+        'imagePlaneModule|t1-0': { frameOfReferenceUID: 'FOR-SESSION' },
+        'generalSeriesModule|t1-0': { seriesInstanceUID: 'SER-T1' },
+        'imagePlaneModule|t2-0': { frameOfReferenceUID: 'FOR-SESSION' },
+        'generalSeriesModule|t2-0': { seriesInstanceUID: 'SER-T2' },
+        'imagePlaneModule|flair-0': { frameOfReferenceUID: 'FOR-SESSION' },
+        'generalSeriesModule|flair-0': { seriesInstanceUID: 'SER-FLAIR' },
+      });
+
+      const vpT2 = { jumpToWorld: vi.fn(() => true), getCurrentImageIdIndex: vi.fn(() => 0), render: vi.fn() };
+      const vpFlair = { jumpToWorld: vi.fn(() => true), getCurrentImageIdIndex: vi.fn(() => 0), render: vi.fn() };
+      getViewportForPanelMock.mockImplementation((panelId: string) => {
+        if (panelId === 'panel_1') return vpT2;
+        if (panelId === 'panel_2') return vpFlair;
+        return null;
+      });
+
+      crosshairSyncService.syncFromViewport('panel_0', [5, 10, 15]);
+
+      expect(vpT2.jumpToWorld).toHaveBeenCalledWith([5, 10, 15]);
+      expect(vpFlair.jumpToWorld).toHaveBeenCalledWith([5, 10, 15]);
+    });
+  });
+
+  describe('different slice spacing and count', () => {
+    it('selects the nearest slice when target scan has coarser spacing than source', () => {
+      // Source: 1mm slices (0–4mm), Target: 2mm slices (0, 2, 4, 6, 8mm)
+      viewerStoreMock.setState({
+        panelImageIdsMap: {
+          panel_0: ['fine-0', 'fine-1', 'fine-2', 'fine-3', 'fine-4'],
+          panel_1: ['coarse-0', 'coarse-1', 'coarse-2', 'coarse-3', 'coarse-4'],
+        },
+      });
+
+      const axialPlane = (z: number): PlaneMeta => ({
+        frameOfReferenceUID: 'FOR-1',
+        imagePositionPatient: [0, 0, z],
+        imageOrientationPatient: [1, 0, 0, 0, 1, 0],
+      });
+
+      setMetadata({
+        'imagePlaneModule|fine-0': axialPlane(0),
+        'imagePlaneModule|fine-1': axialPlane(1),
+        'imagePlaneModule|fine-2': axialPlane(2),
+        'imagePlaneModule|fine-3': axialPlane(3),
+        'imagePlaneModule|fine-4': axialPlane(4),
+        'generalSeriesModule|fine-0': { seriesInstanceUID: 'SER-FINE' },
+        'imagePlaneModule|coarse-0': axialPlane(0),
+        'imagePlaneModule|coarse-1': axialPlane(2),
+        'imagePlaneModule|coarse-2': axialPlane(4),
+        'imagePlaneModule|coarse-3': axialPlane(6),
+        'imagePlaneModule|coarse-4': axialPlane(8),
+        'generalSeriesModule|coarse-0': { seriesInstanceUID: 'SER-COARSE' },
+      });
+
+      getViewportForPanelMock.mockReturnValue({ jumpToWorld: vi.fn(() => false) });
+
+      // Click at z=3 in fine scan → nearest coarse slice is z=2 (index 1) or z=4 (index 2)
+      crosshairSyncService.syncFromViewport('panel_0', [0, 0, 3]);
+
+      const targetIndex = viewerStoreMock.getState().viewports.panel_1?.requestedImageIndex;
+      // z=3 is equidistant from z=2 (index 1) and z=4 (index 2); first match wins → index 1
+      expect(targetIndex).toBe(1);
+      expect(scrollToIndexMock).toHaveBeenCalledWith('panel_1', 1);
+    });
+
+    it('selects the nearest slice when target scan has finer spacing than source', () => {
+      // Source: 5mm slices, Target: 1mm slices
+      viewerStoreMock.setState({
+        panelImageIdsMap: {
+          panel_0: ['thick-0', 'thick-1'],
+          panel_1: ['thin-0', 'thin-1', 'thin-2', 'thin-3', 'thin-4', 'thin-5', 'thin-6', 'thin-7', 'thin-8', 'thin-9', 'thin-10'],
+        },
+      });
+
+      const axialPlane = (z: number): PlaneMeta => ({
+        frameOfReferenceUID: 'FOR-1',
+        imagePositionPatient: [0, 0, z],
+        imageOrientationPatient: [1, 0, 0, 0, 1, 0],
+      });
+
+      const meta: Record<string, unknown> = {
+        'generalSeriesModule|thick-0': { seriesInstanceUID: 'SER-THICK' },
+        'generalSeriesModule|thin-0': { seriesInstanceUID: 'SER-THIN' },
+      };
+      meta['imagePlaneModule|thick-0'] = axialPlane(0);
+      meta['imagePlaneModule|thick-1'] = axialPlane(5);
+      for (let i = 0; i <= 10; i++) {
+        meta[`imagePlaneModule|thin-${i}`] = axialPlane(i);
+      }
+      setMetadata(meta);
+
+      getViewportForPanelMock.mockReturnValue({ jumpToWorld: vi.fn(() => false) });
+
+      // Click at z=5 (thick-1) → target should land on thin-5 (z=5, index 5)
+      crosshairSyncService.syncFromViewport('panel_0', [0, 0, 5]);
+
+      expect(viewerStoreMock.getState().viewports.panel_1?.requestedImageIndex).toBe(5);
+      expect(scrollToIndexMock).toHaveBeenCalledWith('panel_1', 5);
+    });
+
+    it('handles non-axial (sagittal) orientation with different slice counts', () => {
+      // Sagittal slices: varying along X axis
+      viewerStoreMock.setState({
+        panelImageIdsMap: {
+          panel_0: ['sag-src-0', 'sag-src-1', 'sag-src-2'],
+          panel_1: ['sag-tgt-0', 'sag-tgt-1', 'sag-tgt-2', 'sag-tgt-3', 'sag-tgt-4'],
+        },
+      });
+
+      const sagittalPlane = (x: number): PlaneMeta => ({
+        frameOfReferenceUID: 'FOR-1',
+        imagePositionPatient: [x, 0, 0],
+        // Sagittal: row=Y, col=Z → normal=X
+        imageOrientationPatient: [0, 1, 0, 0, 0, 1],
+      });
+
+      const meta: Record<string, unknown> = {
+        'generalSeriesModule|sag-src-0': { seriesInstanceUID: 'SER-SAG-SRC' },
+        'generalSeriesModule|sag-tgt-0': { seriesInstanceUID: 'SER-SAG-TGT' },
+        'imagePlaneModule|sag-src-0': sagittalPlane(0),
+        'imagePlaneModule|sag-src-1': sagittalPlane(10),
+        'imagePlaneModule|sag-src-2': sagittalPlane(20),
+        'imagePlaneModule|sag-tgt-0': sagittalPlane(0),
+        'imagePlaneModule|sag-tgt-1': sagittalPlane(5),
+        'imagePlaneModule|sag-tgt-2': sagittalPlane(10),
+        'imagePlaneModule|sag-tgt-3': sagittalPlane(15),
+        'imagePlaneModule|sag-tgt-4': sagittalPlane(20),
+      };
+      setMetadata(meta);
+
+      getViewportForPanelMock.mockReturnValue({ jumpToWorld: vi.fn(() => false) });
+
+      // Click at world x=12 → nearest target slice is x=10 (index 2)
+      crosshairSyncService.syncFromViewport('panel_0', [12, 0, 0]);
+
+      expect(viewerStoreMock.getState().viewports.panel_1?.requestedImageIndex).toBe(2);
+    });
+  });
+
+  describe('partial anatomic overlap', () => {
+    it('navigates to the closest edge slice when click is beyond target scan coverage', () => {
+      // Source covers z=0..100, target covers z=0..50
+      viewerStoreMock.setState({
+        panelImageIdsMap: {
+          panel_0: ['wide-0', 'wide-1'],
+          panel_1: ['short-0', 'short-1', 'short-2'],
+        },
+      });
+
+      const axialPlane = (z: number): PlaneMeta => ({
+        frameOfReferenceUID: 'FOR-1',
+        imagePositionPatient: [0, 0, z],
+        imageOrientationPatient: [1, 0, 0, 0, 1, 0],
+      });
+
+      setMetadata({
+        'imagePlaneModule|wide-0': axialPlane(0),
+        'imagePlaneModule|wide-1': axialPlane(100),
+        'generalSeriesModule|wide-0': { seriesInstanceUID: 'SER-WIDE' },
+        'imagePlaneModule|short-0': axialPlane(0),
+        'imagePlaneModule|short-1': axialPlane(25),
+        'imagePlaneModule|short-2': axialPlane(50),
+        'generalSeriesModule|short-0': { seriesInstanceUID: 'SER-SHORT' },
+      });
+
+      getViewportForPanelMock.mockReturnValue({ jumpToWorld: vi.fn(() => false) });
+
+      // Click at z=80, beyond the short scan's last slice at z=50
+      crosshairSyncService.syncFromViewport('panel_0', [0, 0, 80]);
+
+      // Should clamp to the nearest available slice: z=50 (index 2)
+      expect(viewerStoreMock.getState().viewports.panel_1?.requestedImageIndex).toBe(2);
+      expect(scrollToIndexMock).toHaveBeenCalledWith('panel_1', 2);
+    });
+
+    it('does not sync to a panel from a completely different frame of reference', () => {
+      viewerStoreMock.setState({
+        panelImageIdsMap: {
+          panel_0: ['brain-0'],
+          panel_1: ['knee-0'],
+        },
+      });
+
+      setMetadata({
+        'imagePlaneModule|brain-0': { frameOfReferenceUID: 'FOR-BRAIN' },
+        'generalSeriesModule|brain-0': { seriesInstanceUID: 'SER-BRAIN' },
+        'imagePlaneModule|knee-0': { frameOfReferenceUID: 'FOR-KNEE' },
+        'generalSeriesModule|knee-0': { seriesInstanceUID: 'SER-KNEE' },
+      });
+
+      const targetViewport = { jumpToWorld: vi.fn(() => true), render: vi.fn() };
+      getViewportForPanelMock.mockReturnValue(targetViewport);
+
+      crosshairSyncService.syncFromViewport('panel_0', [0, 0, 50]);
+
+      // Different body region → no sync
+      expect(targetViewport.jumpToWorld).not.toHaveBeenCalled();
+      expect(scrollToIndexMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('end-to-end pointer to store flow', () => {
+    it('propagates world point from source click through sync to all compatible target panels', () => {
+      // Set up a 3-panel layout: T1, T2 (same session), PET (different session)
+      viewerStoreMock.setState({
+        panelImageIdsMap: {
+          panel_0: ['t1-0', 't1-1', 't1-2'],
+          panel_1: ['t2-0', 't2-1', 't2-2'],
+          panel_2: ['pet-0', 'pet-1'],
+        },
+      });
+
+      const axialPlane = (z: number, forUid: string): PlaneMeta => ({
+        frameOfReferenceUID: forUid,
+        imagePositionPatient: [0, 0, z],
+        imageOrientationPatient: [1, 0, 0, 0, 1, 0],
+      });
+
+      setMetadata({
+        'imagePlaneModule|t1-0': axialPlane(0, 'FOR-MR'),
+        'imagePlaneModule|t1-1': axialPlane(5, 'FOR-MR'),
+        'imagePlaneModule|t1-2': axialPlane(10, 'FOR-MR'),
+        'generalSeriesModule|t1-0': { seriesInstanceUID: 'SER-T1' },
+        'imagePlaneModule|t2-0': axialPlane(0, 'FOR-MR'),
+        'imagePlaneModule|t2-1': axialPlane(5, 'FOR-MR'),
+        'imagePlaneModule|t2-2': axialPlane(10, 'FOR-MR'),
+        'generalSeriesModule|t2-0': { seriesInstanceUID: 'SER-T2' },
+        'imagePlaneModule|pet-0': axialPlane(0, 'FOR-PET'),
+        'imagePlaneModule|pet-1': axialPlane(5, 'FOR-PET'),
+        'generalSeriesModule|pet-0': { seriesInstanceUID: 'SER-PET' },
+      });
+
+      const vpT2 = {
+        jumpToWorld: vi.fn(() => true),
+        getCurrentImageIdIndex: vi.fn(() => 1),
+        render: vi.fn(),
+      };
+      const vpPET = {
+        jumpToWorld: vi.fn(() => true),
+        getCurrentImageIdIndex: vi.fn(() => 0),
+        render: vi.fn(),
+      };
+      getViewportForPanelMock.mockImplementation((panelId: string) => {
+        if (panelId === 'panel_1') return vpT2;
+        if (panelId === 'panel_2') return vpPET;
+        return null;
+      });
+
+      crosshairSyncService.syncFromViewport('panel_0', [0, 0, 5]);
+
+      const state = viewerStoreMock.getState();
+
+      // Global crosshair state should be set
+      expect(state.crosshairWorldPoint).toEqual([0, 0, 5]);
+      expect(state.crosshairSourcePanelId).toBe('panel_0');
+
+      // T2 (same FOR) should have synced
+      expect(vpT2.jumpToWorld).toHaveBeenCalledWith([0, 0, 5]);
+      expect(vpT2.render).toHaveBeenCalled();
+      expect(state.viewports.panel_1?.requestedImageIndex).toBe(1);
+
+      // PET (different FOR) should NOT have synced
+      expect(vpPET.jumpToWorld).not.toHaveBeenCalled();
+      expect(state.viewports.panel_2).toBeUndefined();
+    });
+  });
 });

--- a/src/renderer/lib/cornerstone/crosshairSyncService.ts
+++ b/src/renderer/lib/cornerstone/crosshairSyncService.ts
@@ -1,6 +1,9 @@
 import { metaData } from '@cornerstonejs/core';
+import { wadouri } from '@cornerstonejs/dicom-image-loader';
 import { useViewerStore } from '../../stores/viewerStore';
 import { viewportService } from './viewportService';
+import { mprService } from './mprService';
+import { pLimit } from '../util/pLimit';
 import {
   getPanelDisplayPointForWorld,
   getViewportForPanel,
@@ -114,12 +117,43 @@ function getFrameOfReferenceUid(imageId: string): string | null {
   return plane?.frameOfReferenceUID ?? null;
 }
 
+/**
+ * Parse a DICOM multi-valued numeric string (e.g. "1.0\\2.0\\3.0") into an
+ * array of numbers. Returns null if parsing fails.
+ */
+function parseDicomNumericString(value: string | undefined | null, expectedLength: number): number[] | null {
+  if (!value) return null;
+  const parts = value.split('\\').map(Number);
+  if (parts.length < expectedLength || !parts.every(Number.isFinite)) return null;
+  return parts;
+}
+
 function getImagePlane(imageId: string): { ipp: Point3; normal: Point3 } | null {
+  // Primary path: Cornerstone metadata provider (available after image decode).
   const imagePlane = metaData.get('imagePlaneModule', imageId) as
     | { imagePositionPatient?: number[]; imageOrientationPatient?: number[] }
     | undefined;
-  const ipp = imagePlane?.imagePositionPatient;
-  const iop = imagePlane?.imageOrientationPatient;
+  let ipp = imagePlane?.imagePositionPatient;
+  let iop = imagePlane?.imageOrientationPatient;
+
+  // Fallback: read directly from the wadouri dataset cache.
+  // After dataSetCacheManager.load(), the raw DICOM dataset is cached but the
+  // Cornerstone metadata provider may not yet expose imagePlaneModule.
+  if (!Array.isArray(ipp) || ipp.length < 3 || !Array.isArray(iop) || iop.length < 6) {
+    try {
+      const uri = toWadouriUri(imageId);
+      if (wadouri.dataSetCacheManager.isLoaded(uri)) {
+        const dataSet = wadouri.dataSetCacheManager.get(uri);
+        const rawIpp = parseDicomNumericString(dataSet?.string?.('x00200032'), 3);
+        const rawIop = parseDicomNumericString(dataSet?.string?.('x00200037'), 6);
+        if (rawIpp) ipp = rawIpp;
+        if (rawIop) iop = rawIop;
+      }
+    } catch {
+      // Ignore dataset cache errors.
+    }
+  }
+
   if (!Array.isArray(ipp) || ipp.length < 3 || !Array.isArray(iop) || iop.length < 6) return null;
   const position: Point3 = [Number(ipp[0]), Number(ipp[1]), Number(ipp[2])];
   const row: Point3 = [Number(iop[0]), Number(iop[1]), Number(iop[2])];
@@ -148,14 +182,114 @@ function findNearestStackIndex(imageIds: string[], world: Point3): number | null
   return bestIndex >= 0 ? bestIndex : null;
 }
 
+// ---------------------------------------------------------------------------
+// Metadata pre-loading for stack viewports
+// ---------------------------------------------------------------------------
+
+/** Tracks which panels have had their image metadata pre-loaded. */
+const metadataLoadedPanels = new Set<string>();
+
+/** In-flight metadata pre-load promises (avoids duplicate concurrent loads). */
+const metadataLoadInFlight = new Map<string, Promise<void>>();
+
+function toWadouriUri(imageId: string): string {
+  return imageId.startsWith('wadouri:') ? imageId.slice(8) : imageId;
+}
+
+/**
+ * Pre-load DICOM headers for all images in a stack so that imagePlaneModule
+ * metadata (imagePositionPatient, imageOrientationPatient) is available for
+ * geometric operations like crosshair sync.
+ *
+ * Uses the wadouri dataSetCacheManager — the same mechanism used by
+ * sortImageIdsByDicomMetadata in dicomwebLoader.
+ */
+async function ensureStackMetadata(panelId: string, imageIds: string[]): Promise<void> {
+  if (metadataLoadedPanels.has(panelId)) return;
+
+  const existing = metadataLoadInFlight.get(panelId);
+  if (existing) {
+    await existing;
+    return;
+  }
+
+  const promise = (async () => {
+    const limit = pLimit(12);
+    let loaded = 0;
+    await Promise.all(
+      imageIds.map((imageId) =>
+        limit(async () => {
+          try {
+            const uri = toWadouriUri(imageId);
+            if (!wadouri.dataSetCacheManager.isLoaded(uri)) {
+              await wadouri.dataSetCacheManager.load(uri, undefined as any, imageId);
+            }
+            loaded++;
+          } catch {
+            // Partial failures are tolerable; we'll still get most slices.
+          }
+        }),
+      ),
+    );
+    metadataLoadedPanels.add(panelId);
+  })();
+
+  metadataLoadInFlight.set(panelId, promise);
+  try {
+    await promise;
+  } finally {
+    metadataLoadInFlight.delete(panelId);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sync service
+// ---------------------------------------------------------------------------
+
+/**
+ * Synchronously sync a single target panel using geometric slice matching.
+ * Returns true if the sync succeeded, false if metadata was insufficient.
+ */
+function syncStackPanel(
+  panelId: string,
+  imageIds: string[],
+  worldPoint: Point3,
+  store: ReturnType<typeof useViewerStore.getState>,
+): boolean {
+  const targetIndex = findNearestStackIndex(imageIds, worldPoint);
+  if (targetIndex == null) return false;
+
+  store._requestImageIndex(panelId, targetIndex, imageIds.length);
+  viewportService.scrollToIndex(panelId, targetIndex);
+
+  // Pan the viewport to keep the crosshair point visible in-plane.
+  const viewport = getViewportForPanel(panelId) as AnyViewport | null;
+  if (viewport) {
+    keepPointVisibleByPanning(panelId, viewport, worldPoint);
+    viewport.render?.();
+  }
+  return true;
+}
+
 export const crosshairSyncService = {
   /**
+   * Call when a panel's images change (e.g. scan unloaded) so that stale
+   * metadata-loaded state is cleared.
+   */
+  invalidatePanel(panelId: string): void {
+    metadataLoadedPanels.delete(panelId);
+  },
+
+  /**
    * Publish crosshair coordinate globally and sync compatible viewports.
-   * Primary path uses viewport-native world navigation (`jumpToWorld`) to avoid
-   * orientation-specific math and preserve consistent geometric behavior.
-   * Legacy stack-index fallback remains for non-jumpable targets.
+   *
+   * For MPR/volume viewports: uses viewport-native `jumpToWorld`.
+   * For stack viewports: uses geometric slice matching via imagePlaneModule
+   * metadata. If metadata hasn't been pre-loaded yet, triggers an async
+   * pre-load and retries.
    */
   syncFromViewport(sourcePanelId: string, worldPoint: Point3): void {
+    try {
     const store = useViewerStore.getState();
     store.setCrosshairWorldPoint(worldPoint, sourcePanelId);
 
@@ -176,33 +310,53 @@ export const crosshairSyncService = {
         if (!panelSeriesUid || (sourceSeriesUid && panelSeriesUid !== sourceSeriesUid)) continue;
       }
 
-      // Best-practice path: use viewport-native world navigation.
-      if (typeof targetViewport.jumpToWorld === 'function') {
-        try {
-          const jumped = targetViewport.jumpToWorld(worldPoint);
-          if (jumped) {
-            keepPointVisibleByPanning(panelId, targetViewport, worldPoint);
-            targetViewport.render?.();
-            // Keep stack requested-index state in sync so slider/status remain stable.
-            if (typeof targetViewport.getCurrentImageIdIndex === 'function') {
-              const idx = targetViewport.getCurrentImageIdIndex();
-              if (Number.isFinite(idx) && imageIds.length > 0) {
-                const clamped = Math.max(0, Math.min(imageIds.length - 1, Number(idx)));
-                store._requestImageIndex(panelId, clamped, imageIds.length);
+      // Determine whether the target is a volume (MPR/oriented) or stack viewport.
+      const vpType = (targetViewport as any)?.type as string | undefined;
+      const isVolumeViewport = vpType != null && vpType !== 'stack';
+
+      if (isVolumeViewport) {
+        // Volume viewports have full metadata in the volume — jumpToWorld works reliably.
+        if (typeof targetViewport.jumpToWorld === 'function') {
+          try {
+            const jumped = targetViewport.jumpToWorld(worldPoint);
+            if (jumped) {
+              keepPointVisibleByPanning(panelId, targetViewport, worldPoint);
+              targetViewport.render?.();
+              if (typeof targetViewport.getCurrentImageIdIndex === 'function') {
+                const idx = targetViewport.getCurrentImageIdIndex();
+                if (Number.isFinite(idx) && imageIds.length > 0) {
+                  const clamped = Math.max(0, Math.min(imageIds.length - 1, Number(idx)));
+                  store._requestImageIndex(panelId, clamped, imageIds.length);
+                }
               }
+              continue;
             }
-            continue;
+          } catch (err) {
+            console.warn('[crosshairSync] volume jumpToWorld error', panelId, err);
+            // Fall through to stack-index fallback.
           }
-        } catch {
-          // Fall through to stack-index fallback.
         }
       }
 
-      // Fallback for legacy/non-jumpable targets.
-      const targetIndex = findNearestStackIndex(imageIds, worldPoint);
-      if (targetIndex == null) continue;
-      store._requestImageIndex(panelId, targetIndex, imageIds.length);
-      viewportService.scrollToIndex(panelId, targetIndex);
+      // Stack viewport path: use geometric slice matching.
+      // This requires imagePlaneModule metadata for all images.
+      // If metadata hasn't been pre-loaded yet, trigger async pre-load
+      // and retry — the initial sync with partial metadata is unreliable.
+      if (!metadataLoadedPanels.has(panelId)) {
+        ensureStackMetadata(panelId, imageIds).then(() => {
+          const latestStore = useViewerStore.getState();
+          const latestPoint = latestStore.crosshairWorldPoint;
+          if (!latestPoint) return;
+          const latestImageIds = latestStore.panelImageIdsMap[panelId];
+          if (!latestImageIds || latestImageIds.length === 0) return;
+          syncStackPanel(panelId, latestImageIds, latestPoint, latestStore);
+        });
+      } else {
+        syncStackPanel(panelId, imageIds, worldPoint, store);
+      }
+    }
+    } catch (err) {
+      console.error('[crosshairSync] syncFromViewport ERROR', err);
     }
   },
 };


### PR DESCRIPTION
## Summary
- Fix crosshair sync always landing on slice index 0 for stack viewports by pre-loading imagePlaneModule metadata via the wadouri dataset cache on first crosshair click
- Add dataset cache fallback in `getImagePlane` for cases where the Cornerstone metadata provider hasn't registered the image plane data yet
- Fix duplicate pointer event handlers caused by React StrictMode — `wireEvents()` now returns a dispose function called during `useEffect` cleanup in `CornerstoneViewport`, `OrientedViewport`, and `MPRViewport`
- Clean up all debug logging from the crosshair sync pipeline

## Test plan
- [ ] Load a session with multiple scans (e.g., sagittal + axial) into separate viewports
- [ ] Activate crosshair mode (press C or click crosshairs button)
- [ ] Click in one viewport — verify other viewports jump to the matching anatomic location
- [ ] First click may have a brief delay (metadata pre-load); subsequent clicks should be instant
- [ ] Verify no duplicate events in console (each click should fire sync once, not twice)
- [ ] Verify crosshair sync works across different scan orientations (sagittal ↔ axial ↔ coronal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)