### PR TITLE
Add XNAT navigator entity links

### DIFF
--- a/src/renderer/components/connection/XnatBrowser.test.tsx
+++ b/src/renderer/components/connection/XnatBrowser.test.tsx
@@ -35,7 +35,7 @@ vi.mock('@cornerstonejs/core', async (importOriginal) => {
   };
 });
 
-function setElectronApiMock(overrides?: Partial<ElectronAPI['xnat']>): ElectronAPI['xnat'] {
+function setElectronApiMock(overrides?: Partial<ElectronAPI['xnat']>): ElectronAPI {
   const xnat = {
     browserLogin: vi.fn(),
     logout: vi.fn(),
@@ -56,10 +56,15 @@ function setElectronApiMock(overrides?: Partial<ElectronAPI['xnat']>): ElectronA
     prepareDicomForUpload: vi.fn(),
     autoSaveTemp: vi.fn(),
     listTempFiles: vi.fn(),
+    deleteScan: vi.fn(),
     deleteTempFile: vi.fn(),
     downloadTempFile: vi.fn(),
     ...overrides,
   } as unknown as ElectronAPI['xnat'];
+
+  const shell = {
+    openExternal: vi.fn(async () => ({ ok: true })),
+  };
 
   Object.defineProperty(window, 'electronAPI', {
     configurable: true,
@@ -67,12 +72,13 @@ function setElectronApiMock(overrides?: Partial<ElectronAPI['xnat']>): ElectronA
     value: {
       xnat,
       export: {},
+      shell,
       platform: 'darwin',
       on: vi.fn(() => () => undefined),
     },
   });
 
-  return xnat;
+  return window.electronAPI;
 }
 
 function resetStores(): void {
@@ -154,7 +160,7 @@ describe('XnatBrowser', () => {
 
   it('drills down project -> subject -> session and loads source scans with context', async () => {
     const onLoadScan = vi.fn();
-    const xnat = setElectronApiMock({
+    const electronApi = setElectronApiMock({
       getProjects: vi.fn(async () => [{ id: 'P1', name: 'Project One', subjectCount: 1, sessionCount: 1 }]),
       getSubjects: vi.fn(async () => [{ id: 'SUB1', label: 'Subject-001', projectId: 'P1' }]),
       getSessions: vi.fn(async () => [{ id: 'SESS1', label: 'Session-1', projectId: 'P1', subjectId: 'SUB1', scanCount: 2 }]),
@@ -168,12 +174,23 @@ describe('XnatBrowser', () => {
     const user = userEvent.setup();
     render(<XnatBrowser onLoadScan={onLoadScan} />);
 
+    await user.click(await screen.findByTitle('Open project in XNAT'));
+    expect(electronApi.shell.openExternal).toHaveBeenCalledWith('https://xnat.example/data/projects/P1?format=html');
+
     await user.click(await screen.findByText('Project One'));
+
+    await user.click(await screen.findByTitle('Open subject in XNAT'));
+    expect(electronApi.shell.openExternal).toHaveBeenCalledWith('https://xnat.example/data/projects/P1/subjects/SUB1?format=html');
+
     await user.click(await screen.findByText('Subject-001'));
+
+    await user.click(await screen.findByTitle('Open session in XNAT'));
+    expect(electronApi.shell.openExternal).toHaveBeenCalledWith('https://xnat.example/data/experiments/SESS1?format=html');
+
     await user.click(await screen.findByText('Session-1'));
 
     await waitFor(() => {
-      expect(xnat.getScans).toHaveBeenCalledWith('SESS1');
+      expect(electronApi.xnat.getScans).toHaveBeenCalledWith('SESS1');
     });
     expect(screen.getByText('Axial')).toBeInTheDocument();
     expect(screen.queryByText('#3001 Seg Overlay')).not.toBeInTheDocument();
@@ -196,7 +213,7 @@ describe('XnatBrowser', () => {
     const onLoadScan = vi.fn();
     const onLoadSession = vi.fn();
     const onNavigateComplete = vi.fn();
-    const xnat = setElectronApiMock({
+    const electronApi = setElectronApiMock({
       getProjects: vi.fn(async () => []),
       getScans: vi.fn(async () => [
         { id: '21', type: 'MR', modality: 'MR', seriesDescription: 'T1' },
@@ -239,7 +256,7 @@ describe('XnatBrowser', () => {
     expect(screen.queryByText('#4001 RTSTRUCT')).not.toBeInTheDocument();
 
     await user.click(screen.getByTitle('Refresh scans'));
-    await waitFor(() => expect(xnat.getScans).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(electronApi.xnat.getScans).toHaveBeenCalledTimes(2));
 
     fireEvent.click(getClickableContaining(/T1/), { shiftKey: true });
     expect(onLoadScan).toHaveBeenLastCalledWith(
@@ -254,7 +271,7 @@ describe('XnatBrowser', () => {
   it('supports pinning, search filtering, grid thumbnails, and scan drag payload contracts', async () => {
     const onLoadScan = vi.fn();
     const onTogglePin = vi.fn();
-    const xnat = setElectronApiMock({
+    const electronApi = setElectronApiMock({
       getProjects: vi.fn(async () => [{ id: 'P1', name: 'Project One', subjectCount: 1, sessionCount: 1 }]),
       getSubjects: vi.fn(async () => [{ id: 'SUB1', label: 'Subject-001', projectId: 'P1' }]),
       getSessions: vi.fn(async () => [{ id: 'SESS1', label: 'Session-1', projectId: 'P1', subjectId: 'SUB1', scanCount: 1 }]),
@@ -318,6 +335,6 @@ describe('XnatBrowser', () => {
     );
 
     await user.click(screen.getByTitle('Refresh sessions'));
-    expect(xnat.getSessions).toHaveBeenCalledWith('P1', 'SUB1');
+    expect(electronApi.xnat.getSessions).toHaveBeenCalledWith('P1', 'SUB1');
   });
 });

--- a/src/renderer/components/connection/XnatBrowser.tsx
+++ b/src/renderer/components/connection/XnatBrowser.tsx
@@ -160,6 +160,25 @@ function RefreshIcon({ spinning }: { spinning?: boolean }) {
   );
 }
 
+function ExternalLinkIcon() {
+  return (
+    <svg
+      className="w-3.5 h-3.5"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M9.5 2.5H13.5V6.5" />
+      <path d="M7 9L13.5 2.5" />
+      <path d="M13 9.5V12.5C13 13.0523 12.5523 13.5 12 13.5H3.5C2.94772 13.5 2.5 13.0523 2.5 12.5V4C2.5 3.44772 2.94772 3 3.5 3H6.5" />
+    </svg>
+  );
+}
+
 // ─── Loading Spinner ──────────────────────────────────────────────
 
 function Spinner() {
@@ -290,6 +309,57 @@ export default function XnatBrowser({
 
   const connection = useConnectionStore((s) => s.connection);
   const pins = pinnedItemsProp ?? [];
+  const serverUrl = connection?.serverUrl ?? '';
+  const normalizedServerUrl = serverUrl.replace(/\/$/, '');
+
+  const buildXnatEntityUrl = useCallback(
+    (type: 'project' | 'subject' | 'session', ids: { projectId?: string; subjectId?: string; sessionId?: string }) => {
+      if (!normalizedServerUrl) return null;
+
+      if (type === 'project' && ids.projectId) {
+        return `${normalizedServerUrl}/data/projects/${encodeURIComponent(ids.projectId)}?format=html`;
+      }
+      if (type === 'subject' && ids.projectId && ids.subjectId) {
+        return `${normalizedServerUrl}/data/projects/${encodeURIComponent(ids.projectId)}/subjects/${encodeURIComponent(ids.subjectId)}?format=html`;
+      }
+      if (type === 'session' && ids.sessionId) {
+        return `${normalizedServerUrl}/data/experiments/${encodeURIComponent(ids.sessionId)}?format=html`;
+      }
+
+      return null;
+    },
+    [normalizedServerUrl],
+  );
+
+  const openXnatEntity = useCallback(async (url: string | null) => {
+    if (!url) return;
+
+    const result = await window.electronAPI.shell.openExternal(url);
+    if (!result.ok) {
+      console.error('[XnatBrowser] Failed to open XNAT entity URL:', result.error ?? url);
+    }
+  }, []);
+
+  const renderExternalLinkAction = useCallback(
+    (url: string | null, label: string) => {
+      if (!url) return null;
+
+      return (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            void openXnatEntity(url);
+          }}
+          className="p-1 rounded text-zinc-600 hover:text-sky-300 hover:bg-zinc-800 transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
+          title={`Open ${label} in XNAT`}
+          aria-label={`Open ${label} in XNAT`}
+        >
+          <ExternalLinkIcon />
+        </button>
+      );
+    },
+    [openXnatEntity],
+  );
 
   const downloadDerivedScanFile = useCallback(async (sessionId: string, scanId: string) => {
     const result = await window.electronAPI.xnat.downloadScanFile(sessionId, scanId);
@@ -827,8 +897,6 @@ export default function XnatBrowser({
   }, [level, selectedProject, selectedSubject, selectedSession, maybeResolveSessionAssociations]);
 
   // ─── Pin Helpers ───────────────────────────────────────────────
-  const serverUrl = connection?.serverUrl ?? '';
-
   function makePinItem(type: 'project', project: XnatProject): PinnedItem;
   function makePinItem(type: 'subject', subject: XnatSubject): PinnedItem;
   function makePinItem(type: 'session', session: XnatSession): PinnedItem;
@@ -1019,20 +1087,24 @@ export default function XnatBrowser({
                 )}
                 renderAction={onTogglePin ? (p) => {
                   const pinned = isPinned(pins, 'project', p.id);
+                  const projectUrl = buildXnatEntityUrl('project', { projectId: p.id });
                   return (
-                    <button
-                      onClick={() => onTogglePin(makePinItem('project', p))}
-                      className={`p-1 rounded transition-colors ${
-                        pinned
-                          ? 'text-amber-400 hover:text-amber-300 opacity-100'
-                          : 'text-zinc-600 hover:text-amber-400 opacity-0 group-hover:opacity-100'
-                      }`}
-                      title={pinned ? 'Unpin' : 'Pin'}
-                    >
-                      <IconPin className="w-3 h-3" filled={pinned} />
-                    </button>
+                    <div className="flex items-center gap-1">
+                      {renderExternalLinkAction(projectUrl, 'project')}
+                      <button
+                        onClick={() => onTogglePin(makePinItem('project', p))}
+                        className={`p-1 rounded transition-colors ${
+                          pinned
+                            ? 'text-amber-400 hover:text-amber-300 opacity-100'
+                            : 'text-zinc-600 hover:text-amber-400 opacity-0 group-hover:opacity-100'
+                        }`}
+                        title={pinned ? 'Unpin' : 'Pin'}
+                      >
+                        <IconPin className="w-3 h-3" filled={pinned} />
+                      </button>
+                    </div>
                   );
-                } : undefined}
+                } : (p) => renderExternalLinkAction(buildXnatEntityUrl('project', { projectId: p.id }), 'project')}
                 onSelect={selectProject}
                 emptyMessage={q ? `No projects matching "${search}"` : 'No accessible projects found'}
               />
@@ -1063,20 +1135,30 @@ export default function XnatBrowser({
                 }}
                 renderAction={onTogglePin ? (s) => {
                   const pinned = isPinned(pins, 'subject', s.id);
+                  const subjectUrl = buildXnatEntityUrl('subject', {
+                    projectId: selectedProject?.id,
+                    subjectId: s.id,
+                  });
                   return (
-                    <button
-                      onClick={() => onTogglePin(makePinItem('subject', s))}
-                      className={`p-1 rounded transition-colors ${
-                        pinned
-                          ? 'text-amber-400 hover:text-amber-300 opacity-100'
-                          : 'text-zinc-600 hover:text-amber-400 opacity-0 group-hover:opacity-100'
-                      }`}
-                      title={pinned ? 'Unpin' : 'Pin'}
-                    >
-                      <IconPin className="w-3 h-3" filled={pinned} />
-                    </button>
+                    <div className="flex items-center gap-1">
+                      {renderExternalLinkAction(subjectUrl, 'subject')}
+                      <button
+                        onClick={() => onTogglePin(makePinItem('subject', s))}
+                        className={`p-1 rounded transition-colors ${
+                          pinned
+                            ? 'text-amber-400 hover:text-amber-300 opacity-100'
+                            : 'text-zinc-600 hover:text-amber-400 opacity-0 group-hover:opacity-100'
+                        }`}
+                        title={pinned ? 'Unpin' : 'Pin'}
+                      >
+                        <IconPin className="w-3 h-3" filled={pinned} />
+                      </button>
+                    </div>
                   );
-                } : undefined}
+                } : (s) => renderExternalLinkAction(buildXnatEntityUrl('subject', {
+                  projectId: selectedProject?.id,
+                  subjectId: s.id,
+                }), 'subject')}
                 onSelect={selectSubject}
                 emptyMessage={q ? `No subjects matching "${search}"` : 'No subjects found'}
               />
@@ -1095,6 +1177,7 @@ export default function XnatBrowser({
                     const sessionError = sessionScansErrorById[session.id];
                     const sessionScans = getSourceScansForSession(session.id);
                     const isPinnedSession = isPinned(pins, 'session', session.id);
+                    const sessionUrl = buildXnatEntityUrl('session', { sessionId: session.id });
 
                     return (
                       <div key={session.id}>
@@ -1136,6 +1219,7 @@ export default function XnatBrowser({
                             </div>
                           </div>
                           <div className="shrink-0 flex items-center gap-1.5">
+                            {renderExternalLinkAction(sessionUrl, 'session')}
                             {onTogglePin && (
                               <button
                                 onClick={(e) => {


### PR DESCRIPTION
## Summary
- add external link actions for project, subject, and session rows in the XNAT navigator
- route link clicks through the Electron shell bridge without interfering with row selection or expansion
- cover the new entity URL behavior in the navigator component tests

## Testing
- npm test -- src/renderer/components/connection/XnatBrowser.test.tsx