### PR TITLE
Fix crosshair sync across same-subject sessions

### DIFF
--- a/src/renderer/lib/cornerstone/__tests__/crosshairSyncService.test.ts
+++ b/src/renderer/lib/cornerstone/__tests__/crosshairSyncService.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const metaDataGetMock = vi.hoisted(() => vi.fn());
 const scrollToIndexMock = vi.hoisted(() => vi.fn());
+const mprScrollToIndexMock = vi.hoisted(() => vi.fn());
 const getPanelDisplayPointForWorldMock = vi.hoisted(() => vi.fn());
 const getViewportForPanelMock = vi.hoisted(() => vi.fn());
 const getWorldPointFromClientPointMock = vi.hoisted(() => vi.fn());
@@ -10,6 +11,8 @@ const getWorldPointFromClientPointMock = vi.hoisted(() => vi.fn());
 type ViewerState = {
   panelImageIdsMap: Record<string, string[]>;
   viewports: Record<string, { imageIndex: number; requestedImageIndex: number | null; totalImages: number }>;
+  panelXnatContextMap: Record<string, { subjectId: string; sessionId: string }>;
+  panelSubjectLabelMap: Record<string, string>;
   crosshairWorldPoint: [number, number, number] | null;
   crosshairSourcePanelId: string | null;
   setCrosshairWorldPoint: (point: [number, number, number], sourcePanelId: string) => void;
@@ -23,6 +26,8 @@ const viewerStoreMock = vi.hoisted(() => {
       panel_1: ['img-target-a', 'img-target-b', 'img-target-c'],
     },
     viewports: {},
+    panelXnatContextMap: {},
+    panelSubjectLabelMap: {},
     crosshairWorldPoint: null,
     crosshairSourcePanelId: null,
     setCrosshairWorldPoint(point, sourcePanelId) {
@@ -77,6 +82,13 @@ vi.mock('@cornerstonejs/dicom-image-loader', () => ({
 vi.mock('../viewportService', () => ({
   viewportService: {
     scrollToIndex: scrollToIndexMock,
+  },
+}));
+
+vi.mock('../mprService', () => ({
+  mprService: {
+    getViewport: vi.fn(() => null),
+    scrollToIndex: mprScrollToIndexMock,
   },
 }));
 
@@ -192,7 +204,7 @@ describe('crosshairSyncService', () => {
     crosshairSyncService.syncFromViewport('panel_0', [0, 0, 9]);
 
     expect(viewerStoreMock.getState().viewports.panel_1?.requestedImageIndex).toBe(1);
-    expect(scrollToIndexMock).toHaveBeenCalledWith('panel_1', 1);
+    expect(mprScrollToIndexMock).toHaveBeenCalledWith('panel_1', 1);
   });
 
   it('keeps jumped point visible by in-plane camera pan when offscreen', () => {
@@ -386,6 +398,88 @@ describe('crosshairSyncService', () => {
       expect(vpT2.jumpToWorld).toHaveBeenCalledWith([5, 10, 15]);
       expect(vpFlair.jumpToWorld).toHaveBeenCalledWith([5, 10, 15]);
     });
+  });
+
+  it('syncs same-subject panels across different sessions by slice geometry when FOR UIDs differ', () => {
+    viewerStoreMock.setState({
+      panelImageIdsMap: {
+        panel_0: ['sess1-0', 'sess1-1', 'sess1-2'],
+        panel_1: ['sess2-0', 'sess2-1', 'sess2-2', 'sess2-3'],
+      },
+      panelXnatContextMap: {
+        panel_0: { subjectId: 'SUB-1', sessionId: 'SESS-1' },
+        panel_1: { subjectId: 'SUB-1', sessionId: 'SESS-2' },
+      },
+    });
+
+    const axialPlane = (z: number, forUid: string): PlaneMeta => ({
+      frameOfReferenceUID: forUid,
+      imagePositionPatient: [0, 0, z],
+      imageOrientationPatient: [1, 0, 0, 0, 1, 0],
+    });
+
+    setMetadata({
+      'imagePlaneModule|sess1-0': axialPlane(0, 'FOR-SESS-1'),
+      'imagePlaneModule|sess1-1': axialPlane(5, 'FOR-SESS-1'),
+      'imagePlaneModule|sess1-2': axialPlane(10, 'FOR-SESS-1'),
+      'generalSeriesModule|sess1-0': { seriesInstanceUID: 'SER-SESS-1' },
+      'imagePlaneModule|sess2-0': axialPlane(0, 'FOR-SESS-2'),
+      'imagePlaneModule|sess2-1': axialPlane(4, 'FOR-SESS-2'),
+      'imagePlaneModule|sess2-2': axialPlane(8, 'FOR-SESS-2'),
+      'imagePlaneModule|sess2-3': axialPlane(12, 'FOR-SESS-2'),
+      'generalSeriesModule|sess2-0': { seriesInstanceUID: 'SER-SESS-2' },
+    });
+
+    crosshairSyncService._markMetadataLoaded('panel_1');
+    const targetViewport = {
+      type: 'stack',
+      jumpToWorld: vi.fn(() => true),
+      getCamera: vi.fn(),
+      setCamera: vi.fn(),
+      render: vi.fn(),
+    };
+    getViewportForPanelMock.mockReturnValue(targetViewport);
+
+    crosshairSyncService.syncFromViewport('panel_0', [0, 0, 9]);
+
+    expect(targetViewport.jumpToWorld).not.toHaveBeenCalled();
+    expect(viewerStoreMock.getState().viewports.panel_1?.requestedImageIndex).toBe(2);
+    expect(scrollToIndexMock).toHaveBeenCalledWith('panel_1', 2);
+    expect(targetViewport.setCamera).not.toHaveBeenCalled();
+    expect(targetViewport.render).toHaveBeenCalled();
+  });
+
+  it('still skips panels from different known subjects when FOR UIDs differ', () => {
+    viewerStoreMock.setState({
+      panelImageIdsMap: {
+        panel_0: ['sub1-0'],
+        panel_1: ['sub2-0'],
+      },
+      panelXnatContextMap: {
+        panel_0: { subjectId: 'SUB-1', sessionId: 'SESS-1' },
+        panel_1: { subjectId: 'SUB-2', sessionId: 'SESS-9' },
+      },
+    });
+
+    setMetadata({
+      'imagePlaneModule|sub1-0': { frameOfReferenceUID: 'FOR-1' },
+      'generalSeriesModule|sub1-0': { seriesInstanceUID: 'SER-1' },
+      'imagePlaneModule|sub2-0': { frameOfReferenceUID: 'FOR-2' },
+      'generalSeriesModule|sub2-0': { seriesInstanceUID: 'SER-2' },
+    });
+
+    const targetViewport = {
+      type: 'stack',
+      jumpToWorld: vi.fn(() => true),
+      render: vi.fn(),
+    };
+    getViewportForPanelMock.mockReturnValue(targetViewport);
+
+    crosshairSyncService.syncFromViewport('panel_0', [0, 0, 10]);
+
+    expect(targetViewport.jumpToWorld).not.toHaveBeenCalled();
+    expect(scrollToIndexMock).not.toHaveBeenCalled();
+    expect(viewerStoreMock.getState().viewports.panel_1).toBeUndefined();
   });
 
   describe('different slice spacing and count', () => {

--- a/src/renderer/lib/cornerstone/crosshairSyncService.ts
+++ b/src/renderer/lib/cornerstone/crosshairSyncService.ts
@@ -117,6 +117,41 @@ function getFrameOfReferenceUid(imageId: string): string | null {
   return plane?.frameOfReferenceUID ?? null;
 }
 
+function normalizeSubjectKey(value: string | undefined | null): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function getPanelSubjectKey(
+  store: ReturnType<typeof useViewerStore.getState>,
+  panelId: string,
+): string | null {
+  const panelCtx = store.panelXnatContextMap?.[panelId] as { subjectId?: string } | undefined;
+  return normalizeSubjectKey(panelCtx?.subjectId)
+    ?? normalizeSubjectKey(store.panelSubjectLabelMap?.[panelId]);
+}
+
+function panelsShareKnownSubject(
+  store: ReturnType<typeof useViewerStore.getState>,
+  sourcePanelId: string,
+  targetPanelId: string,
+): boolean {
+  const sourceSubject = getPanelSubjectKey(store, sourcePanelId);
+  const targetSubject = getPanelSubjectKey(store, targetPanelId);
+  return sourceSubject != null && targetSubject != null && sourceSubject === targetSubject;
+}
+
+function panelsHaveDifferentKnownSubjects(
+  store: ReturnType<typeof useViewerStore.getState>,
+  sourcePanelId: string,
+  targetPanelId: string,
+): boolean {
+  const sourceSubject = getPanelSubjectKey(store, sourcePanelId);
+  const targetSubject = getPanelSubjectKey(store, targetPanelId);
+  return sourceSubject != null && targetSubject != null && sourceSubject !== targetSubject;
+}
+
 /**
  * Parse a DICOM multi-valued numeric string (e.g. "1.0\\2.0\\3.0") into an
  * array of numbers. Returns null if parsing fails.
@@ -257,22 +292,32 @@ async function ensureStackMetadata(panelId: string, imageIds: string[]): Promise
  * Synchronously sync a single target panel using geometric slice matching.
  * Returns true if the sync succeeded, false if metadata was insufficient.
  */
-function syncStackPanel(
+function syncPanelByGeometry(
   panelId: string,
   imageIds: string[],
   worldPoint: Point3,
   store: ReturnType<typeof useViewerStore.getState>,
+  options?: { panToWorld?: boolean },
 ): boolean {
   const targetIndex = findNearestStackIndex(imageIds, worldPoint);
   if (targetIndex == null) return false;
 
   store._requestImageIndex(panelId, targetIndex, imageIds.length);
-  viewportService.scrollToIndex(panelId, targetIndex);
-
-  // Pan the viewport to keep the crosshair point visible in-plane.
   const viewport = getViewportForPanel(panelId) as AnyViewport | null;
+  const vpType = (viewport as { type?: string } | null)?.type;
+  const isVolumeViewport = vpType != null && vpType !== 'stack';
+
+  if (isVolumeViewport) {
+    mprService.scrollToIndex(panelId, targetIndex);
+  } else {
+    viewportService.scrollToIndex(panelId, targetIndex);
+  }
+
+  // Only pan in world space when the source/target coordinate systems are compatible.
   if (viewport) {
-    keepPointVisibleByPanning(panelId, viewport, worldPoint);
+    if (options?.panToWorld !== false) {
+      keepPointVisibleByPanning(panelId, viewport, worldPoint);
+    }
     viewport.render?.();
   }
   return true;
@@ -313,11 +358,22 @@ export const crosshairSyncService = {
       const targetViewport = getViewportForPanel(panelId) as AnyViewport | null;
       if (!targetViewport) continue;
 
+      if (panelsHaveDifferentKnownSubjects(store, sourcePanelId, panelId)) {
+        console.warn(`[crosshairSync] Skipping ${panelId}: subject mismatch`);
+        continue;
+      }
+
       // Only skip if both FORs are known and genuinely differ (different anatomy).
       // When either FOR is unavailable (metadata not yet decoded), proceed with
       // sync rather than silently skipping — avoids race conditions with wadouri.
       const targetForUid = imageIds[0] ? getFrameOfReferenceUid(imageIds[0]) : null;
-      if (sourceForUid && targetForUid && sourceForUid !== targetForUid) {
+      const allowCrossSessionGeometryFallback =
+        sourceForUid != null &&
+        targetForUid != null &&
+        sourceForUid !== targetForUid &&
+        panelsShareKnownSubject(store, sourcePanelId, panelId);
+
+      if (sourceForUid && targetForUid && sourceForUid !== targetForUid && !allowCrossSessionGeometryFallback) {
         console.warn(`[crosshairSync] Skipping ${panelId}: FOR mismatch (${sourceForUid} vs ${targetForUid})`);
         continue;
       }
@@ -326,7 +382,7 @@ export const crosshairSyncService = {
       const vpType = (targetViewport as any)?.type as string | undefined;
       const isVolumeViewport = vpType != null && vpType !== 'stack';
 
-      if (isVolumeViewport) {
+      if (isVolumeViewport && !allowCrossSessionGeometryFallback) {
         // Volume viewports have full metadata in the volume — jumpToWorld works reliably.
         if (typeof targetViewport.jumpToWorld === 'function') {
           try {
@@ -361,10 +417,25 @@ export const crosshairSyncService = {
           if (!latestPoint) return;
           const latestImageIds = latestStore.panelImageIdsMap[panelId];
           if (!latestImageIds || latestImageIds.length === 0) return;
-          syncStackPanel(panelId, latestImageIds, latestPoint, latestStore);
+          const latestSourcePanelId = latestStore.crosshairSourcePanelId;
+          const latestSourceIds = latestSourcePanelId
+            ? (latestStore.panelImageIdsMap[latestSourcePanelId] ?? [])
+            : [];
+          const latestSourceForUid = latestSourceIds[0] ? getFrameOfReferenceUid(latestSourceIds[0]) : null;
+          const latestTargetForUid = latestImageIds[0] ? getFrameOfReferenceUid(latestImageIds[0]) : null;
+          const panToWorld = !(
+            latestSourcePanelId
+            && latestSourceForUid
+            && latestTargetForUid
+            && latestSourceForUid !== latestTargetForUid
+            && panelsShareKnownSubject(latestStore, latestSourcePanelId, panelId)
+          );
+          syncPanelByGeometry(panelId, latestImageIds, latestPoint, latestStore, { panToWorld });
         });
       } else {
-        syncStackPanel(panelId, imageIds, worldPoint, store);
+        syncPanelByGeometry(panelId, imageIds, worldPoint, store, {
+          panToWorld: !allowCrossSessionGeometryFallback,
+        });
       }
     }
     } catch (err) {


### PR DESCRIPTION
## Summary
- allow crosshair sync across different sessions when both panels belong to the same subject
- fall back to geometric slice matching instead of blocking on FrameOfReferenceUID mismatch in that case
- keep the existing safety block for different known subjects
- add regression tests for same-subject cross-session sync and different-subject non-sync

## Testing
- npm test
- npm run build
