### PR TITLE
Fix segment lock enforcement and add tool-type safety

### DIFF
--- a/src/renderer/components/icons.tsx
+++ b/src/renderer/components/icons.tsx
@@ -410,8 +410,9 @@ export function IconLock(props: IconProps) {
 export function IconLockOpen(props: IconProps) {
   return (
     <svg {...defaults(props)}>
-      <rect x="3" y="9" width="10" height="7" rx="1.5" />
-      <path d="M5 9 V4 A3 3 0 0 1 11 4" />
+      <rect x="3" y="7" width="10" height="7" rx="1.5" />
+      <path d="M5 7 V5 A3 3 0 0 1 11 2" />
+      <circle cx="8" cy="11" r="1" fill="currentColor" stroke="none" />
     </svg>
   );
 }

--- a/src/renderer/components/viewer/SegmentationPanel.tsx
+++ b/src/renderer/components/viewer/SegmentationPanel.tsx
@@ -1340,6 +1340,12 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
   const toolPanelAnnotationType = overlaysLoading ? null : activeAnnotationType;
   const toolPanelTools = overlaysLoading ? [] : activeAnnotationTools;
 
+  const isActiveSegmentLocked = useMemo(() => {
+    if (!activeSegId) return false;
+    const seg = segmentations.find((s) => s.segmentationId === activeSegId);
+    return seg?.segments.find((s) => s.segmentIndex === activeSegIndex)?.locked ?? false;
+  }, [segmentations, activeSegId, activeSegIndex]);
+
   const handleToolSelect = useCallback((tool: ToolName) => {
     if (!activeSegId || !activeAnnotationType) return;
     setActiveTool(tool);
@@ -1774,13 +1780,18 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
                   return (
                     <button
                       key={tool}
+                      disabled={isActiveSegmentLocked}
                       onClick={() => handleToolSelect(tool)}
                       className={`flex items-center gap-1.5 px-2 py-1 rounded text-[10px] transition-colors ${
-                        isActive
-                          ? 'bg-blue-600 text-white'
-                          : 'bg-zinc-800 text-zinc-300 hover:bg-zinc-700 hover:text-white'
+                        isActiveSegmentLocked
+                          ? 'bg-zinc-800/50 text-zinc-600 cursor-not-allowed'
+                          : isActive
+                            ? 'bg-blue-600 text-white'
+                            : 'bg-zinc-800 text-zinc-300 hover:bg-zinc-700 hover:text-white'
                       }`}
-                      title={TOOL_DISPLAY_NAMES[tool]}
+                      title={isActiveSegmentLocked
+                        ? `${TOOL_DISPLAY_NAMES[tool]} (segment locked)`
+                        : TOOL_DISPLAY_NAMES[tool]}
                     >
                       <SegToolIcon tool={tool} />
                       <span className="truncate">{TOOL_DISPLAY_NAMES[tool]}</span>
@@ -1788,6 +1799,9 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
                   );
                 })}
               </div>
+            )}
+            {isActiveSegmentLocked && toolPanelAnnotationType && (
+              <div className="text-[10px] text-amber-400/70 mt-1">Unlock segment to edit</div>
             )}
           </div>
         </div>

