### PR TITLE
Fix crosshair sync for multi-subject and oriented viewports

### DIFF
--- a/src/renderer/components/viewer/ViewportOverlay.tsx
+++ b/src/renderer/components/viewer/ViewportOverlay.tsx
@@ -205,6 +205,21 @@ export default function ViewportOverlay({ panelId }: ViewportOverlayProps) {
   });
   const overlay = useMetadataStore((s) => s.overlays[panelId] ?? EMPTY_OVERLAY);
   const crosshairPoint = useViewerStore((s) => s.crosshairWorldPoint);
+  const crosshairSourcePanelId = useViewerStore((s) => s.crosshairSourcePanelId);
+  const crosshairSubjectMismatch = useViewerStore((s) => {
+    if (!s.crosshairSourcePanelId || s.crosshairSourcePanelId === panelId) return false;
+    const normalize = (v: string | undefined | null) => {
+      if (typeof v !== 'string') return null;
+      const t = v.trim().toLowerCase();
+      return t.length > 0 ? t : null;
+    };
+    const getSubject = (pid: string) =>
+      normalize((s.panelXnatContextMap?.[pid] as { subjectId?: string } | undefined)?.subjectId)
+      ?? normalize(s.panelSubjectLabelMap?.[pid]);
+    const source = getSubject(s.crosshairSourcePanelId);
+    const target = getSubject(panelId);
+    return source != null && target != null && source !== target;
+  });
   const activeTool = useViewerStore((s) => s.activeTool);
   const displayOrientation: MPRPlane =
     (panelOrientation === 'STACK' ? nativeOrientation : panelOrientation) as MPRPlane;
@@ -217,7 +232,7 @@ export default function ViewportOverlay({ panelId }: ViewportOverlayProps) {
   const cornerFields = overlayPrefs.corners ?? DEFAULT_OVERLAY_CORNERS;
 
   const crosshairGuides =
-    activeTool === ToolName.Crosshairs && crosshairPoint
+    activeTool === ToolName.Crosshairs && crosshairPoint && !crosshairSubjectMismatch
       ? getCrosshairDisplayPoint(panelId, crosshairPoint)
       : null;
   const showCrosshairGuides = crosshairGuides !== null;
@@ -226,7 +241,7 @@ export default function ViewportOverlay({ panelId }: ViewportOverlayProps) {
     && (showContextOverlay || showCrosshairGuides || showHorizontalRuler || showVerticalRuler || showOrientationMarkers);
 
   const crosshairText =
-    activeTool === ToolName.Crosshairs && crosshairPoint
+    activeTool === ToolName.Crosshairs && crosshairPoint && !crosshairSubjectMismatch
       ? `${crosshairPoint[0].toFixed(1)}, ${crosshairPoint[1].toFixed(1)}, ${crosshairPoint[2].toFixed(1)}`
       : null;
 

--- a/src/renderer/lib/cornerstone/__tests__/crosshairSyncService.test.ts
+++ b/src/renderer/lib/cornerstone/__tests__/crosshairSyncService.test.ts
@@ -178,7 +178,7 @@ describe('crosshairSyncService', () => {
     expect(scrollToIndexMock).not.toHaveBeenCalled();
   });
 
-  it('falls back to nearest stack index when jumpToWorld is unavailable/unsuccessful', () => {
+  it('skips volume viewport when jumpToWorld fails instead of falling back to stack geometry', () => {
     const plane = (z: number): PlaneMeta => ({
       frameOfReferenceUID: 'FOR-1',
       imagePositionPatient: [0, 0, z],
@@ -198,13 +198,14 @@ describe('crosshairSyncService', () => {
       jumpToWorld: vi.fn(() => false),
     });
 
-    // Mark target panel metadata as loaded so stack fallback works synchronously.
     crosshairSyncService._markMetadataLoaded('panel_1');
 
     crosshairSyncService.syncFromViewport('panel_0', [0, 0, 9]);
 
-    expect(viewerStoreMock.getState().viewports.panel_1?.requestedImageIndex).toBe(1);
-    expect(mprScrollToIndexMock).toHaveBeenCalledWith('panel_1', 1);
+    // Volume viewports should not fall back to acquisition-plane geometry
+    // because the coordinate frame differs from the reoriented view.
+    expect(viewerStoreMock.getState().viewports.panel_1?.requestedImageIndex).toBeUndefined();
+    expect(mprScrollToIndexMock).not.toHaveBeenCalled();
   });
 
   it('keeps jumped point visible by in-plane camera pan when offscreen', () => {

--- a/src/renderer/lib/cornerstone/crosshairSyncService.ts
+++ b/src/renderer/lib/cornerstone/crosshairSyncService.ts
@@ -390,7 +390,17 @@ export const crosshairSyncService = {
             if (jumped) {
               keepPointVisibleByPanning(panelId, targetViewport, worldPoint);
               targetViewport.render?.();
-              if (typeof targetViewport.getCurrentImageIdIndex === 'function') {
+              // Use the volume viewport's own slice geometry for index tracking.
+              // imageIds.length reflects acquisition slices, but oriented viewports
+              // have a different slice count along the reoriented axis.
+              const vp = targetViewport as any;
+              if (typeof vp.getSliceIndex === 'function' && typeof vp.getNumberOfSlices === 'function') {
+                const idx = vp.getSliceIndex() as number;
+                const total = vp.getNumberOfSlices() as number;
+                if (Number.isFinite(idx) && total > 0) {
+                  store._requestImageIndex(panelId, Math.max(0, idx), total);
+                }
+              } else if (typeof targetViewport.getCurrentImageIdIndex === 'function') {
                 const idx = targetViewport.getCurrentImageIdIndex();
                 if (Number.isFinite(idx) && imageIds.length > 0) {
                   const clamped = Math.max(0, Math.min(imageIds.length - 1, Number(idx)));
@@ -401,9 +411,13 @@ export const crosshairSyncService = {
             }
           } catch (err) {
             console.warn('[crosshairSync] volume jumpToWorld error', panelId, err);
-            // Fall through to stack-index fallback.
           }
         }
+        // Do not fall through to geometric slice matching for volume viewports.
+        // The acquisition-plane geometry is in a different coordinate frame than
+        // the reoriented view, so stack-index fallback would scroll to the wrong
+        // position (often resulting in a black viewport).
+        continue;
       }
 
       // Stack viewport path: use geometric slice matching.


### PR DESCRIPTION
## Summary
- Suppress crosshair overlay (guide lines + coordinate text) in viewports showing a different subject than the source click panel
- Fix oriented viewport sync: use volume viewport's own slice geometry for index tracking after `jumpToWorld`, instead of clamping to acquisition image count
- Stop falling back to acquisition-plane geometric matching when `jumpToWorld` fails on a volume viewport — this was scrolling to wrong positions and causing black viewports

## Test plan
- [x] Load two different subjects in separate viewports, activate crosshair tool, click in one — guides should only appear in same-subject viewports
- [x] Load a scan in two viewports: one native stack, one reoriented (e.g. sagittal) — crosshair click in the stack should correctly sync the oriented viewport without going black
- [x] Run `npm run test` — all 424 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)