### PR TITLE
Add annotation deletion with XNAT integration

### DIFF
--- a/src/main/ipc/uploadHandlers.ts
+++ b/src/main/ipc/uploadHandlers.ts
@@ -289,6 +289,27 @@ export function registerUploadHandlers(): void {
     },
   );
 
+  // ─── Delete scan from XNAT session ─────────────────────────────
+  ipcMain.handle(
+    IPC.XNAT_DELETE_SCAN,
+    async (_event, sessionId: string, scanId: string, trashResourceName?: string) => {
+      const client = sessionManager.getClient();
+      if (!client) {
+        return { ok: false, error: 'Not connected to XNAT' };
+      }
+
+      try {
+        await client.deleteScan(sessionId, scanId, trashResourceName);
+        return { ok: true };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[uploadHandlers] Delete scan failed:', msg);
+        sessionManager.handleAuthFailure(err);
+        return { ok: false, error: msg };
+      }
+    },
+  );
+
   // ─── Download temp resource file ───────────────────────────────
   ipcMain.handle(
     IPC.XNAT_DOWNLOAD_TEMP_FILE,

--- a/src/main/xnat/xnatClient.ts
+++ b/src/main/xnat/xnatClient.ts
@@ -1241,6 +1241,72 @@ export class XnatClient {
   }
 
   /**
+   * Delete an entire scan from an image session.
+   *
+   * If `trashResourceName` is provided, the scan's DICOM files are first copied
+   * to a session-level resource folder (e.g. "trash") before the scan is removed.
+   */
+  async deleteScan(
+    sessionId: string,
+    scanId: string,
+    trashResourceName?: string,
+  ): Promise<void> {
+    if (!this.jsessionId || this._disconnected) throw new XnatAuthError('Not authenticated');
+
+    const encSession = encodeURIComponent(sessionId);
+    const encScan = encodeURIComponent(scanId);
+    const scanBase = `${this.baseUrl}/data/experiments/${encSession}/scans/${encScan}`;
+
+    // ─── Optionally copy DICOM files to a trash resource ───
+    if (trashResourceName) {
+      try {
+        // List files in the scan's DICOM resource
+        const listUrl = `${scanBase}/resources/DICOM/files?format=json`;
+        const listResp = await this.xfetch(listUrl, { method: 'GET' });
+        if (listResp.ok) {
+          const listData = await listResp.json().catch(() => ({ ResultSet: { Result: [] } }));
+          const files: Array<{ Name: string; URI: string }> = listData?.ResultSet?.Result ?? [];
+          const encTrash = encodeURIComponent(trashResourceName);
+
+          for (const file of files) {
+            // Download the file content
+            const fileUrl = `${this.baseUrl}${file.URI}`;
+            const fileResp = await this.xfetch(fileUrl, { method: 'GET' });
+            if (!fileResp.ok) continue;
+            const fileBuffer = Buffer.from(await fileResp.arrayBuffer());
+
+            // Upload to the trash resource — use scan ID prefix to avoid name collisions
+            const trashFilename = `scan-${scanId}_${file.Name}`;
+            const putUrl = `${this.baseUrl}/data/experiments/${encSession}`
+              + `/resources/${encTrash}/files/${encodeURIComponent(trashFilename)}`
+              + `?format=DICOM&content=TRASH&overwrite=true`;
+            await this.xfetch(putUrl, {
+              method: 'PUT',
+              body: fileBuffer,
+              headers: { 'Content-Type': 'application/octet-stream' },
+            });
+          }
+          console.log(`[xnatClient] Copied ${files.length} file(s) from scan ${scanId} to resource "${trashResourceName}"`);
+        }
+      } catch (err) {
+        // Log but don't fail — trash is best-effort
+        console.warn(`[xnatClient] Failed to copy scan ${scanId} files to trash:`, err);
+      }
+    }
+
+    // ─── Delete the scan ───
+    const deleteUrl = `${scanBase}?removeFiles=true`;
+    const resp = await this.xfetch(deleteUrl, { method: 'DELETE' });
+
+    if (!resp.ok && resp.status !== 404) {
+      const text = await resp.text().catch(() => '');
+      throw new Error(`Failed to delete scan ${scanId}: ${resp.status} ${text}`.trim());
+    }
+
+    console.log(`[xnatClient] Deleted scan ${scanId} from session ${sessionId}`);
+  }
+
+  /**
    * Download a file from the session-level "temp" resource.
    */
   async downloadTempFile(

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -105,6 +105,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     listTempFiles: (sessionId: string) =>
       ipcRenderer.invoke(IPC.XNAT_LIST_TEMP_FILES, sessionId),
 
+    deleteScan: (sessionId: string, scanId: string, trashResourceName?: string) =>
+      ipcRenderer.invoke(IPC.XNAT_DELETE_SCAN, sessionId, scanId, trashResourceName),
+
     deleteTempFile: (sessionId: string, filename: string) =>
       ipcRenderer.invoke(IPC.XNAT_DELETE_TEMP_FILE, sessionId, filename),
 

--- a/src/renderer/components/icons.tsx
+++ b/src/renderer/components/icons.tsx
@@ -406,13 +406,12 @@ export function IconLock(props: IconProps) {
   );
 }
 
-/** Lock open — open padlock */
+/** Lock open — open padlock with shackle raised */
 export function IconLockOpen(props: IconProps) {
   return (
     <svg {...defaults(props)}>
-      <rect x="3" y="7" width="10" height="7" rx="1.5" />
-      <path d="M5 7 V5 A3 3 0 0 1 11 5" />
-      <circle cx="8" cy="11" r="1" fill="currentColor" stroke="none" />
+      <rect x="3" y="9" width="10" height="7" rx="1.5" />
+      <path d="M5 9 V4 A3 3 0 0 1 11 4" />
     </svg>
   );
 }

--- a/src/renderer/components/settings/SettingsModal.tsx
+++ b/src/renderer/components/settings/SettingsModal.tsx
@@ -194,6 +194,9 @@ export default function SettingsModal({ open, onClose, onRecover, initialTab }: 
   const backupPrefs = usePreferencesStore((s) => s.preferences.backup);
   const setBackupEnabled = usePreferencesStore((s) => s.setBackupEnabled);
   const setBackupIntervalSeconds = usePreferencesStore((s) => s.setBackupIntervalSeconds);
+  const deletionPrefs = usePreferencesStore((s) => s.preferences.deletion);
+  const setTrashOnServerDelete = usePreferencesStore((s) => s.setTrashOnServerDelete);
+  const setTrashResourceName = usePreferencesStore((s) => s.setTrashResourceName);
   const resetAll = usePreferencesStore((s) => s.resetAll);
 
   // ─── Backup tab state ──────────────────────────────────────
@@ -907,6 +910,42 @@ export default function SettingsModal({ open, onClose, onRecover, initialTab }: 
                       <div className="text-[11px] text-zinc-500">Cache location</div>
                       <div className="text-[11px] text-zinc-400 font-mono bg-zinc-900/80 rounded px-2 py-1.5 break-all select-text">
                         {backupCachePath}
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                {/* Server deletion settings */}
+                <div className="rounded-lg border border-zinc-800 bg-zinc-950/40 p-4 space-y-4">
+                  <div className="text-xs text-zinc-400">
+                    When deleting annotations from XNAT, optionally archive the DICOM file
+                    to a session resource folder before removing the scan.
+                  </div>
+
+                  {/* Trash toggle */}
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={deletionPrefs.trashOnServerDelete}
+                      onChange={(e) => setTrashOnServerDelete(e.target.checked)}
+                      className="w-3.5 h-3.5 rounded border-zinc-600 bg-zinc-800 accent-blue-500"
+                    />
+                    <span className="text-xs text-zinc-300">Archive to session resource before deleting</span>
+                  </label>
+
+                  {/* Resource name */}
+                  {deletionPrefs.trashOnServerDelete && (
+                    <div>
+                      <label className="text-xs text-zinc-300 block mb-1">Resource folder name</label>
+                      <input
+                        type="text"
+                        value={deletionPrefs.trashResourceName}
+                        onChange={(e) => setTrashResourceName(e.target.value)}
+                        placeholder="trash"
+                        className="w-full text-xs text-zinc-200 bg-zinc-800 border border-zinc-600 rounded px-2 py-1.5 outline-none focus:border-blue-500 transition-colors"
+                      />
+                      <div className="text-[10px] text-zinc-600 mt-1">
+                        Files will be copied to the session&apos;s <span className="font-mono">{deletionPrefs.trashResourceName || 'trash'}</span> resource.
                       </div>
                     </div>
                   )}

--- a/src/renderer/components/viewer/SegmentationPanel.tsx
+++ b/src/renderer/components/viewer/SegmentationPanel.tsx
@@ -61,6 +61,10 @@ import ExistingSaveDialog, {
   type ExistingSaveDialogResult,
   type ExistingSaveDialogState,
 } from './segmentation/ExistingSaveDialog';
+import DeleteConfirmDialog, {
+  type DeleteConfirmDialogResult,
+  type DeleteConfirmDialogState,
+} from './segmentation/DeleteConfirmDialog';
 import NameEntryDialog from './segmentation/NameEntryDialog';
 import PanelToast from './segmentation/PanelToast';
 import SavingOverlay from './segmentation/SavingOverlay';
@@ -216,6 +220,8 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
   const sessionScans = useViewerStore((s) => s.sessionScans);
   const viewerSessionId = useViewerStore((s) => s.sessionId);
   const connectionStatus = useConnectionStore((s) => s.status);
+  const connectionInfo = useConnectionStore((s) => s.connection);
+  const deletionPrefs = usePreferencesStore((s) => s.preferences.deletion);
   const sourceSeriesUidByScanId = useSessionDerivedIndexStore((s) => s.sourceSeriesUidByScanId);
   const derivedRefSeriesUidByScanId = useSessionDerivedIndexStore((s) => s.derivedRefSeriesUidByScanId);
   const resolveAssociationsForSession = useSessionDerivedIndexStore((s) => s.resolveAssociationsForSession);
@@ -507,6 +513,8 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
   const saveMenuRef = useRef<HTMLDivElement>(null);
   const [existingSaveDialog, setExistingSaveDialog] = useState<ExistingSaveDialogState | null>(null);
   const existingSaveDialogResolverRef = useRef<((result: ExistingSaveDialogResult) => void) | null>(null);
+  const [deleteConfirmDialog, setDeleteConfirmDialog] = useState<DeleteConfirmDialogState | null>(null);
+  const deleteConfirmResolverRef = useRef<((result: DeleteConfirmDialogResult) => void) | null>(null);
 
   // Auto-dismiss toast
   useEffect(() => {
@@ -635,7 +643,10 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
     setSegmentNamingDialog(null);
   }, []);
 
-  const handleRemoveSegmentation = useCallback((segId: string) => {
+  // ─── Delete confirmation flow ──────────────────────────────────
+
+  /** Perform local-only removal of a segmentation and clean up UI state. */
+  const doLocalRemoval = useCallback((segId: string) => {
     segmentationManager.removeSegmentation(segId);
     setExpandedIds((prev) => {
       const next = new Set(prev);
@@ -643,6 +654,96 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
       return next;
     });
   }, []);
+
+  /** Resolve the delete-confirm dialog (callback passed to the dialog component). */
+  const resolveDeleteConfirmDialog = useCallback((result: DeleteConfirmDialogResult) => {
+    deleteConfirmResolverRef.current?.(result);
+    deleteConfirmResolverRef.current = null;
+    setDeleteConfirmDialog(null);
+  }, []);
+
+  /** Show the delete-confirm dialog and wait for the user's choice. */
+  const promptDeleteConfirm = useCallback(
+    (state: DeleteConfirmDialogState): Promise<DeleteConfirmDialogResult> => {
+      return new Promise<DeleteConfirmDialogResult>((resolve) => {
+        deleteConfirmResolverRef.current = resolve;
+        setDeleteConfirmDialog(state);
+      });
+    },
+    [],
+  );
+
+  /**
+   * Handle removing a segmentation. If it has an XNAT origin, show the
+   * delete-confirm dialog; otherwise remove locally immediately.
+   */
+  const handleRemoveSegmentation = useCallback(
+    async (segId: string) => {
+      const origin = useSegmentationStore.getState().xnatOriginMap[segId];
+
+      // Not saved to XNAT — just remove locally.
+      // origin.scanId is '' for locally-created annotations that haven't been uploaded yet.
+      if (!origin?.scanId) {
+        doLocalRemoval(segId);
+        return;
+      }
+
+      // Determine dicom type and label for the dialog
+      const seg = useSegmentationStore.getState().segmentations.find((s) => s.segmentationId === segId);
+      const dicomType = useSegmentationStore.getState().dicomTypeBySegmentationId[segId] ?? 'SEG';
+      const xnatHost = connectionInfo?.serverUrl ?? '';
+
+      const result = await promptDeleteConfirm({
+        segmentationId: segId,
+        segmentLabel: seg?.label ?? 'Annotation',
+        scanId: origin.scanId,
+        xnatHost,
+        dicomType,
+      });
+
+      if (result.action === 'cancel') return;
+
+      if (result.action === 'delete-from-xnat') {
+        try {
+          setSaving(true);
+          const trashResource = deletionPrefs.trashOnServerDelete
+            ? deletionPrefs.trashResourceName
+            : undefined;
+          const resp = await window.electronAPI.xnat.deleteScan(
+            origin.sessionId,
+            origin.scanId,
+            trashResource,
+          );
+          if (!resp.ok) {
+            setToast({ message: resp.error ?? 'Failed to delete from XNAT', type: 'error' });
+            return;
+          }
+
+          // Refresh session scan list so the deleted scan no longer appears
+          if (viewerSessionId) {
+            try {
+              const refreshedScans = await window.electronAPI.xnat.getScans(viewerSessionId);
+              setSessionData(viewerSessionId, refreshedScans);
+            } catch {
+              // Best-effort refresh
+            }
+          }
+
+          setToast({ message: `Scan #${origin.scanId} deleted from XNAT`, type: 'success' });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          setToast({ message: msg, type: 'error' });
+          return;
+        } finally {
+          setSaving(false);
+        }
+      }
+
+      // Both "local-only" and "delete-from-xnat" remove locally
+      doLocalRemoval(segId);
+    },
+    [doLocalRemoval, promptDeleteConfirm, connectionInfo, deletionPrefs, viewerSessionId, setSessionData],
+  );
 
   const handleToggleExpand = useCallback((segId: string) => {
     setExpandedIds((prev) => {
@@ -1571,7 +1672,7 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
                                   segment.segmentIndex,
                                 );
                               }}
-                              className="text-zinc-500 hover:text-zinc-300 transition-colors p-0.5 shrink-0"
+                              className={`${segment.locked ? 'text-amber-400 hover:text-amber-300' : 'text-zinc-500 hover:text-zinc-300'} transition-colors p-0.5 shrink-0`}
                               title={segment.locked ? 'Unlock segment' : 'Lock segment'}
                             >
                               {segment.locked ? (
@@ -1585,6 +1686,14 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
                             <button
                               onClick={(e) => {
                                 e.stopPropagation();
+                                // If this is the last segment and the segmentation is saved to XNAT,
+                                // treat as a full segmentation delete (shows confirm dialog).
+                                const isLastSegment = seg.segments.length <= 1;
+                                const hasXnatOrigin = !!xnatOriginMap[seg.segmentationId];
+                                if (isLastSegment && hasXnatOrigin) {
+                                  void handleRemoveSegmentation(seg.segmentationId);
+                                  return;
+                                }
                                 const removedSelectedComponent =
                                   segmentationManager.removeSelectedContourComponents(
                                     seg.segmentationId,
@@ -1848,6 +1957,11 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
         state={existingSaveDialog}
         onStateChange={(updater) => setExistingSaveDialog((prev) => updater(prev))}
         onResolve={resolveExistingSaveDialog}
+      />
+
+      <DeleteConfirmDialog
+        state={deleteConfirmDialog}
+        onResolve={resolveDeleteConfirmDialog}
       />
 
       <NameEntryDialog

--- a/src/renderer/components/viewer/segmentation/DeleteConfirmDialog.tsx
+++ b/src/renderer/components/viewer/segmentation/DeleteConfirmDialog.tsx
@@ -1,0 +1,70 @@
+import type { SegmentationDicomType } from '../../../stores/segmentationStore';
+
+export type DeleteConfirmDialogResult =
+  | { action: 'local-only' }
+  | { action: 'delete-from-xnat' }
+  | { action: 'cancel' };
+
+export interface DeleteConfirmDialogState {
+  segmentationId: string;
+  segmentLabel: string;
+  scanId: string;
+  xnatHost: string;
+  dicomType: SegmentationDicomType;
+}
+
+interface DeleteConfirmDialogProps {
+  state: DeleteConfirmDialogState | null;
+  onResolve: (result: DeleteConfirmDialogResult) => void;
+}
+
+export default function DeleteConfirmDialog({
+  state,
+  onResolve,
+}: DeleteConfirmDialogProps) {
+  if (!state) return null;
+
+  const typeLabel = state.dicomType === 'RTSTRUCT' ? 'structure' : 'segmentation';
+
+  // Extract just the hostname from the full URL for concise display
+  let hostDisplay = state.xnatHost;
+  try {
+    hostDisplay = new URL(state.xnatHost).hostname;
+  } catch {
+    // Use raw value if not a valid URL
+  }
+
+  return (
+    <div className="absolute inset-0 z-50 bg-zinc-950/70 flex items-center justify-center">
+      <div className="bg-zinc-900 border border-zinc-700 rounded-lg shadow-xl p-4 mx-4 w-full max-w-[280px]">
+        <div className="text-xs text-zinc-300 leading-relaxed">
+          This {typeLabel} is saved on XNAT as scan{' '}
+          <span className="font-semibold text-zinc-100">#{state.scanId}</span>.
+        </div>
+        <div className="text-[11px] text-zinc-500 mt-1.5">
+          How do you want to delete it?
+        </div>
+        <div className="grid gap-2 mt-3">
+          <button
+            onClick={() => onResolve({ action: 'local-only' })}
+            className="text-[11px] text-zinc-200 px-3 py-1.5 rounded bg-zinc-800 hover:bg-zinc-700 transition-colors text-left"
+          >
+            Delete {typeLabel} locally only
+          </button>
+          <button
+            onClick={() => onResolve({ action: 'delete-from-xnat' })}
+            className="text-[11px] text-red-300 px-3 py-1.5 rounded bg-red-900/25 hover:bg-red-900/40 transition-colors text-left"
+          >
+            Delete {typeLabel} on {hostDisplay}
+          </button>
+          <button
+            onClick={() => onResolve({ action: 'cancel' })}
+            className="text-[11px] text-zinc-400 hover:text-zinc-200 px-3 py-1.5 rounded hover:bg-zinc-800 transition-colors text-left"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/lib/cornerstone/segmentationService.ts
+++ b/src/renderer/lib/cornerstone/segmentationService.ts
@@ -878,6 +878,9 @@ async function performLabelmapInterpolation(): Promise<void> {
   let segmentIndex = Number(pending?.segmentIndex ?? segStore.activeSegmentIndex);
   if (!Number.isInteger(segmentIndex) || segmentIndex <= 0) return;
 
+  // Don't interpolate on a locked segment
+  if (segmentationService.getSegmentLocked(activeSegId, segmentIndex)) return;
+
   // For multi-layer groups, resolve to the sub-seg and use segment index 1
   let effectiveSegId = activeSegId;
   let effectiveSegIndex = segmentIndex;
@@ -1837,6 +1840,9 @@ export const segmentationService = {
         }
         store.clearXnatOrigin(segmentationId);
 
+        // Clean up manager store (loadedBySourceScan, presentation, localOrigin, dirty)
+        useSegmentationManagerStore.getState().cleanupRemovedSegmentation(segmentationId);
+
         console.log(`[segmentationService] Removed group segmentation: ${segmentationId} (${allSubSegIds.length} sub-segs)`);
       } catch (err) {
         console.error('[segmentationService] Failed to remove group segmentation:', err);
@@ -1871,6 +1877,9 @@ export const segmentationService = {
         store.setActiveSegmentation(null);
       }
       store.clearXnatOrigin(segmentationId);
+
+      // Clean up manager store (loadedBySourceScan, presentation, localOrigin, dirty)
+      useSegmentationManagerStore.getState().cleanupRemovedSegmentation(segmentationId);
 
       console.log(`[segmentationService] Removed segmentation: ${segmentationId}`);
     } catch (err) {
@@ -2560,10 +2569,13 @@ export const segmentationService = {
       const subSegId = resolveSubSegId(segmentationId, segmentIndex);
       if (!subSegId) return;
       const isLocked = csSegmentation.segmentLocking.isSegmentIndexLocked(subSegId, 1);
-      csSegmentation.segmentLocking.setSegmentIndexLocked(subSegId, 1, !isLocked);
+      const newLocked = !isLocked;
+      csSegmentation.segmentLocking.setSegmentIndexLocked(subSegId, 1, newLocked);
       // Update metadata
       const meta = segmentMetaMap.get(segmentationId)?.get(segmentIndex);
-      if (meta) meta.locked = !isLocked;
+      if (meta) meta.locked = newLocked;
+      // Update presentation cache BEFORE sync so syncSegmentations reads the correct value
+      useSegmentationManagerStore.getState().setPresentation(segmentationId, segmentIndex, { locked: newLocked });
       syncSegmentations();
       return;
     }
@@ -2573,11 +2585,14 @@ export const segmentationService = {
       segmentationId,
       segmentIndex,
     );
+    const newLocked = !isLocked;
     csSegmentation.segmentLocking.setSegmentIndexLocked(
       segmentationId,
       segmentIndex,
-      !isLocked,
+      newLocked,
     );
+    // Update presentation cache BEFORE sync so syncSegmentations reads the correct value
+    useSegmentationManagerStore.getState().setPresentation(segmentationId, segmentIndex, { locked: newLocked });
     syncSegmentations();
   },
 
@@ -2647,6 +2662,18 @@ export const segmentationService = {
     } catch {
       return false; // default unlocked
     }
+  },
+
+  /**
+   * Check whether the currently active segment is locked.
+   * Returns true if the active segmentation + active segment index are locked.
+   */
+  isActiveSegmentLocked(): boolean {
+    const segStore = useSegmentationStore.getState();
+    const activeSegId = segStore.activeSegmentationId;
+    const activeSegIdx = segStore.activeSegmentIndex;
+    if (!activeSegId || !activeSegIdx || activeSegIdx <= 0) return false;
+    return this.getSegmentLocked(activeSegId, activeSegIdx);
   },
 
   /**

--- a/src/renderer/lib/cornerstone/toolService.ts
+++ b/src/renderer/lib/cornerstone/toolService.ts
@@ -126,6 +126,32 @@ let scissorShiftPressed = false;
 let modifierListenersInstalled = false;
 const SCISSOR_TOOL_PATCH_FLAG = '__xnatScissorToolPatched';
 
+// ─── Segment lock guard ────────────────────────────────────────
+// Prevents segmentation tools from receiving pointer events when the active
+// segment is locked.  Installed as a capturing pointerdown listener on each
+// viewport element so it fires before Cornerstone's own handlers.
+const lockGuardInstalled = new WeakSet<Element>();
+
+/** Tools that read but don't modify segment data — exempt from lock guard. */
+const LOCK_EXEMPT_TOOLS = new Set<ToolName>([
+  ToolName.SegmentSelect,
+  ToolName.SegmentBidirectional,
+]);
+
+function installLockGuard(element: Element | null): void {
+  if (!element || lockGuardInstalled.has(element)) return;
+  lockGuardInstalled.add(element);
+  element.addEventListener('pointerdown', ((e: PointerEvent) => {
+    if (!SEGMENTATION_TOOLS.has(currentActiveTool)) return;
+    if (LOCK_EXEMPT_TOOLS.has(currentActiveTool)) return;
+    if (segmentationService.isActiveSegmentLocked()) {
+      e.stopImmediatePropagation();
+      e.preventDefault();
+      console.debug('[toolService] Blocked pointer event — active segment is locked');
+    }
+  }) as EventListener, true); // capturing phase
+}
+
 type ScissorStrategyName = 'FILL_INSIDE' | 'ERASE_INSIDE';
 type ScissorToolName =
   | ToolName.CircleScissors
@@ -460,9 +486,14 @@ function rebuildToolGroup(primaryTool: ToolName): ToolTypes.IToolGroup | undefin
     usePreferencesStore.getState().preferences.interpolation.enabled,
   );
 
-  // Re-add viewports
+  // Re-add viewports and install lock guards
+  const engine = getRenderingEngine(viewportService.ENGINE_ID);
   for (const vpId of viewportIds) {
     toolGroup.addViewport(vpId, viewportService.ENGINE_ID);
+    try {
+      const vp = engine?.getViewport(vpId);
+      if (vp) installLockGuard(vp.element);
+    } catch { /* ok */ }
   }
 
   // Restore the brush size from the store — addAllTools creates fresh tool
@@ -719,6 +750,14 @@ export const toolService = {
     }
     toolGroup.addViewport(viewportId, viewportService.ENGINE_ID);
     syncPrimaryToolCursor(toolGroup, currentActiveTool);
+
+    // Install lock guard on the viewport's DOM element so pointer events
+    // are blocked when the active segment is locked.
+    try {
+      const engine = getRenderingEngine(viewportService.ENGINE_ID);
+      const vp = engine?.getViewport(viewportId);
+      if (vp) installLockGuard(vp.element);
+    } catch { /* viewport may not be rendered yet — guard installed lazily */ }
 
     // Sync the store's brush size to Cornerstone3D now that the tool group
     // has at least one viewport — setBrushSizeForToolGroup is a no-op when

--- a/src/renderer/lib/cornerstone/tools/SafePaintFillTool.ts
+++ b/src/renderer/lib/cornerstone/tools/SafePaintFillTool.ts
@@ -106,6 +106,12 @@ export class SafePaintFillTool extends PaintFillTool {
       const { segmentationId } = activeSegmentationRepresentation;
       const activeSegmentIndex = csSegmentation.segmentIndex.getActiveSegmentIndex(segmentationId);
       if (!activeSegmentIndex || activeSegmentIndex <= 0) return true;
+
+      // Block paint fill if the active segment is locked
+      if (csSegmentation.segmentLocking.isSegmentIndexLocked(segmentationId, activeSegmentIndex)) {
+        return true; // consume event, do nothing
+      }
+
       this.doneEditMemo();
 
       const segmentsLocked = csSegmentation.segmentLocking.getLockedSegmentIndices(segmentationId);

--- a/src/renderer/lib/segmentation/SegmentationManager.ts
+++ b/src/renderer/lib/segmentation/SegmentationManager.ts
@@ -721,11 +721,6 @@ export class SegmentationManager {
    */
   userToggledLock(segmentationId: string, segmentIndex: number): void {
     segmentationService.toggleSegmentLocked(segmentationId, segmentIndex);
-
-    // Read the actual post-toggle lock state from Cornerstone rather than
-    // inferring from the cache (which can be uninitialized or out of sync).
-    const newLocked = segmentationService.getSegmentLocked(segmentationId, segmentIndex);
-    useSegmentationManagerStore.getState().setPresentation(segmentationId, segmentIndex, { locked: newLocked });
   }
 
   /**

--- a/src/renderer/stores/preferencesStore.ts
+++ b/src/renderer/stores/preferencesStore.ts
@@ -9,7 +9,9 @@ import {
   type ScissorStrategyMode,
   DEFAULT_INTERPOLATION_PREFERENCES,
   DEFAULT_BACKUP_PREFERENCES,
+  DEFAULT_DELETION_PREFERENCES,
   type BackupPreferences,
+  type DeletionPreferences,
   type InterpolationAlgorithm,
   type InterpolationPreferences,
   type OverlayCornerId,
@@ -46,6 +48,9 @@ interface PreferencesStore {
   // ─── Backup ─────────────────────────────────────────────
   setBackupEnabled: (enabled: boolean) => void;
   setBackupIntervalSeconds: (seconds: number) => void;
+  // ─── Deletion ─────────────────────────────────────────────
+  setTrashOnServerDelete: (enabled: boolean) => void;
+  setTrashResourceName: (name: string) => void;
   resetAll: () => void;
 }
 
@@ -118,6 +123,7 @@ function makeDefaultPreferences(): PreferencesV1 {
     },
     interpolation: { ...DEFAULT_INTERPOLATION_PREFERENCES },
     backup: { ...DEFAULT_BACKUP_PREFERENCES },
+    deletion: { ...DEFAULT_DELETION_PREFERENCES },
   };
 }
 
@@ -509,6 +515,24 @@ export const usePreferencesStore = create<PreferencesStore>()(
           },
         })),
 
+      // ─── Deletion ──────────────────────────────────────────
+
+      setTrashOnServerDelete: (enabled) =>
+        set((state) => ({
+          preferences: {
+            ...state.preferences,
+            deletion: { ...state.preferences.deletion, trashOnServerDelete: enabled },
+          },
+        })),
+
+      setTrashResourceName: (name) =>
+        set((state) => ({
+          preferences: {
+            ...state.preferences,
+            deletion: { ...state.preferences.deletion, trashResourceName: name.trim() || 'trash' },
+          },
+        })),
+
       resetAll: () =>
         set({
           preferences: makeDefaultPreferences(),
@@ -555,6 +579,19 @@ export const usePreferencesStore = create<PreferencesStore>()(
               : base.preferences.backup.intervalSeconds,
         };
 
+        // Merge deletion preferences with defaults as fallback
+        const incomingDeletion = (incoming as Partial<PreferencesV1>).deletion;
+        const mergedDeletion: DeletionPreferences = {
+          trashOnServerDelete:
+            typeof incomingDeletion?.trashOnServerDelete === 'boolean'
+              ? incomingDeletion.trashOnServerDelete
+              : base.preferences.deletion.trashOnServerDelete,
+          trashResourceName:
+            typeof incomingDeletion?.trashResourceName === 'string' && incomingDeletion.trashResourceName.trim()
+              ? incomingDeletion.trashResourceName.trim()
+              : base.preferences.deletion.trashResourceName,
+        };
+
         return {
           ...base,
           preferences: {
@@ -565,6 +602,7 @@ export const usePreferencesStore = create<PreferencesStore>()(
             annotation: mergeAnnotationPreferences(base.preferences.annotation, incoming.annotation),
             interpolation: mergedInterpolation,
             backup: mergedBackup,
+            deletion: mergedDeletion,
           },
         };
       },

--- a/src/renderer/stores/segmentationManagerStore.ts
+++ b/src/renderer/stores/segmentationManagerStore.ts
@@ -88,6 +88,8 @@ interface SegmentationManagerState {
   setActiveSegmentationForPanel: (panelId: string, segId: string | null) => void;
   setActiveSegmentIndexForPanel: (panelId: string, segIdx: number) => void;
   setLocalOrigin: (segId: string, compositeKey: string) => void;
+  /** Remove a loaded overlay entry and clean up associated state for a deleted segmentation */
+  cleanupRemovedSegmentation: (segmentationId: string) => void;
   clearPanel: (panelId: string) => void;
   /** Check if any segmentation is dirty */
   hasDirtySegmentations: () => boolean;
@@ -222,6 +224,44 @@ export const useSegmentationManagerStore = create<SegmentationManagerState>((set
     set((s) => ({
       localOriginBySegId: { ...s.localOriginBySegId, [segId]: compositeKey },
     })),
+
+  cleanupRemovedSegmentation: (segmentationId) =>
+    set((s) => {
+      // Remove from loadedBySourceScan — iterate all source scans and remove
+      // entries whose segmentationId matches the deleted one.
+      const nextLoaded: Record<string, Record<string, LoadedOverlayInfo>> = {};
+      for (const [sourceKey, derivedMap] of Object.entries(s.loadedBySourceScan)) {
+        const filtered: Record<string, LoadedOverlayInfo> = {};
+        for (const [derivedId, info] of Object.entries(derivedMap)) {
+          if (info.segmentationId !== segmentationId) {
+            filtered[derivedId] = info;
+          }
+        }
+        if (Object.keys(filtered).length > 0) {
+          nextLoaded[sourceKey] = filtered;
+        }
+      }
+
+      // Remove presentation cache
+      const { [segmentationId]: _p, ...restPresentation } = s.presentation;
+
+      // Remove local origin
+      const { [segmentationId]: _l, ...restLocalOrigin } = s.localOriginBySegId;
+
+      // Remove dirty state
+      const { [segmentationId]: _d, ...restDirty } = s.dirtySegIds;
+
+      // Remove manual save timestamp
+      const { [segmentationId]: _m, ...restManualSave } = s.lastManualSaveAt;
+
+      return {
+        loadedBySourceScan: nextLoaded,
+        presentation: restPresentation,
+        localOriginBySegId: restLocalOrigin,
+        dirtySegIds: restDirty,
+        lastManualSaveAt: restManualSave,
+      };
+    }),
 
   clearPanel: (panelId) =>
     set((s) => {

--- a/src/shared/ipcChannels.ts
+++ b/src/shared/ipcChannels.ts
@@ -38,6 +38,9 @@ export const IPC = {
   XNAT_OVERWRITE_DICOM_RTSTRUCT: 'xnat:overwrite-dicom-rtstruct',
   XNAT_PREPARE_DICOM_UPLOAD: 'xnat:prepare-dicom-upload',
 
+  // XNAT scan deletion (renderer → main)
+  XNAT_DELETE_SCAN: 'xnat:delete-scan',
+
   // XNAT temp resource (auto-save, renderer → main)
   XNAT_AUTOSAVE_TEMP: 'xnat:autosave-temp',
   XNAT_LIST_TEMP_FILES: 'xnat:list-temp-files',

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -98,6 +98,11 @@ export interface ElectronAPI {
     listTempFiles(
       sessionId: string,
     ): Promise<{ ok: boolean; files?: Array<{ name: string; uri: string; size: number }>; error?: string }>;
+    deleteScan(
+      sessionId: string,
+      scanId: string,
+      trashResourceName?: string,
+    ): Promise<{ ok: boolean; error?: string }>;
     deleteTempFile(
       sessionId: string,
       filename: string,

--- a/src/shared/types/preferences.ts
+++ b/src/shared/types/preferences.ts
@@ -97,6 +97,20 @@ export const DEFAULT_BACKUP_PREFERENCES: BackupPreferences = {
   intervalSeconds: 10,
 };
 
+// ─── Deletion Preferences ───────────────────────────────────────
+
+export interface DeletionPreferences {
+  /** When deleting from XNAT, copy the DICOM file to a session resource first */
+  trashOnServerDelete: boolean;
+  /** Session resource name used for trashed files (e.g. 'trash') */
+  trashResourceName: string;
+}
+
+export const DEFAULT_DELETION_PREFERENCES: DeletionPreferences = {
+  trashOnServerDelete: false,
+  trashResourceName: 'trash',
+};
+
 // ─── Top-level Preferences ──────────────────────────────────────
 
 export interface PreferencesV1 {
@@ -107,6 +121,7 @@ export interface PreferencesV1 {
   annotation: AnnotationToolPreferences;
   interpolation: InterpolationPreferences;
   backup: BackupPreferences;
+  deletion: DeletionPreferences;
 }
 
 export const DEFAULT_OVERLAY_CORNERS: Record<OverlayCornerId, OverlayFieldKey[]> = {
@@ -177,4 +192,5 @@ export const DEFAULT_PREFERENCES: PreferencesV1 = {
   },
   interpolation: { ...DEFAULT_INTERPOLATION_PREFERENCES },
   backup: { ...DEFAULT_BACKUP_PREFERENCES },
+  deletion: { ...DEFAULT_DELETION_PREFERENCES },
 };


### PR DESCRIPTION
## Summary
- Add delete confirmation dialog for segmentations/structures with options to delete locally, delete from XNAT server, or cancel
- Implement XNAT scan deletion API with optional trash/archive to session resource folder
- Add deletion preferences UI in File Backup settings tab (trash toggle + resource folder name)
- Fix segment lock icons (visually distinguishable at small sizes, amber color for locked)
- Fix lock toggle race condition where stale presentation cache prevented unlocking
- Remove stub rows for deleted segmentations from annotation panel
- Guard brush/paint tools from modifying locked segments

## Test plan
- [ ] Load a segmentation from XNAT, delete a segment — verify local-only delete works
- [ ] Delete a segment saved to XNAT — verify server deletion dialog appears with correct options
- [ ] Enable trash archive in settings, delete from XNAT — verify files archived to session resource
- [ ] Verify lock button toggles correctly (locked = amber closed lock, unlocked = zinc open lock)
- [ ] Verify locked segments cannot be painted on or erased
- [ ] Delete an entire segmentation — verify stub row is removed from panel
- [ ] Repeat deletion tests for RT structures

🤖 Generated with [Claude Code](https://claude.com/claude-code)