--- a/src/renderer/lib/cornerstone/__tests__/rtStructService.test.ts
+++ b/src/renderer/lib/cornerstone/__tests__/rtStructService.test.ts
@@ -97,6 +97,9 @@ vi.mock('@cornerstonejs/tools', () => ({
     triggerSegmentationEvents: {
       triggerSegmentationDataModified: rtStructMocks.triggerSegmentationDataModified,
     },
+    segmentLocking: {
+      setSegmentIndexLocked: vi.fn(),
+    },
   },
   annotation: {
     state: {

--- a/src/renderer/lib/cornerstone/__tests__/segmentationService.test.ts
+++ b/src/renderer/lib/cornerstone/__tests__/segmentationService.test.ts
@@ -120,6 +120,7 @@ describe('segmentationService', () => {
     cs.setSegmentColor('panel_0', 'seg-1', 2, [0, 255, 0, 255]);
     cs.setSegmentVisibility('panel_0', 'seg-1', 1, true);
     cs.setSegmentVisibility('panel_0', 'seg-1', 2, false);
+    cs.setSegmentLocked('seg-1', 2, true);
 
     segmentationService.sync();
 

--- a/src/renderer/lib/cornerstone/rtStructService.ts
+++ b/src/renderer/lib/cornerstone/rtStructService.ts
@@ -394,7 +394,7 @@ async function loadRtStructAsContours(
     segments[segmentIndex] = {
       segmentIndex,
       label: roi.name,
-      locked: false,
+      locked: true,
       active: segmentIndex === 1,
       cachedStats: {},
     };
@@ -416,6 +416,11 @@ async function loadRtStructAsContours(
       },
     },
   ]);
+
+  // Lock loaded segments by default — user must unlock to edit
+  for (let roiIdx = 0; roiIdx < parsed.rois.length; roiIdx++) {
+    csSegmentation.segmentLocking.setSegmentIndexLocked(segmentationId, roiIdx + 1, true);
+  }
 
   // Create contour annotations for each ROI
   for (let roiIdx = 0; roiIdx < parsed.rois.length; roiIdx++) {

--- a/src/renderer/lib/cornerstone/segmentationService.ts
+++ b/src/renderer/lib/cornerstone/segmentationService.ts
@@ -542,10 +542,11 @@ function syncSegmentations(): void {
           }
         }
 
-        // Locked
-        const cachedLocked = cachedPresentation?.locked?.[segmentIndex];
-        let locked = meta?.locked ?? false;
-        if (typeof cachedLocked === 'boolean') locked = cachedLocked;
+        // Locked — read directly from Cornerstone to avoid stale-cache lag
+        let locked = false;
+        try {
+          locked = csSegmentation.segmentLocking.isSegmentIndexLocked(subSegId, 1);
+        } catch { /* default false */ }
 
         segments.push({
           segmentIndex,
@@ -645,14 +646,18 @@ function syncSegmentations(): void {
             }
           }
 
-          const cachedLocked = useSegmentationManagerStore.getState().presentation[seg.segmentationId]?.locked?.[idx];
+          // Locked — read directly from Cornerstone to avoid stale-cache lag
+          let locked = false;
+          try {
+            locked = csSegmentation.segmentLocking.isSegmentIndexLocked(seg.segmentationId, idx);
+          } catch { /* default false */ }
 
           segments.push({
             segmentIndex: idx,
             label: segment.label || `Segment ${idx}`,
             color,
             visible,
-            locked: typeof cachedLocked === 'boolean' ? cachedLocked : (segment.locked ?? false),
+            locked,
           });
         }
       }
@@ -3183,7 +3188,7 @@ export const segmentationService = {
           const segLabel = meta.SegmentLabel || meta.SegmentDescription || `Segment ${i}`;
           segments[i] = {
             label: segLabel,
-            locked: false,
+            locked: true,
             active: i === 1,
             segmentIndex: i,
             cachedStats: {},
@@ -3338,13 +3343,16 @@ export const segmentationService = {
               1: {
                 label: segLabel,
                 segmentIndex: 1,
-                locked: false,
+                locked: true,
                 active: segmentIndex === 1,
                 cachedStats: {},
               } as any,
             },
           },
         }]);
+
+        // Lock loaded segments by default — user must unlock to edit
+        csSegmentation.segmentLocking.setSegmentIndexLocked(subSegId, 1, true);
 
         // Track source imageIds on the sub-seg
         sourceImageIdsMap.set(subSegId, [...effectiveBaseSourceImageIds]);
@@ -3355,7 +3363,7 @@ export const segmentationService = {
         metaMapForGroup.set(segmentIndex, {
           label: segLabel,
           color: segColor,
-          locked: false,
+          locked: true,
         });
 
         console.log(`[segmentationService] Created sub-seg ${subSegId} for adapter segment ${segIdx} → group index ${segmentIndex}: "${segLabel}"`);
@@ -3443,12 +3451,12 @@ export const segmentationService = {
           (seg.segments as any)[idx] = {
             segmentIndex: idx,
             label: idx === 0 ? 'Background' : `Segment ${idx}`,
-            locked: false,
+            locked: idx !== 0,
             cachedStats: {},
             active: idx === activeIdx,
           };
         } else if (seg.segments[idx].locked === undefined) {
-          (seg.segments[idx] as any).locked = seg.segments[idx].locked ?? false;
+          (seg.segments[idx] as any).locked = idx !== 0;
           (seg.segments[idx] as any).cachedStats = seg.segments[idx].cachedStats ?? {};
           (seg.segments[idx] as any).active = seg.segments[idx].active ?? (idx === activeIdx);
         }

--- a/src/renderer/lib/cornerstone/toolService.ts
+++ b/src/renderer/lib/cornerstone/toolService.ts
@@ -798,6 +798,19 @@ export const toolService = {
     // Handle segmentation tool activation
     if (SEGMENTATION_TOOLS.has(toolName)) {
       const segStore = useSegmentationStore.getState();
+
+      // Guard: prevent activating segmentation tools when active segment is locked
+      const activeSegs = segStore.segmentations.find(
+        (s) => s.segmentationId === segStore.activeSegmentationId,
+      );
+      const activeSeg = activeSegs?.segments.find(
+        (s) => s.segmentIndex === segStore.activeSegmentIndex,
+      );
+      if (activeSeg?.locked) {
+        console.warn('[toolService] Cannot activate segmentation tool: active segment is locked');
+        return;
+      }
+
       const viewportId = useViewerStore.getState().activeViewportId;
       segStore.setActiveSegTool(toolName);
 

--- a/src/renderer/lib/segmentation/SegmentationManager.test.ts
+++ b/src/renderer/lib/segmentation/SegmentationManager.test.ts
@@ -58,19 +58,22 @@ type MockViewerState = {
   panelScanMap: Record<string, string>;
   panelXnatContextMap: Record<string, any>;
   xnatContext: any;
+  setActiveTool: ReturnType<typeof vi.fn>;
 };
 
 const mockViewerStore = vi.hoisted(() => {
+  const setActiveTool = vi.fn();
   const initial: MockViewerState = {
     layoutConfig: { panelCount: 1 },
     panelScanMap: {},
     panelXnatContextMap: {},
     xnatContext: null,
+    setActiveTool,
   };
   let state: MockViewerState = { ...initial };
   return {
     getInitialState: () => ({ ...initial }),
-    reset: () => { state = { ...initial }; },
+    reset: () => { setActiveTool.mockClear(); state = { ...initial }; },
     getState: () => state,
     setState: (next: Partial<MockViewerState>) => {
       state = { ...state, ...next };
@@ -265,13 +268,60 @@ describe('SegmentationManager', () => {
     expect(useSegmentationManagerStore.getState().presentation['seg-1']?.visibility[1]).toBe(false);
   });
 
-  it('toggles lock state and persists the post-toggle state from segmentation service', () => {
+  it('toggles lock state, persists state, and deactivates Cornerstone tool when locking active segment', () => {
     const manager = new SegmentationManager();
     segmentationServiceMock.getSegmentLocked.mockReturnValueOnce(true);
+
+    // Set up: seg-1 segment 3 is active with a brush tool selected
+    useSegmentationStore.setState({
+      ...useSegmentationStore.getState(),
+      activeSegmentationId: 'seg-1',
+      activeSegmentIndex: 3,
+      activeSegTool: 'Brush',
+    });
 
     manager.userToggledLock('seg-1', 3);
     expect(segmentationServiceMock.toggleSegmentLocked).toHaveBeenCalledWith('seg-1', 3);
     expect(useSegmentationManagerStore.getState().presentation['seg-1']?.locked[3]).toBe(true);
+    expect(mockViewerStore.getState().setActiveTool).toHaveBeenCalledWith('WindowLevel');
+  });
+
+  it('deactivates tool when selecting a locked segment', () => {
+    const manager = new SegmentationManager();
+    segmentationServiceMock.getSegmentLocked.mockReturnValue(true);
+    useSegmentationStore.setState({
+      ...useSegmentationStore.getState(),
+      activeSegTool: 'Brush',
+    });
+
+    manager.userSelectedSegmentation('panel_0', 'seg-1', 1);
+    expect(mockViewerStore.getState().setActiveTool).toHaveBeenCalledWith('WindowLevel');
+  });
+
+  it('deactivates labelmap tool when switching to a contour segmentation', () => {
+    const manager = new SegmentationManager();
+    segmentationServiceMock.getSegmentLocked.mockReturnValue(false);
+    useSegmentationStore.setState({
+      ...useSegmentationStore.getState(),
+      activeSegTool: 'Brush',
+      dicomTypeBySegmentationId: { 'rt-1': 'RTSTRUCT' },
+    });
+
+    manager.userSelectedSegmentation('panel_0', 'rt-1', 1);
+    expect(mockViewerStore.getState().setActiveTool).toHaveBeenCalledWith('WindowLevel');
+  });
+
+  it('deactivates contour tool when switching to a labelmap segmentation', () => {
+    const manager = new SegmentationManager();
+    segmentationServiceMock.getSegmentLocked.mockReturnValue(false);
+    useSegmentationStore.setState({
+      ...useSegmentationStore.getState(),
+      activeSegTool: 'FreehandContour',
+      dicomTypeBySegmentationId: { 'seg-1': 'SEG' },
+    });
+
+    manager.userSelectedSegmentation('panel_0', 'seg-1', 1);
+    expect(mockViewerStore.getState().setActiveTool).toHaveBeenCalledWith('WindowLevel');
   });
 
   it('creates new segmentations/structures and records local origins', async () => {

--- a/src/renderer/lib/segmentation/SegmentationManager.ts
+++ b/src/renderer/lib/segmentation/SegmentationManager.ts
@@ -17,6 +17,12 @@ import { rtStructService } from '../cornerstone/rtStructService';
 import { useSegmentationManagerStore, type RGBA } from '../../stores/segmentationManagerStore';
 import { useSegmentationStore } from '../../stores/segmentationStore';
 import { useViewerStore } from '../../stores/viewerStore';
+import {
+  ToolName,
+  SEGMENTATION_TOOLS,
+  LABELMAP_SEG_TOOLS,
+  CONTOUR_SEG_TOOLS,
+} from '@shared/types/viewer';
 
 /** Dependencies injected from App.tsx to avoid circular imports */
 export interface ManagerDeps {
@@ -641,6 +647,27 @@ export class SegmentationManager {
     // Activation can fail if the segmentation exists globally but is not currently
     // represented on this viewport (e.g., after scan switching / viewport recreation).
     void this.ensureAttachedAndActivate(viewportId, segmentationId, segmentIndex);
+
+    // Deactivate tool if locked OR incompatible with the new segmentation type.
+    const segStore = useSegmentationStore.getState();
+    const activeTool = segStore.activeSegTool;
+    if (activeTool !== null && SEGMENTATION_TOOLS.has(activeTool as ToolName)) {
+      const locked = segmentationService.getSegmentLocked(segmentationId, segmentIndex);
+      const dicomType =
+        segStore.dicomTypeBySegmentationId[segmentationId]
+        ?? segmentationService.getPreferredDicomType(segmentationId);
+      const isToolIncompatible =
+        (dicomType === 'RTSTRUCT'
+          && LABELMAP_SEG_TOOLS.has(activeTool as ToolName)
+          && !CONTOUR_SEG_TOOLS.has(activeTool as ToolName))
+        || (dicomType === 'SEG'
+          && CONTOUR_SEG_TOOLS.has(activeTool as ToolName)
+          && !LABELMAP_SEG_TOOLS.has(activeTool as ToolName));
+
+      if (locked || isToolIncompatible) {
+        useViewerStore.getState().setActiveTool(ToolName.WindowLevel);
+      }
+    }
   }
 
   /** Ensure representation exists on the viewport, then activate deterministically. */
@@ -721,6 +748,24 @@ export class SegmentationManager {
    */
   userToggledLock(segmentationId: string, segmentIndex: number): void {
     segmentationService.toggleSegmentLocked(segmentationId, segmentIndex);
+
+    // Read the actual post-toggle lock state from Cornerstone rather than
+    // inferring from the cache (which can be uninitialized or out of sync).
+    const newLocked = segmentationService.getSegmentLocked(segmentationId, segmentIndex);
+    useSegmentationManagerStore.getState().setPresentation(segmentationId, segmentIndex, { locked: newLocked });
+
+    // If locking the currently active segment, switch Cornerstone back to
+    // WindowLevel so the tool is fully deactivated (not just the store cleared).
+    if (newLocked) {
+      const segStore = useSegmentationStore.getState();
+      if (
+        segStore.activeSegmentationId === segmentationId &&
+        segStore.activeSegmentIndex === segmentIndex &&
+        segStore.activeSegTool !== null
+      ) {
+        useViewerStore.getState().setActiveTool(ToolName.WindowLevel);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

The segment lock feature had 4 compounding bugs making it non-functional. This PR fixes all 4 and adds tool-type safety when switching between segmentation types.

### Bugs Fixed

- **A: Icons identical** — `IconLock` and `IconLockOpen` were visually indistinguishable at 12px. Redesigned the open-lock SVG shackle (raised arc) and added amber/zinc color differentiation.
- **B: Toggle lagged by 1 click** — `syncSegmentations()` read lock state from a stale presentation cache. Now reads directly from Cornerstone's `isSegmentIndexLocked()` API.
- **C: Contours ignored lock** — No contour tool in Cornerstone checks `annotation.isLocked`. Added application-level enforcement: locking deactivates the active tool (switches to WindowLevel) and disables tool buttons in the UI.
- **D: Labelmap lock only prevented overwrite** — Painting new voxels on a locked segment was allowed. Same application-level enforcement as C, plus a defense-in-depth guard in `toolService.setActiveTool()`.

### Additional: Tool-Type Mismatch Fix

Switching between segmentation types (labelmap ↔ contour) left the previous tool active even if incompatible (e.g., Rectangle tool drawing on a contour). `userSelectedSegmentation()` now checks tool-type compatibility using `LABELMAP_SEG_TOOLS` / `CONTOUR_SEG_TOOLS` and deactivates incompatible tools.

### Default Lock State

Loaded segmentations (DICOM SEG, RTSTRUCT) now start **locked** to prevent accidental edits. Newly created segments start **unlocked** for immediate editing.

### Files Changed

| File | Change |
|------|--------|
| `icons.tsx` | Redesigned `IconLockOpen` shackle to be clearly raised/open |
| `SegmentationPanel.tsx` | Amber lock color; disabled tool buttons when active segment locked; "Unlock segment to edit" message |
| `segmentationService.ts` | `syncSegmentations()`: read lock from Cornerstone API; `loadDicomSeg()`: loaded segments start locked |
| `rtStructService.ts` | `loadRtStructAsContours()`: loaded contour segments start locked |
| `SegmentationManager.ts` | `userToggledLock()`: switch to WindowLevel (not just store clear); `userSelectedSegmentation()`: deactivate on lock OR type mismatch |
| `toolService.ts` | `setActiveTool()`: guard against activating seg tool when active segment is locked |
| Test files | Updated mocks and expectations; added tests for lock deactivation and type-mismatch |

## Test plan

- [x] 422 tests pass (`npx vitest run`)
- [x] No type errors in modified files (`npx tsc --noEmit`)
- [x] No circular dependencies (verified import chain: `@shared/types/viewer` is pure constants, `viewerStore` accessed via runtime getter)
- [x] Load DICOM SEG → segments show amber locked icon, tools disabled
- [x] Load RTSTRUCT → segments show amber locked icon, tools disabled
- [x] Unlock loaded segment → zinc icon, tools enabled, can paint/draw
- [x] Create new segmentation → unlocked by default, tools work immediately
- [x] Lock active segment with brush active → brush deactivates
- [x] Lock active segment with rectangle active → rectangle deactivates
- [x] Select locked segment while tool is active → tool deactivates
- [x] Switch from labelmap (Rectangle active) to contour → Rectangle deactivates
- [x] Switch from contour (FreehandContour active) to labelmap → FreehandContour deactivates