### PR TITLE
Add settings button to login screen and About tab

### DIFF
--- a/src/renderer/components/connection/LoginForm.tsx
+++ b/src/renderer/components/connection/LoginForm.tsx
@@ -8,7 +8,8 @@
  */
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useConnectionStore } from '../../stores/connectionStore';
-import { IconServer, XnatLogo } from '../icons';
+import { IconServer, IconSettings, XnatLogo } from '../icons';
+import SettingsModal from '../settings/SettingsModal';
 
 // ─── Recent Connections ──────────────────────────────────────────
 
@@ -62,6 +63,7 @@ export default function LoginForm() {
   const [recentConnections] = useState(loadRecent);
   const [serverUrl, setServerUrl] = useState('');
   const [showRecent, setShowRecent] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const isConnecting = status === 'connecting';
@@ -120,7 +122,18 @@ export default function LoginForm() {
   const hasRecent = recentConnections.length > 0;
 
   return (
-    <div data-testid="login-form" className="h-full flex items-center justify-center bg-zinc-950">
+    <div data-testid="login-form" className="h-full flex items-center justify-center bg-zinc-950 relative">
+      {/* Settings button — top-right corner */}
+      <button
+        type="button"
+        onClick={() => setShowSettings(true)}
+        className="absolute top-4 right-4 p-2 text-zinc-600 hover:text-zinc-300 transition-colors rounded-md hover:bg-zinc-800/50"
+        title="Settings"
+      >
+        <IconSettings className="w-4 h-4" />
+      </button>
+      <SettingsModal open={showSettings} onClose={() => setShowSettings(false)} />
+
       <div className="w-full max-w-sm px-6">
         {/* Header */}
         <div className="text-center mb-8">

--- a/src/renderer/components/settings/SettingsModal.tsx
+++ b/src/renderer/components/settings/SettingsModal.tsx
@@ -18,7 +18,10 @@ import type { BackupSessionSummary } from '@shared/types/backup';
 import { buildIssueReport } from '../../lib/diagnostics/issueReport';
 import { IconClose } from '../icons';
 
-type SettingsTab = 'hotkeys' | 'overlay' | 'annotation' | 'interpolation' | 'backup' | 'issue';
+declare const __APP_VERSION__: string;
+const APP_VERSION = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev';
+
+type SettingsTab = 'hotkeys' | 'overlay' | 'annotation' | 'interpolation' | 'backup' | 'issue' | 'about';
 
 interface SettingsModalProps {
   open: boolean;
@@ -36,6 +39,10 @@ const TAB_ITEMS: Array<{ id: SettingsTab; label: string }> = [
   { id: 'interpolation', label: 'Interpolation' },
   { id: 'backup', label: 'File Backup' },
   { id: 'issue', label: 'Issue Report' },
+];
+
+const DOC_ITEMS: Array<{ id: SettingsTab; label: string }> = [
+  { id: 'about', label: 'About' },
 ];
 
 const CORNER_OPTIONS: Array<{
@@ -405,6 +412,23 @@ export default function SettingsModal({ open, onClose, onRecover, initialTab }: 
           <div className="px-2 py-2 text-[11px] uppercase tracking-wide text-zinc-500">Settings</div>
           <div className="space-y-1">
             {TAB_ITEMS.map((tab) => (
+              <button
+                key={tab.id}
+                type="button"
+                onClick={() => setActiveTab(tab.id)}
+                className={`w-full text-left px-2.5 py-2 rounded text-xs transition-colors ${
+                  activeTab === tab.id
+                    ? 'bg-blue-600/20 text-blue-300'
+                    : 'text-zinc-300 hover:bg-zinc-800 hover:text-white'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+          <div className="px-2 py-2 mt-2 text-[11px] uppercase tracking-wide text-zinc-500 border-t border-zinc-800 pt-3">Documentation</div>
+          <div className="space-y-1">
+            {DOC_ITEMS.map((tab) => (
               <button
                 key={tab.id}
                 type="button"
@@ -1074,6 +1098,47 @@ export default function SettingsModal({ open, onClose, onRecover, initialTab }: 
                   )}
                 </div>
               </>
+            )}
+
+            {activeTab === 'about' && (
+              <div className="space-y-4">
+                <div className="rounded-lg border border-zinc-800 bg-zinc-950/40 p-5 space-y-4">
+                  <div>
+                    <h3 className="text-sm font-semibold text-zinc-100">XNAT Workstation</h3>
+                    <p className="text-xs text-zinc-500 mt-1">Version {APP_VERSION}</p>
+                  </div>
+                  <p className="text-xs text-zinc-300 leading-relaxed">
+                    XNAT Workstation is provided with the XNAT project with contributions from{' '}
+                    <button
+                      type="button"
+                      onClick={() => window.electronAPI.shell.openExternal('https://www.mir.wustl.edu/research/research-centers/computational-imaging-research-center-circ/labs/marcus-lab/')}
+                      className="text-blue-400 hover:text-blue-300 underline underline-offset-2"
+                    >
+                      Washington University
+                    </button>
+                    {' '}and{' '}
+                    <button
+                      type="button"
+                      onClick={() => window.electronAPI.shell.openExternal('https://www.embarklabs.ai')}
+                      className="text-blue-400 hover:text-blue-300 underline underline-offset-2"
+                    >
+                      Embark Labs
+                    </button>
+                    .
+                  </p>
+                  <p className="text-xs text-zinc-300 leading-relaxed">
+                    Email{' '}
+                    <button
+                      type="button"
+                      onClick={() => window.electronAPI.shell.openExternal('mailto:info@xnat.org')}
+                      className="text-blue-400 hover:text-blue-300 underline underline-offset-2"
+                    >
+                      info@xnat.org
+                    </button>
+                    {' '}if you'd like to get in touch.
+                  </p>
+                </div>
+              </div>
             )}
 
             {activeTab === 'issue' && (

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,12 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import pkg from './package.json';
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   plugins: [
     react(),
   ],


### PR DESCRIPTION
## Summary
- Add a gear icon on the login page so users can access settings before connecting to an XNAT server
- Add an "About" tab to the settings modal showing app version, credits (Washington University, Embark Labs), and contact email
- Inject `__APP_VERSION__` from `package.json` via Vite `define` so the version is available at runtime

## Test plan
- [ ] Verify the settings gear icon appears in the top-right corner of the login screen
- [ ] Confirm clicking it opens the settings modal
- [ ] Check the About tab displays the correct version from `package.json`
- [ ] Verify external links (Washington University, Embark Labs, mailto) open correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)