### PR TITLE
Add Help menu with Quick Start Guide and Report an Issue

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,354 @@
+# Contextual Help Panel Content
+
+Quick start up guide for end users (clinicians/researchers, not developers).
+
+---
+
+## 1. XNAT Browser (Left Sidebar)
+
+**Panel header: XNAT Browser**
+
+Browse your XNAT repository to find and load scans.
+
+**Navigation**
+- Click a **project** to see its subjects, then a **subject** to see sessions, then a **session** to see scans.
+- Use the **breadcrumb** at the top to navigate back to any level.
+- Type in the **search bar** to filter items at the current level.
+
+**Loading Scans**
+- Click a scan to load it into the active viewport panel.
+- Drag a scan onto any viewport panel to load it there.
+- Hold **Shift** and click a scan to open it in MPR (multi-planar) mode.
+
+**Bookmarks**
+- Hover over a project, subject, or session and click the **pin icon** to bookmark it.
+- Access bookmarks from the **pin icon** in the toolbar.
+
+---
+
+## 2. Toolbar
+
+**Panel header: Toolbar**
+
+The toolbar provides navigation tools, viewport controls, and quick actions.
+
+**Navigation Tools**
+- **W/L** — Click and drag to adjust window width and level (brightness/contrast).
+- **Pan** — Click and drag to move the image.
+- **Zoom** — Click and drag to zoom in or out.
+- **Crosshairs** — Click to sync slice position across panels. Hold Shift and move for continuous sync.
+
+**Viewport Actions** (icon buttons, right side)
+- **Reset** — Restore the viewport to its original zoom, pan, rotation, and orientation.
+- **Invert** — Toggle grayscale inversion.
+- **Rotate 90°** — Rotate the image 90 degrees clockwise.
+- **Flip H / Flip V** — Flip the image horizontally or vertically.
+
+**Undo / Redo**
+- **Undo** (Ctrl+Z) — Undo the last segmentation or annotation edit.
+- **Redo** (Ctrl+Shift+Z) — Redo a previously undone edit.
+
+**Cine Playback** (far right of toolbar — may require a wider window to see)
+- Click **Play** to scroll through slices automatically.
+- Adjust the **FPS slider** to control playback speed (1–60 frames per second).
+
+---
+
+## 3. Layout & MPR
+
+**Panel header: Layout**
+
+**Viewport Layout**
+- Click the **layout button** in the toolbar to choose a grid arrangement: 1×1, 1×2, 2×1, 2×2, or a custom grid (up to 8×8).
+- Each panel can display a different scan. Drag scans from the XNAT Browser onto panels.
+- Click a panel to make it the **active panel** — tools and annotations apply to the active panel.
+
+**MPR Mode** (Multi-Planar Reconstruction)
+- Click **MPR** in the toolbar to enter MPR mode.
+- The viewport switches to a fixed 2×2 layout: **Axial** (top-left), **Sagittal** (top-right), **Coronal** (bottom-left), and the original **Stack** view (bottom-right).
+- Use crosshairs to navigate — clicking in one plane updates the others.
+- Click **MPR** again to exit and return to the standard layout.
+
+---
+
+## 4. W/L Presets
+
+**Panel header: Window/Level Presets**
+
+Quickly apply standard window/level settings optimized for different tissue types:
+
+| Preset | Window | Level | Best For |
+|--------|--------|-------|----------|
+| CT Soft Tissue | 400 | 40 | General soft tissue |
+| CT Lung | 1500 | -600 | Lung parenchyma |
+| CT Bone | 2500 | 480 | Bone structures |
+| CT Brain | 80 | 40 | Brain tissue |
+| CT Abdomen | 400 | 60 | Abdominal organs |
+
+You can also adjust window/level manually by selecting the **W/L** tool and dragging on the image.
+
+---
+
+## 5. Measurement Tools
+
+**Panel header: Measure**
+
+Click **Measure** in the toolbar to open the measurement tool menu. Select a tool, then click on the image to place it.
+
+| Tool | Description |
+|------|-------------|
+| **Length** | Measure the distance between two points. |
+| **Angle** | Measure the angle between three points. |
+| **Bidirectional** | Two perpendicular length measurements (e.g., tumor long and short axis). |
+| **Probe** | Place a point to read the pixel value (e.g., Hounsfield Units). |
+| **Ellipse ROI** | Draw an elliptical region and view area, mean, and standard deviation. |
+| **Rectangle ROI** | Draw a rectangular region with statistics. |
+| **Circle ROI** | Draw a circular region with statistics. |
+| **Freehand ROI** | Draw a freehand region with statistics. |
+| **Arrow** | Place an arrow annotation with an optional text label. |
+
+Measurements appear as interactive overlays directly on the image. Press **O** to open the Annotations list panel on the right, where you can click a measurement to select it or **Clear** to remove all. To export measurements as a CSV file, use the **Export** button in the toolbar → **Export Annotations**.
+
+---
+
+## 6. Segmentation Panel — Annotations Overview
+
+**Panel header: Annotations**
+
+This panel manages your segmentation and structure annotations.
+
+**Annotation Types**
+- **SEG** (purple badge) — Labelmap segmentation. Paints directly on voxels. Best for filled regions (tumors, organs).
+- **STRUCT** (green badge) — RT Structure Set. Draws contour outlines. Best for structure delineation.
+
+**Creating Annotations**
+- Click **+ SEG** to create a new segmentation, or **+ STRUCT** to create a new structure set.
+- Enter a name and click **Create**.
+
+**Loading Existing Annotations**
+- Annotations already saved on XNAT appear in the **Available** section at the top. Click one to load it.
+
+**Managing Annotations**
+- Click an annotation row to select it and activate its tools.
+- Double-click a label to **rename** it.
+- Click the **save icon** on a row to save locally or upload to XNAT.
+- Click **×** to remove an annotation from the viewer.
+- A blue dot next to the name indicates **unsaved changes**.
+- Click **Save All** to save all modified annotations at once.
+
+---
+
+## 7. Segmentation Panel — Segments
+
+**Panel header: Segments**
+
+Each annotation contains one or more segments (individual structures or regions).
+
+**Working with Segments**
+- Click a segment row to make it the **active segment** — painting tools will apply to this segment.
+- Each segment should represent **one anatomical structure** (e.g., "Left Lung," "Tumor").
+- Click **+ Add Segment** (or **+ Add Structure** for RTSTRUCT) to add a new segment.
+
+**Segment Controls** (icons on each segment row)
+- **Color swatch** — Click to change the segment's display color.
+- **Eye icon** — Toggle segment visibility on/off.
+- **Lock icon** — Lock the segment to prevent accidental edits. Unlock to resume editing.
+- **× icon** — Delete the segment.
+
+---
+
+## 8. Segmentation Panel — SEG Tools
+
+**Panel header: Labelmap Tools**
+
+These tools paint directly on the labelmap. Available when a **SEG** annotation is selected.
+
+**Painting Tools**
+- **Brush** — Freehand circular brush. Adjust size with the Brush Size slider.
+- **Eraser** — Erase painted regions. Same size control as Brush.
+- **Threshold Brush** — Paints only on pixels within a specified value range (e.g., Hounsfield Units). Set the range in the Threshold Range inputs below the tool grid.
+
+**Fill Tools**
+- **Circle Scissors** — Draw a circle to fill the enclosed region.
+- **Rectangle Scissors** — Draw a rectangle to fill the enclosed region.
+- **Sphere Scissors** — Fill a spherical region in 3D (affects multiple slices).
+- **Paint Fill** — Flood-fill a connected region of the same value.
+- **Contour Fill** — Draw a freehand contour outline, which is then filled into the labelmap automatically.
+
+**Smart Tools**
+- **Region Segment** — Click on a region to auto-segment it using intensity-based region growing.
+- **Region Segment+** — Enhanced region segmentation with improved boundary detection.
+- **Rect Threshold** — Draw a rectangle; only pixels within the threshold range are filled.
+- **Circle Threshold** — Draw a circle; only pixels within the threshold range are filled.
+
+**Tool Options**
+- **Brush Size** (1–50 px) — Controls the radius for Brush, Eraser, and Threshold Brush.
+- **Labelmap Opacity** (0–100%) — Controls how transparent the segmentation overlay appears.
+- **Threshold Range** — Set the minimum and maximum pixel values for threshold-based tools.
+
+---
+
+## 9. Segmentation Panel — RTSTRUCT Tools
+
+**Panel header: Contour Tools**
+
+These tools draw contour outlines. Available when a **STRUCT** (RT Structure Set) annotation is selected.
+
+**Drawing Tools**
+- **Freehand Contour** — Draw a contour by clicking and dragging freehand.
+- **Spline Contour** — Place control points; a smooth spline curve connects them. Choose the spline type (Catmull-Rom, Cardinal, B-Spline, or Linear) from the dropdown below.
+- **Livewire Contour** — Click to place anchor points; the contour automatically snaps to image edges between points.
+
+**Editing Tools**
+- **Sculptor** — Click and drag on an existing freehand contour to reshape it. For spline or livewire contours, the Sculptor will offer to convert them to freehand first (this is permanent).
+
+**Tool Options**
+- **Contour Thickness** (1–8 px) — Line width for contour display.
+- **Contour Opacity** (5–100%) — Transparency of contour lines.
+- **Spline Type** — Curve interpolation method (shown when Spline Contour is active).
+
+---
+
+## 10. Export Options
+
+**Panel header: Export**
+
+Click the **Export** icon in the toolbar to access export options.
+
+| Option | Description |
+|--------|-------------|
+| **Save as Image** | Save the current viewport as a PNG or JPEG file, including any visible annotations. |
+| **Copy to Clipboard** | Copy the current viewport image to the clipboard for pasting into other applications. |
+| **Save All Slices** | Export every slice in the current stack as individual PNG files. |
+| **Save DICOM File** | Download the raw DICOM file (.dcm) for the current slice. |
+| **Export Annotations** | Save all measurement annotations as a CSV report. |
+
+---
+
+## 11. DICOM Tags Panel
+
+**Panel header: DICOM Tags**
+
+View the DICOM metadata for the currently displayed image.
+
+- Use the **search bar** to find tags by name, tag number, or value.
+- Tags are grouped by DICOM module (Patient, Study, Series, Equipment, etc.). Click a group header to expand or collapse it.
+- Enable **Show private tags** to display vendor-specific proprietary tags.
+- Tag numbers are shown in standard DICOM format (e.g., `(0010,0010)` for Patient Name).
+
+---
+
+## 12. Viewport
+
+**Panel header: Viewport**
+
+**Slice Navigation**
+- Scroll the mouse wheel to move through slices.
+- Drag the **scroll slider** on the right edge of the viewport.
+- The current slice position is shown as "Im: {current}/{total}" in the overlay.
+
+**Overlay Information**
+- The four corners of the viewport display configurable metadata (patient name, series description, window/level, zoom, etc.).
+- Orientation markers (A/P, R/L, S/I) appear at the viewport edges.
+- Rulers along the bottom and left edges show physical measurements.
+- Overlay fields can be customized in **Settings → Overlay**.
+
+**Orientation**
+- Use the orientation dropdown (in the top-left overlay) to switch between Stack, Axial, Sagittal, and Coronal views.
+
+---
+
+## 13. Settings — Interpolation
+
+**Panel header: Between-Slice Interpolation**
+
+When enabled, painting on two or more separated slices will automatically fill the gap slices using the selected algorithm.
+
+- **Enable between-slice interpolation** — Master toggle. Turn off to disable all automatic gap-filling.
+- **Algorithm** — Choose the interpolation method:
+  - **Morphological (Raya-Udupa)** — Classic medical image interpolation. Interpolates inside-distance fields for better volume preservation and shape handling.
+  - **Signed Distance Field (SDF)** — Computes signed distance transforms on each anchor slice and blends them. Good for smooth, rounded structures.
+  - **Linear Blend** — Simple weighted average of anchor masks. Fast but may produce blocky results. Adjust the **Blend Threshold** slider to control fill aggressiveness.
+  - **Nearest Slice** — Copies the nearest anchor slice into each gap. No shape blending — useful for structures with sharp boundaries.
+
+**Tip:** Interpolation operates per-segment. Keep one anatomical structure per segment for best results.
+
+---
+
+## 14. Settings — File Backup
+
+**Panel header: Local File Backup**
+
+Automatically backs up your annotation work to local files at regular intervals.
+
+- **Enable local file backup** — Master toggle for automatic backups.
+- **Backup frequency** — How often backups run (5–120 seconds).
+- **Cache location** — Where backup files are stored on disk.
+
+**Deletion Safety**
+
+When deleting annotations from XNAT, you can optionally archive the DICOM file to a session resource folder before the scan is removed.
+
+- **Archive to session resource before deleting** — Enable this checkbox to copy the file to a resource folder before deletion.
+- **Resource folder name** — The XNAT resource folder where archived copies are stored (defaults to "trash").
+
+**Cached Backups** — Lists all locally stored backup files grouped by session. For each entry you can:
+- **Recover** — Restore the backed-up annotation into the viewer.
+- **Open** — Open the backup file location on disk.
+- **Delete** — Remove the local backup file.
+
+---
+
+## 15. Settings — Hotkeys
+
+**Panel header: Keyboard Shortcuts**
+
+Customize keyboard shortcuts for tools and actions.
+
+- Select an **action** from the dropdown, choose the **key** and any **modifier keys** (Ctrl, Shift, Alt, Meta), then click **Set Override**.
+- Click **Clear Selected** to remove a single override, or **Reset Hotkeys** to restore all defaults.
+- Your custom overrides appear in the list below and persist across sessions.
+
+---
+
+## 16. Settings — Overlay
+
+**Panel header: Viewport Overlay**
+
+Configure what information appears on the viewport.
+
+- **Show viewport context overlay** — Master toggle for all overlay text.
+- **Show horizontal ruler / Show vertical ruler** — Toggle measurement rulers on viewport edges.
+- **Show A/P and L/R indicators** — Toggle anatomical orientation markers.
+- **Corner fields** — For each corner (top-left, top-right, bottom-left, bottom-right), check the metadata fields you want displayed: patient name, study date, series description, window/level, zoom, slice location, and more.
+
+---
+
+## 17. Settings — Annotation Defaults
+
+**Panel header: Annotation Defaults**
+
+Set default appearance and behavior for new annotations.
+
+- **Default brush size** — Starting brush radius (1–50 px) for new segments.
+- **Default contour thickness** — Starting line width (1–8 px) for new structure contours.
+- **Default segment opacity** — Starting overlay transparency (0–100%).
+- **Default display mask outlines** — Whether to show outlines on labelmap segments by default.
+- **Automatically display annotations** — When enabled, annotations are shown on the viewport as soon as they are loaded.
+- **Default color sequence** — Edit the color palette used when adding new segments.
+- **Scissors default mode** — Whether scissors tools default to "Fill" or "Erase" mode.
+- **Preview toggle / Preview color** — Show a preview overlay when using scissors tools, in the specified color.
+
+---
+
+## 18. Settings — Issue Report
+
+**Panel header: Issue Report**
+
+Generate a diagnostic report to help troubleshoot problems.
+
+- Add any **notes** about what you were doing when the issue occurred.
+- Click **Refresh Report** to regenerate the system information.
+- Click **Copy Report** to copy the full report to your clipboard for sharing with support.
+
+The report includes system information, browser details, loaded scans, and current application state.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -135,6 +135,20 @@ function buildAppMenu(): void {
         ]),
       ],
     },
+    // Help menu
+    {
+      label: 'Help',
+      submenu: [
+        {
+          label: 'Quick Start Guide',
+          click: () => mainWindow?.webContents.send(IPC.HELP_OPEN_GUIDE),
+        },
+        {
+          label: 'Report an Issue',
+          click: () => mainWindow?.webContents.send(IPC.HELP_OPEN_ISSUE_REPORT),
+        },
+      ],
+    },
   ];
 
   const menu = Menu.buildFromTemplate(template);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -171,7 +171,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
 
   on: (channel: string, callback: (...args: unknown[]) => void) => {
-    const allowedChannels = [IPC.XNAT_SESSION_EXPIRED];
+    const allowedChannels = [IPC.XNAT_SESSION_EXPIRED, IPC.HELP_OPEN_GUIDE, IPC.HELP_OPEN_ISSUE_REPORT];
     if (!allowedChannels.includes(channel as any)) {
       console.warn(`[preload] Blocked IPC listener for unknown channel: ${channel}`);
       return () => {};

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -656,6 +656,20 @@ export default function App() {
   const [backupBannerCount, setBackupBannerCount] = useState(0);
   const [backupBannerDismissed, setBackupBannerDismissed] = useState(false);
   const [openSettingsToBackup, setOpenSettingsToBackup] = useState(false);
+  const [openHelpGuide, setOpenHelpGuide] = useState(false);
+  const [openSettingsToIssue, setOpenSettingsToIssue] = useState(false);
+
+  // Listen for Help menu IPC events from the main process
+  useEffect(() => {
+    const api = (window as any).electronAPI;
+    if (!api?.on) return;
+    const unsubGuide = api.on('help:open-guide', () => setOpenHelpGuide(true));
+    const unsubIssue = api.on('help:open-issue-report', () => setOpenSettingsToIssue(true));
+    return () => {
+      unsubGuide?.();
+      unsubIssue?.();
+    };
+  }, []);
 
   // Connection state
   const connectionStatus = useConnectionStore((s) => s.status);
@@ -2708,6 +2722,10 @@ export default function App() {
         onRecoverBackup={handleRecoverBackup}
         openSettingsToBackup={openSettingsToBackup}
         onSettingsToBackupConsumed={() => setOpenSettingsToBackup(false)}
+        openHelpGuide={openHelpGuide}
+        onHelpGuideConsumed={() => setOpenHelpGuide(false)}
+        openSettingsToIssue={openSettingsToIssue}
+        onSettingsToIssueConsumed={() => setOpenSettingsToIssue(false)}
         mprSourceImageIds={mprSourceImageIds}
         leftSlot={
           <>

--- a/src/renderer/components/help/HelpModal.tsx
+++ b/src/renderer/components/help/HelpModal.tsx
@@ -1,0 +1,104 @@
+/**
+ * HelpModal — Quick Start Guide modal.
+ *
+ * Mirrors the SettingsModal layout: left sidebar with grouped tabs,
+ * right scrollable content pane. Content is defined in helpGuideContent.tsx.
+ */
+import { useState, useEffect } from 'react';
+import { IconClose } from '../icons';
+import { GUIDE_SECTIONS, GUIDE_GROUPS } from './helpGuideContent';
+
+interface HelpModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function HelpModal({ open, onClose }: HelpModalProps) {
+  const [activeSection, setActiveSection] = useState(GUIDE_SECTIONS[0].id);
+
+  // Dismiss on Escape
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const current = GUIDE_SECTIONS.find((s) => s.id === activeSection) ?? GUIDE_SECTIONS[0];
+
+  return (
+    <div className="fixed inset-0 z-[120] flex items-center justify-center p-4">
+      {/* Backdrop */}
+      <button
+        type="button"
+        aria-label="Close guide"
+        className="absolute inset-0 bg-zinc-950/70"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div className="relative w-full max-w-4xl h-[min(80vh,560px)] bg-zinc-900 border border-zinc-700 rounded-xl shadow-2xl overflow-hidden flex">
+        {/* Sidebar */}
+        <div className="w-44 border-r border-zinc-800 bg-zinc-950/50 flex flex-col overflow-hidden">
+          <div className="px-3 py-2.5 text-[11px] uppercase tracking-wide text-zinc-500 shrink-0">
+            Quick Start Guide
+          </div>
+          <div className="flex-1 overflow-y-auto px-2 pb-2 space-y-2">
+            {GUIDE_GROUPS.map((group) => {
+              const sections = GUIDE_SECTIONS.filter((s) => s.group === group);
+              if (sections.length === 0) return null;
+              return (
+                <div key={group}>
+                  <div className="px-1 pt-1.5 pb-1 text-[10px] uppercase tracking-wider text-zinc-600 font-medium">
+                    {group}
+                  </div>
+                  <div className="space-y-0.5">
+                    {sections.map((section) => (
+                      <button
+                        key={section.id}
+                        type="button"
+                        onClick={() => setActiveSection(section.id)}
+                        className={`w-full text-left px-2.5 py-1.5 rounded text-xs transition-colors ${
+                          activeSection === section.id
+                            ? 'bg-blue-600/20 text-blue-300'
+                            : 'text-zinc-300 hover:bg-zinc-800 hover:text-white'
+                        }`}
+                      >
+                        {section.title}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Content area */}
+        <div className="flex-1 min-w-0 flex flex-col">
+          {/* Header */}
+          <div className="h-11 shrink-0 border-b border-zinc-800 px-4 flex items-center justify-between">
+            <h2 className="text-sm font-medium text-zinc-100">{current.title}</h2>
+            <button
+              type="button"
+              onClick={onClose}
+              className="p-1.5 rounded text-zinc-400 hover:text-white hover:bg-zinc-800 transition-colors"
+              title="Close"
+            >
+              <IconClose className="w-4 h-4" />
+            </button>
+          </div>
+
+          {/* Scrollable content */}
+          <div className="flex-1 overflow-y-auto p-4">
+            {current.content}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/help/helpGuideContent.tsx
+++ b/src/renderer/components/help/helpGuideContent.tsx
@@ -1,0 +1,527 @@
+/**
+ * helpGuideContent — All 18 sections of the Quick Start Guide.
+ *
+ * Content is plain JSX + Tailwind. Each section is a self-contained block
+ * that renders inside the HelpModal's scrollable content area.
+ *
+ * Source of truth: docs/user-guide.md (user-verified).
+ */
+
+// ─── Types ──────────────────────────────────────────────────────
+
+export interface GuideSection {
+  id: string;
+  title: string;
+  group: string;
+  content: React.ReactNode;
+}
+
+// ─── Group ordering ─────────────────────────────────────────────
+
+export const GUIDE_GROUPS = [
+  'Browsing & Navigation',
+  'Viewing',
+  'Measurements & Export',
+  'Segmentation',
+  'Settings',
+] as const;
+
+// ─── Shared styling helpers ─────────────────────────────────────
+
+const h3 = 'text-xs font-semibold text-zinc-200 mt-3 mb-1.5';
+const p = 'text-[11px] text-zinc-400 leading-relaxed';
+const ul = 'text-[11px] text-zinc-400 leading-relaxed list-disc list-outside ml-3.5 space-y-1';
+const li = ''; // inherit from ul
+const bold = 'text-zinc-300 font-medium';
+const tip = 'text-[11px] text-blue-300/80 bg-blue-950/30 border border-blue-900/40 rounded px-2.5 py-1.5 mt-2';
+const table = 'w-full text-[11px] text-zinc-400 mt-1.5';
+const th = 'text-left text-zinc-300 font-medium pb-1.5 pr-3 border-b border-zinc-800';
+const td = 'py-1.5 pr-3 border-b border-zinc-800/50 align-top';
+
+// ─── Sections ───────────────────────────────────────────────────
+
+export const GUIDE_SECTIONS: GuideSection[] = [
+  // ── Browsing & Navigation ───────────────────────────────────
+  {
+    id: 'xnat-browser',
+    title: 'XNAT Browser',
+    group: 'Browsing & Navigation',
+    content: (
+      <div className="space-y-2">
+        <p className={p}>Browse your XNAT repository to find and load scans.</p>
+
+        <h3 className={h3}>Navigation</h3>
+        <ul className={ul}>
+          <li className={li}>Click a <strong className={bold}>project</strong> to see its subjects, then a <strong className={bold}>subject</strong> to see sessions, then a <strong className={bold}>session</strong> to see scans.</li>
+          <li className={li}>Use the <strong className={bold}>breadcrumb</strong> at the top to navigate back to any level.</li>
+          <li className={li}>Type in the <strong className={bold}>search bar</strong> to filter items at the current level.</li>
+        </ul>
+
+        <h3 className={h3}>Loading Scans</h3>
+        <ul className={ul}>
+          <li className={li}>Click a scan to load it into the active viewport panel.</li>
+          <li className={li}>Drag a scan onto any viewport panel to load it there.</li>
+          <li className={li}>Hold <strong className={bold}>Shift</strong> and click a scan to open it in MPR (multi-planar) mode.</li>
+        </ul>
+
+        <h3 className={h3}>Bookmarks</h3>
+        <ul className={ul}>
+          <li className={li}>Hover over a project, subject, or session and click the <strong className={bold}>pin icon</strong> to bookmark it.</li>
+          <li className={li}>Access bookmarks from the <strong className={bold}>pin icon</strong> in the toolbar.</li>
+        </ul>
+      </div>
+    ),
+  },
+  {
+    id: 'toolbar',
+    title: 'Toolbar',
+    group: 'Browsing & Navigation',
+    content: (
+      <div className="space-y-2">
+        <p className={p}>The toolbar provides navigation tools, viewport controls, and quick actions.</p>
+
+        <h3 className={h3}>Navigation Tools</h3>
+        <ul className={ul}>
+          <li className={li}><strong className={bold}>W/L</strong> — Click and drag to adjust window width and level (brightness/contrast).</li>
+          <li className={li}><strong className={bold}>Pan</strong> — Click and drag to move the image.</li>
+          <li className={li}><strong className={bold}>Zoom</strong> — Click and drag to zoom in or out.</li>
+          <li className={li}><strong className={bold}>Crosshairs</strong> — Click to sync slice position across panels. Hold Shift and move for continuous sync.</li>
+        </ul>
+
+        <h3 className={h3}>Viewport Actions</h3>
+        <ul className={ul}>
+          <li className={li}><strong className={bold}>Reset</strong> — Restore the viewport to its original zoom, pan, rotation, and orientation.</li>
+          <li className={li}><strong className={bold}>Invert</strong> — Toggle grayscale inversion.</li>
+          <li className={li}><strong className={bold}>Rotate 90&deg;</strong> — Rotate the image 90 degrees clockwise.</li>
+          <li className={li}><strong className={bold}>Flip H / Flip V</strong> — Flip the image horizontally or vertically.</li>
+        </ul>
+
+        <h3 className={h3}>Undo / Redo</h3>
+        <ul className={ul}>
+          <li className={li}><strong className={bold}>Undo</strong> (Ctrl+Z) — Undo the last segmentation or annotation edit.</li>
+          <li className={li}><strong className={bold}>Redo</strong> (Ctrl+Shift+Z) — Redo a previously undone edit.</li>
+        </ul>
+
+        <h3 className={h3}>Cine Playback</h3>
+        <ul className={ul}>
+          <li className={li}>Click <strong className={bold}>Play</strong> to scroll through slices automatically.</li>
+          <li className={li}>Adjust the <strong className={bold}>FPS slider</strong> to control playback speed (1&ndash;60 frames per second).</li>
+        </ul>
+        <p className={tip}>Cine controls are on the far right of the toolbar and may require a wider window to see.</p>
+      </div>
+    ),
+  },
+  {
+    id: 'layout-mpr',
+    title: 'Layout & MPR',
+    group: 'Browsing & Navigation',
+    content: (
+      <div className="space-y-2">
+        <h3 className={h3}>Viewport Layout</h3>
+        <ul className={ul}>
+          <li className={li}>Click the <strong className={bold}>layout button</strong> in the toolbar to choose a grid arrangement: 1&times;1, 1&times;2, 2&times;1, 2&times;2, or a custom grid (up to 8&times;8).</li>
+          <li className={li}>Each panel can display a different scan. Drag scans from the XNAT Browser onto panels.</li>
+          <li className={li}>Click a panel to make it the <strong className={bold}>active panel</strong> — tools and annotations apply to the active panel.</li>
+        </ul>
+
+        <h3 className={h3}>MPR Mode (Multi-Planar Reconstruction)</h3>
+        <ul className={ul}>
+          <li className={li}>Click <strong className={bold}>MPR</strong> in the toolbar to enter MPR mode.</li>
+          <li className={li}>The viewport switches to a fixed 2&times;2 layout: <strong className={bold}>Axial</strong> (top-left), <strong className={bold}>Sagittal</strong> (top-right), <strong className={bold}>Coronal</strong> (bottom-left), and the original <strong className={bold}>Stack</strong> view (bottom-right).</li>
+          <li className={li}>Use crosshairs to navigate — clicking in one plane updates the others.</li>
+          <li className={li}>Click <strong className={bold}>MPR</strong> again to exit and return to the standard layout.</li>
+        </ul>
+      </div>
+    ),
+  },
+
+  // ── Viewing ─────────────────────────────────────────────────
+  {
+    id: 'viewport',
+    title: 'Viewport',
+    group: 'Viewing',
+    content: (
+      <div className="space-y-2">
+        <h3 className={h3}>Slice Navigation</h3>
+        <ul className={ul}>
+          <li className={li}>Scroll the mouse wheel to move through slices.</li>
+          <li className={li}>Drag the <strong className={bold}>scroll slider</strong> on the right edge of the viewport.</li>
+          <li className={li}>The current slice position is shown as &ldquo;Im: current/total&rdquo; in the overlay.</li>
+        </ul>
+
+        <h3 className={h3}>Overlay Information</h3>
+        <ul className={ul}>
+          <li className={li}>The four corners of the viewport display configurable metadata (patient name, series description, window/level, zoom, etc.).</li>
+          <li className={li}>Orientation markers (A/P, R/L, S/I) appear at the viewport edges.</li>
+          <li className={li}>Rulers along the bottom and left edges show physical measurements.</li>
+          <li className={li}>Overlay fields can be customized in <strong className={bold}>Settings &rarr; Overlay</strong>.</li>
+        </ul>
+
+        <h3 className={h3}>Orientation</h3>
+        <ul className={ul}>
+          <li className={li}>Use the orientation dropdown (in the top-left overlay) to switch between Stack, Axial, Sagittal, and Coronal views.</li>
+        </ul>
+      </div>
+    ),
+  },
+  {
+    id: 'wl-presets',
+    title: 'W/L Presets',
+    group: 'Viewing',
+    content: (
+      <div className="space-y-2">
+        <p className={p}>Quickly apply standard window/level settings optimized for different tissue types.</p>
+
+        <table className={table}>
+          <thead>
+            <tr>
+              <th className={th}>Preset</th>
+              <th className={th}>Window</th>
+              <th className={th}>Level</th>
+              <th className={th}>Best For</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td className={td}>CT Soft Tissue</td><td className={td}>400</td><td className={td}>40</td><td className={td}>General soft tissue</td></tr>
+            <tr><td className={td}>CT Lung</td><td className={td}>1500</td><td className={td}>-600</td><td className={td}>Lung parenchyma</td></tr>
+            <tr><td className={td}>CT Bone</td><td className={td}>2500</td><td className={td}>480</td><td className={td}>Bone structures</td></tr>
+            <tr><td className={td}>CT Brain</td><td className={td}>80</td><td className={td}>40</td><td className={td}>Brain tissue</td></tr>
+            <tr><td className={td}>CT Abdomen</td><td className={td}>400</td><td className={td}>60</td><td className={td}>Abdominal organs</td></tr>
+          </tbody>
+        </table>
+
+        <p className={p}>You can also adjust window/level manually by selecting the <strong className={bold}>W/L</strong> tool and dragging on the image.</p>
+      </div>
+    ),
+  },
+  {
+    id: 'dicom-tags',
+    title: 'DICOM Tags',
+    group: 'Viewing',
+    content: (
+      <div className="space-y-2">
+        <p className={p}>View the DICOM metadata for the currently displayed image.</p>
+        <ul className={ul}>
+          <li className={li}>Use the <strong className={bold}>search bar</strong> to find tags by name, tag number, or value.</li>
+          <li className={li}>Tags are grouped by DICOM module (Patient, Study, Series, Equipment, etc.). Click a group header to expand or collapse it.</li>
+          <li className={li}>Enable <strong className={bold}>Show private tags</strong> to display vendor-specific proprietary tags.</li>
+          <li className={li}>Tag numbers are shown in standard DICOM format (e.g., <code className="text-zinc-300 bg-zinc-800 px-1 rounded text-[10px]">(0010,0010)</code> for Patient Name).</li>
+        </ul>
+      </div>
+    ),
+  },
+
+  // ── Measurements & Export ───────────────────────────────────
+  {
+    id: 'measurement-tools',
+    title: 'Measurement Tools',
+    group: 'Measurements & Export',
+    content: (
+      <div className="space-y-2">
+        <p className={p}>Click <strong className={bold}>Measure</strong> in the toolbar to open the measurement tool menu. Select a tool, then click on the image to place it.</p>
+
+        <table className={table}>
+          <thead>
+            <tr>
+              <th className={th}>Tool</th>
+              <th className={th}>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td className={td}><strong className={bold}>Length</strong></td><td className={td}>Measure the distance between two points.</td></tr>
+            <tr><td className={td}><strong className={bold}>Angle</strong></td><td className={td}>Measure the angle between three points.</td></tr>
+            <tr><td className={td}><strong className={bold}>Bidirectional</strong></td><td className={td}>Two perpendicular length measurements (e.g., tumor long and short axis).</td></tr>
+            <tr><td className={td}><strong className={bold}>Probe</strong></td><td className={td}>Place a point to read the pixel value (e.g., Hounsfield Units).</td></tr>
+            <tr><td className={td}><strong className={bold}>Ellipse ROI</strong></td><td className={td}>Draw an elliptical region and view area, mean, and standard deviation.</td></tr>
+            <tr><td className={td}><strong className={bold}>Rectangle ROI</strong></td><td className={td}>Draw a rectangular region with statistics.</td></tr>
+            <tr><td className={td}><strong className={bold}>Circle ROI</strong></td><td className={td}>Draw a circular region with statistics.</td></tr>
+            <tr><td className={td}><strong className={bold}>Freehand ROI</strong></td><td className={td}>Draw a freehand region with statistics.</td></tr>
+            <tr><td className={td}><strong className={bold}>Arrow</strong></td><td className={td}>Place an arrow annotation with an optional text label.</td></tr>
+          </tbody>
+        </table>
+
+        <p className={p}>Measurements appear as interactive overlays directly on the image. Press <strong className={bold}>O</strong> to open the Annotations list panel on the right, where you can click a measurement to select it or <strong className={bold}>Clear</strong> to remove all. To export measurements as a CSV file, use the <strong className={bold}>Export</strong> button in the toolbar &rarr; <strong className={bold}>Export Annotations</strong>.</p>
+      </div>
+    ),
+  },
+  {
+    id: 'export',
+    title: 'Export',
+    group: 'Measurements & Export',
+    content: (
+      <div className="space-y-2">
+        <p className={p}>Click the <strong className={bold}>Export</strong> icon in the toolbar to access export options.</p>
+
+        <table className={table}>
+          <thead>
+            <tr>
+              <th className={th}>Option</th>
+              <th className={th}>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td className={td}><strong className={bold}>Save as Image</strong></td><td className={td}>Save the current viewport as a PNG or JPEG file, including any visible annotations.</td></tr>
+            <tr><td className={td}><strong className={bold}>Copy to Clipboard</strong></td><td className={td}>Copy the current viewport image to the clipboard for pasting into other applications.</td></tr>
+            <tr><td className={td}><strong className={bold}>Save All Slices</strong></td><td className={td}>Export every slice in the current stack as individual PNG files.</td></tr>
+            <tr><td className={td}><strong className={bold}>Save DICOM File</strong></td><td className={td}>Download the raw DICOM file (.dcm) for the current slice.</td></tr>
+            <tr><td className={td}><strong className={bold}>Export Annotations</strong></td><td className={td}>Save all measurement annotations as a CSV report.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    ),
+  },
+
+  // ── Segmentation ────────────────────────────────────────────
+  {
+    id: 'seg-overview',
+    title: 'Annotations Overview',
+    group: 'Segmentation',
+    content: (
+      <div className="space-y-2">
+        <p className={p}>This panel manages your segmentation and structure annotations.</p>
+
+        <h3 className={h3}>Annotation Types</h3>
+        <ul className={ul}>
+          <li className={li}><strong className={bold}>SEG</strong> (purple badge) — Labelmap segmentation. Paints directly on voxels. Best for filled regions (tumors, organs).</li>
+          <li className={li}><strong className={bold}>STRUCT</strong> (green badge) — RT Structure Set. Draws contour outlines. Best for structure delineation.</li>
+        </ul>
+
+        <h3 className={h3}>Creating Annotations</h3>
+        <ul className={ul}>
+          <li className={li}>Click <strong className={bold}>+ SEG</strong> to create a new segmentation, or <strong className={bold}>+ STRUCT</strong> to create a new structure set.</li>
+          <li className={li}>Enter a name and click <strong className={bold}>Create</strong>.</li>
+        </ul>
+
+        <h3 className={h3}>Loading Existing Annotations</h3>
+        <ul className={ul}>
+          <li className={li}>Annotations already saved on XNAT appear in the <strong className={bold}>Available</strong> section at the top. Click one to load it.</li>
+        </ul>
+
+        <h3 className={h3}>Managing Annotations</h3>
+        <ul className={ul}>
+          <li className={li}>Click an annotation row to select it and activate its tools.</li>
+          <li className={li}>Double-click a label to <strong className={bold}>rename</strong> it.</li>
+          <li className={li}>Click the <strong className={bold}>save icon</strong> on a row to save locally or upload to XNAT.</li>
+          <li className={li}>Click <strong className={bold}>&times;</strong> to remove an annotation from the viewer.</li>
+          <li className={li}>A blue dot next to the name indicates <strong className={bold}>unsaved changes</strong>.</li>
+          <li className={li}>Click <strong className={bold}>Save All</strong> to save all modified annotations at once.</li>
+        </ul>
+      </div>
+    ),
+  },
+  {
+    id: 'seg-segments',
+    title: 'Segments',
+    group: 'Segmentation',
+    content: (
+      <div className="space-y-2">
+        <p className={p}>Each annotation contains one or more segments (individual structures or regions).</p>
+
+        <h3 className={h3}>Working with Segments</h3>
+        <ul className={ul}>
+          <li className={li}>Click a segment row to make it the <strong className={bold}>active segment</strong> — painting tools will apply to this segment.</li>
+          <li className={li}>Each segment should represent <strong className={bold}>one anatomical structure</strong> (e.g., &ldquo;Left Lung,&rdquo; &ldquo;Tumor&rdquo;).</li>
+          <li className={li}>Click <strong className={bold}>+ Add Segment</strong> (or <strong className={bold}>+ Add Structure</strong> for RTSTRUCT) to add a new segment.</li>
+        </ul>
+
+        <h3 className={h3}>Segment Controls</h3>
+        <ul className={ul}>
+          <li className={li}><strong className={bold}>Color swatch</strong> — Click to change the segment&apos;s display color.</li>
+          <li className={li}><strong className={bold}>Eye icon</strong> — Toggle segment visibility on/off.</li>
+          <li className={li}><strong className={bold}>Lock icon</strong> — Lock the segment to prevent accidental edits. Unlock to resume editing.</li>
+          <li className={li}><strong className={bold}>&times; icon</strong> — Delete the segment.</li>
+        </ul>
+      </div>
+    ),
+  },
+  {
+    id: 'seg-labelmap-tools',
+    title: 'Labelmap Tools',
+    group: 'Segmentation',
+    content: (
+      <div className="space-y-2">
+        <p className={p}>These tools paint directly on the labelmap. Available when a <strong className={bold}>SEG</strong> annotation is selected.</p>
+
+        <h3 className={h3}>Painting Tools</h3>
+        <ul className={ul}>
+          <li className={li}><strong className={bold}>Brush</strong> — Freehand circular brush. Adjust size with the Brush Size slider.</li>
+          <li className={li}><strong className={bold}>Eraser</strong> — Erase painted regions. Same size control as Brush.</li>
+          <li className={li}><strong className={bold}>Threshold Brush</strong> — Paints only on pixels within a specified value range (e.g., Hounsfield Units). Set the range in the Threshold Range inputs below the tool grid.</li>
+        </ul>
+
+        <h3 className={h3}>Fill Tools</h3>
+        <ul className={ul}>
+          <li className={li}><strong className={bold}>Circle Scissors</strong> — Draw a circle to fill the enclosed region.</li>
+          <li className={li}><strong className={bold}>Rectangle Scissors</strong> — Draw a rectangle to fill the enclosed region.</li>
+          <li className={li}><strong className={bold}>Sphere Scissors</strong> — Fill a spherical region in 3D (affects multiple slices).</li>
+          <li className={li}><strong className={bold}>Paint Fill</strong> — Flood-fill a connected region of the same value.</li>
+          <li className={li}><strong className={bold}>Contour Fill</strong> — Draw a freehand contour outline, which is then filled into the labelmap automatically.</li>
+        </ul>
+
+        <h3 className={h3}>Smart Tools</h3>
+        <ul className={ul}>
+          <li className={li}><strong className={bold}>Region Segment</strong> — Click on a region to auto-segment it using intensity-based region growing.</li>
+          <li className={li}><strong className={bold}>Region Segment+</strong> — Enhanced region segmentation with improved boundary detection.</li>
+          <li className={li}><strong className={bold}>Rect Threshold</strong> — Draw a rectangle; only pixels within the threshold range are filled.</li>
+          <li className={li}><strong className={bold}>Circle Threshold</strong> — Draw a circle; only pixels within the threshold range are filled.</li>
+        </ul>
+
+        <h3 className={h3}>Tool Options</h3>
+        <ul className={ul}>
+          <li className={li}><strong className={bold}>Brush Size</strong> (1&ndash;50 px) — Controls the radius for Brush, Eraser, and Threshold Brush.</li>
+          <li className={li}><strong className={bold}>Labelmap Opacity</strong> (0&ndash;100%) — Controls how transparent the segmentation overlay appears.</li>
+          <li className={li}><strong className={bold}>Threshold Range</strong> — Set the minimum and maximum pixel values for threshold-based tools.</li>
+        </ul>
+      </div>
+    ),
+  },
+  {
+    id: 'seg-contour-tools',
+    title: 'Contour Tools',
+    group: 'Segmentation',
+    content: (
+      <div className="space-y-2">
+        <p className={p}>These tools draw contour outlines. Available when a <strong className={bold}>STRUCT</strong> (RT Structure Set) annotation is selected.</p>
+
+        <h3 className={h3}>Drawing Tools</h3>
+        <ul className={ul}>
+          <li className={li}><strong className={bold}>Freehand Contour</strong> — Draw a contour by clicking and dragging freehand.</li>
+          <li className={li}><strong className={bold}>Spline Contour</strong> — Place control points; a smooth spline curve connects them. Choose the spline type (Catmull-Rom, Cardinal, B-Spline, or Linear) from the dropdown below.</li>
+          <li className={li}><strong className={bold}>Livewire Contour</strong> — Click to place anchor points; the contour automatically snaps to image edges between points.</li>
+        </ul>
+
+        <h3 className={h3}>Editing Tools</h3>
+        <ul className={ul}>
+          <li className={li}><strong className={bold}>Sculptor</strong> — Click and drag on an existing freehand contour to reshape it. For spline or livewire contours, the Sculptor will offer to convert them to freehand first (this is permanent).</li>
+        </ul>
+
+        <h3 className={h3}>Tool Options</h3>
+        <ul className={ul}>
+          <li className={li}><strong className={bold}>Contour Thickness</strong> (1&ndash;8 px) — Line width for contour display.</li>
+          <li className={li}><strong className={bold}>Contour Opacity</strong> (5&ndash;100%) — Transparency of contour lines.</li>
+          <li className={li}><strong className={bold}>Spline Type</strong> — Curve interpolation method (shown when Spline Contour is active).</li>
+        </ul>
+      </div>
+    ),
+  },
+
+  // ── Settings ────────────────────────────────────────────────
+  {
+    id: 'settings-hotkeys',
+    title: 'Hotkeys',
+    group: 'Settings',
+    content: (
+      <div className="space-y-2">
+        <p className={p}>Customize keyboard shortcuts for tools and actions.</p>
+        <ul className={ul}>
+          <li className={li}>Select an <strong className={bold}>action</strong> from the dropdown, choose the <strong className={bold}>key</strong> and any <strong className={bold}>modifier keys</strong> (Ctrl, Shift, Alt, Meta), then click <strong className={bold}>Set Override</strong>.</li>
+          <li className={li}>Click <strong className={bold}>Clear Selected</strong> to remove a single override, or <strong className={bold}>Reset Hotkeys</strong> to restore all defaults.</li>
+          <li className={li}>Your custom overrides appear in the list below and persist across sessions.</li>
+        </ul>
+      </div>
+    ),
+  },
+  {
+    id: 'settings-overlay',
+    title: 'Overlay',
+    group: 'Settings',
+    content: (
+      <div className="space-y-2">
+        <p className={p}>Configure what information appears on the viewport.</p>
+        <ul className={ul}>
+          <li className={li}><strong className={bold}>Show viewport context overlay</strong> — Master toggle for all overlay text.</li>
+          <li className={li}><strong className={bold}>Show horizontal ruler / Show vertical ruler</strong> — Toggle measurement rulers on viewport edges.</li>
+          <li className={li}><strong className={bold}>Show A/P and L/R indicators</strong> — Toggle anatomical orientation markers.</li>
+          <li className={li}><strong className={bold}>Corner fields</strong> — For each corner (top-left, top-right, bottom-left, bottom-right), check the metadata fields you want displayed: patient name, study date, series description, window/level, zoom, slice location, and more.</li>
+        </ul>
+      </div>
+    ),
+  },
+  {
+    id: 'settings-annotation',
+    title: 'Annotation Defaults',
+    group: 'Settings',
+    content: (
+      <div className="space-y-2">
+        <p className={p}>Set default appearance and behavior for new annotations.</p>
+        <ul className={ul}>
+          <li className={li}><strong className={bold}>Default brush size</strong> — Starting brush radius (1&ndash;50 px) for new segments.</li>
+          <li className={li}><strong className={bold}>Default contour thickness</strong> — Starting line width (1&ndash;8 px) for new structure contours.</li>
+          <li className={li}><strong className={bold}>Default segment opacity</strong> — Starting overlay transparency (0&ndash;100%).</li>
+          <li className={li}><strong className={bold}>Default display mask outlines</strong> — Whether to show outlines on labelmap segments by default.</li>
+          <li className={li}><strong className={bold}>Automatically display annotations</strong> — When enabled, annotations are shown on the viewport as soon as they are loaded.</li>
+          <li className={li}><strong className={bold}>Default color sequence</strong> — Edit the color palette used when adding new segments.</li>
+          <li className={li}><strong className={bold}>Scissors default mode</strong> — Whether scissors tools default to &ldquo;Fill&rdquo; or &ldquo;Erase&rdquo; mode.</li>
+          <li className={li}><strong className={bold}>Preview toggle / Preview color</strong> — Show a preview overlay when using scissors tools, in the specified color.</li>
+        </ul>
+      </div>
+    ),
+  },
+  {
+    id: 'settings-interpolation',
+    title: 'Interpolation',
+    group: 'Settings',
+    content: (
+      <div className="space-y-2">
+        <p className={p}>When enabled, painting on two or more separated slices will automatically fill the gap slices using the selected algorithm.</p>
+        <ul className={ul}>
+          <li className={li}><strong className={bold}>Enable between-slice interpolation</strong> — Master toggle. Turn off to disable all automatic gap-filling.</li>
+          <li className={li}><strong className={bold}>Algorithm</strong> — Choose the interpolation method:</li>
+        </ul>
+        <ul className={`${ul} ml-7`}>
+          <li className={li}><strong className={bold}>Morphological (Raya-Udupa)</strong> — Classic medical image interpolation. Interpolates inside-distance fields for better volume preservation and shape handling.</li>
+          <li className={li}><strong className={bold}>Signed Distance Field (SDF)</strong> — Computes signed distance transforms on each anchor slice and blends them. Good for smooth, rounded structures.</li>
+          <li className={li}><strong className={bold}>Linear Blend</strong> — Simple weighted average of anchor masks. Fast but may produce blocky results. Adjust the Blend Threshold slider to control fill aggressiveness.</li>
+          <li className={li}><strong className={bold}>Nearest Slice</strong> — Copies the nearest anchor slice into each gap. No shape blending — useful for structures with sharp boundaries.</li>
+        </ul>
+        <p className={tip}>Interpolation operates per-segment. Keep one anatomical structure per segment for best results.</p>
+      </div>
+    ),
+  },
+  {
+    id: 'settings-backup',
+    title: 'File Backup',
+    group: 'Settings',
+    content: (
+      <div className="space-y-2">
+        <p className={p}>Automatically backs up your annotation work to local files at regular intervals.</p>
+        <ul className={ul}>
+          <li className={li}><strong className={bold}>Enable local file backup</strong> — Master toggle for automatic backups.</li>
+          <li className={li}><strong className={bold}>Backup frequency</strong> — How often backups run (5&ndash;120 seconds).</li>
+          <li className={li}><strong className={bold}>Cache location</strong> — Where backup files are stored on disk.</li>
+        </ul>
+
+        <h3 className={h3}>Deletion Safety</h3>
+        <p className={p}>When deleting annotations from XNAT, you can optionally archive the DICOM file to a session resource folder before the scan is removed.</p>
+        <ul className={ul}>
+          <li className={li}><strong className={bold}>Archive to session resource before deleting</strong> — Enable this checkbox to copy the file to a resource folder before deletion.</li>
+          <li className={li}><strong className={bold}>Resource folder name</strong> — The XNAT resource folder where archived copies are stored (defaults to &ldquo;trash&rdquo;).</li>
+        </ul>
+
+        <h3 className={h3}>Cached Backups</h3>
+        <p className={p}>Lists all locally stored backup files grouped by session. For each entry you can:</p>
+        <ul className={ul}>
+          <li className={li}><strong className={bold}>Recover</strong> — Restore the backed-up annotation into the viewer.</li>
+          <li className={li}><strong className={bold}>Open</strong> — Open the backup file location on disk.</li>
+          <li className={li}><strong className={bold}>Delete</strong> — Remove the local backup file.</li>
+        </ul>
+      </div>
+    ),
+  },
+  {
+    id: 'settings-issue-report',
+    title: 'Issue Report',
+    group: 'Settings',
+    content: (
+      <div className="space-y-2">
+        <p className={p}>Generate a diagnostic report to help troubleshoot problems.</p>
+        <ul className={ul}>
+          <li className={li}>Add any <strong className={bold}>notes</strong> about what you were doing when the issue occurred.</li>
+          <li className={li}>Click <strong className={bold}>Refresh Report</strong> to regenerate the system information.</li>
+          <li className={li}>Click <strong className={bold}>Copy Report</strong> to copy the full report to your clipboard for sharing with support.</li>
+        </ul>
+        <p className={p}>The report includes system information, browser details, loaded scans, and current application state.</p>
+      </div>
+    ),
+  },
+];

--- a/src/renderer/components/viewer/Toolbar.tsx
+++ b/src/renderer/components/viewer/Toolbar.tsx
@@ -10,6 +10,7 @@ import type { LayoutType } from '@shared/types/viewer';
 import { BUILT_IN_PROTOCOLS } from '@shared/types/hangingProtocol';
 import AnnotationToolDropdown from './AnnotationToolDropdown';
 import SettingsModal from '../settings/SettingsModal';
+import HelpModal from '../help/HelpModal';
 import {
   IconWindowLevel,
   IconCrosshairs,
@@ -490,9 +491,17 @@ interface ToolbarProps {
   openSettingsToBackup?: boolean;
   /** Called after the open-settings-to-backup request has been consumed. */
   onSettingsToBackupConsumed?: () => void;
+  /** When true, open the Quick Start Guide modal. */
+  openHelpGuide?: boolean;
+  /** Called after the help guide request has been consumed. */
+  onHelpGuideConsumed?: () => void;
+  /** When true, open Settings to the Issue Report tab. */
+  openSettingsToIssue?: boolean;
+  /** Called after the settings-to-issue request has been consumed. */
+  onSettingsToIssueConsumed?: () => void;
 }
 
-export default function Toolbar({ showDicomPanel = false, onToggleDicomPanel, onApplyProtocol, onToggleMPR, hasImages = false, leftSlot, onRecoverBackup, openSettingsToBackup, onSettingsToBackupConsumed }: ToolbarProps) {
+export default function Toolbar({ showDicomPanel = false, onToggleDicomPanel, onApplyProtocol, onToggleMPR, hasImages = false, leftSlot, onRecoverBackup, openSettingsToBackup, onSettingsToBackupConsumed, openHelpGuide, onHelpGuideConsumed, openSettingsToIssue, onSettingsToIssueConsumed }: ToolbarProps) {
   const [showSettings, setShowSettings] = useState(false);
   const [settingsInitialTab, setSettingsInitialTab] = useState<string | undefined>(undefined);
 
@@ -504,6 +513,27 @@ export default function Toolbar({ showDicomPanel = false, onToggleDicomPanel, on
       onSettingsToBackupConsumed?.();
     }
   }, [openSettingsToBackup, onSettingsToBackupConsumed]);
+
+  const [showHelpGuide, setShowHelpGuide] = useState(false);
+
+  // Open Quick Start Guide when requested by parent (Help menu)
+  useEffect(() => {
+    if (openHelpGuide) {
+      setShowSettings(false); // close Settings if open
+      setShowHelpGuide(true);
+      onHelpGuideConsumed?.();
+    }
+  }, [openHelpGuide, onHelpGuideConsumed]);
+
+  // Open Settings to Issue Report tab when requested by parent (Help menu)
+  useEffect(() => {
+    if (openSettingsToIssue) {
+      setShowHelpGuide(false); // close Quick Start Guide if open
+      setSettingsInitialTab('issue');
+      setShowSettings(true);
+      onSettingsToIssueConsumed?.();
+    }
+  }, [openSettingsToIssue, onSettingsToIssueConsumed]);
 
   const activeTool = useViewerStore((s) => s.activeTool);
   const mprActive = useViewerStore((s) => s.mprActive);
@@ -710,6 +740,7 @@ export default function Toolbar({ showDicomPanel = false, onToggleDicomPanel, on
         </div>
       </div>
       <SettingsModal open={showSettings} onClose={() => { setShowSettings(false); setSettingsInitialTab(undefined); }} onRecover={onRecoverBackup} initialTab={settingsInitialTab} />
+      <HelpModal open={showHelpGuide} onClose={() => setShowHelpGuide(false)} />
     </>
   );
 }

--- a/src/renderer/pages/ViewerPage.tsx
+++ b/src/renderer/pages/ViewerPage.tsx
@@ -34,9 +34,17 @@ interface ViewerPageProps {
   openSettingsToBackup?: boolean;
   /** Called after the Settings-to-backup request has been consumed. */
   onSettingsToBackupConsumed?: () => void;
+  /** When true, open the Quick Start Guide modal. */
+  openHelpGuide?: boolean;
+  /** Called after the help guide request has been consumed. */
+  onHelpGuideConsumed?: () => void;
+  /** When true, open Settings to the Issue Report tab. */
+  openSettingsToIssue?: boolean;
+  /** Called after the settings-to-issue request has been consumed. */
+  onSettingsToIssueConsumed?: () => void;
 }
 
-export default function ViewerPage({ panelImageIds, onApplyProtocol, onToggleMPR, mprSourceImageIds, leftSlot, browserSlot, onRecoverBackup, openSettingsToBackup, onSettingsToBackupConsumed }: ViewerPageProps) {
+export default function ViewerPage({ panelImageIds, onApplyProtocol, onToggleMPR, mprSourceImageIds, leftSlot, browserSlot, onRecoverBackup, openSettingsToBackup, onSettingsToBackupConsumed, openHelpGuide, onHelpGuideConsumed, openSettingsToIssue, onSettingsToIssueConsumed }: ViewerPageProps) {
   const showAnnotationPanel = useAnnotationStore((s) => s.showPanel);
   const showSegPanel = useSegmentationStore((s) => s.showPanel);
   const [showDicomPanel, setShowDicomPanel] = useState(false);
@@ -79,6 +87,10 @@ export default function ViewerPage({ panelImageIds, onApplyProtocol, onToggleMPR
         onRecoverBackup={onRecoverBackup}
         openSettingsToBackup={openSettingsToBackup}
         onSettingsToBackupConsumed={onSettingsToBackupConsumed}
+        openHelpGuide={openHelpGuide}
+        onHelpGuideConsumed={onHelpGuideConsumed}
+        openSettingsToIssue={openSettingsToIssue}
+        onSettingsToIssueConsumed={onSettingsToIssueConsumed}
       />
       <div className="flex-1 min-h-0 flex relative">
         {/* Optional browser sidebar (rendered by App) */}

--- a/src/shared/ipcChannels.ts
+++ b/src/shared/ipcChannels.ts
@@ -8,7 +8,7 @@
  *   XNAT_AUTOSAVE_TEMP, XNAT_LIST_TEMP_FILES, XNAT_DELETE_TEMP_FILE, XNAT_DOWNLOAD_TEMP_FILE
  *
  * main → renderer (send/on):
- *   XNAT_SESSION_EXPIRED
+ *   XNAT_SESSION_EXPIRED, HELP_OPEN_GUIDE, HELP_OPEN_ISSUE_REPORT
  */
 export const IPC = {
   // Auth (renderer → main)
@@ -77,6 +77,10 @@ export const IPC = {
 
   // Diagnostics (renderer → main)
   DIAGNOSTICS_GET_MAIN_SNAPSHOT: 'diagnostics:get-main-snapshot',
+
+  // Help menu (main → renderer)
+  HELP_OPEN_GUIDE: 'help:open-guide',
+  HELP_OPEN_ISSUE_REPORT: 'help:open-issue-report',
 } as const;
 
 export type IpcChannel = (typeof IPC)[keyof typeof IPC];


### PR DESCRIPTION
## Summary

- Adds a **Help** menu to the Electron native menu bar (after Window) with two items:
  - **Quick Start Guide** — opens an in-app modal with 18 help sections organized into 6 groups (Browsing & Navigation, Viewing, Measurements & Export, Segmentation, Settings), with a vertical sidebar for navigation mirroring the Settings modal layout
  - **Report an Issue** — opens the existing Settings modal directly on the Issue Report tab
- Help content manually reviewed and copy-edited for accuracy; stored in `docs/user-guide.md` and rendered as plain JSX + Tailwind (no markdown library dependency)
- Modal exclusivity: triggering one Help action while the other modal is open closes the first before opening the second

## Implementation

- **IPC**: Two new `main→renderer` channels (`help:open-guide`, `help:open-issue-report`) following the existing `xnat:session-expired` pattern
- **State flow**: `App.tsx` IPC listeners → boolean flags → prop-drilled through `ViewerPage` → `Toolbar` opens the appropriate modal (same pattern as `openSettingsToBackup`)
- **Files created**: `HelpModal.tsx`, `helpGuideContent.tsx`, `docs/user-guide.md`
- **Files modified**: `ipcChannels.ts`, `main/index.ts`, `preload/index.ts`, `App.tsx`, `ViewerPage.tsx`, `Toolbar.tsx`

## Test plan

- [x] Help menu appears in menu bar after Window menu
- [x] Help → Quick Start Guide opens modal with all 18 sections in grouped sidebar tabs
- [x] Clicking sidebar tabs switches content; content pane is scrollable
- [x] Close button, Escape key, and backdrop click all dismiss the modal
- [x] Help → Report an Issue opens Settings modal on the Issue Report tab
- [x] Both menu items work before and after loading scans
- [x] Triggering one Help action while the other modal is open closes the first and opens the second (no stacking)
- [x] `npx tsc --noEmit`: no new type errors (pre-existing test errors only)
- [x] `npx vitest run`: all 422 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)