### PR TITLE
Improve backup recovery workflow and banner UX

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -679,6 +679,14 @@ export default function App() {
       }
     }
     segStore._markClean();
+
+    // Delete local backup files for this session since the user confirmed discard
+    const currentSessionId = useViewerStore.getState().sessionId;
+    if (currentSessionId) {
+      backupService.deleteSessionBackups(currentSessionId).catch((err) => {
+        console.warn('[App] Failed to delete backup after discard:', err);
+      });
+    }
   }, []);
 
   const unsavedNavigation = useUnsavedNavigationDialog(discardCurrentAnnotations);
@@ -845,11 +853,10 @@ export default function App() {
     backupService.listAllBackups().then((sessions) => {
       // Only count entries for the currently connected server
       const matching = sessions.filter((s) => s.serverUrl === connectedServerUrl);
-      const totalEntries = matching.reduce((sum, s) => sum + s.entryCount, 0);
-      setBackupBannerCount(totalEntries);
+      setBackupBannerCount(matching.length);
       setBackupBannerDismissed(false);
-      if (totalEntries > 0) {
-        console.log(`[App] Found ${totalEntries} backed-up annotation(s) for ${connectedServerUrl}`);
+      if (matching.length > 0) {
+        console.log(`[App] Found ${matching.length} session(s) with backed-up annotations for ${connectedServerUrl}`);
       }
     }).catch(() => { /* ignore */ });
   }, [connectedServerUrl]);
@@ -2054,6 +2061,7 @@ export default function App() {
       sessionId: string,
       scans: XnatScan[],
       context: { projectId: string; subjectId: string; sessionLabel: string; projectName?: string; subjectLabel?: string },
+      options?: { useHangingProtocol?: boolean; targetScanId?: string },
     ) => {
       if (!isConnected) return;
 
@@ -2099,8 +2107,26 @@ export default function App() {
           console.log(`[App] Found ${rtStructScans.length} RTSTRUCT scan(s) — will auto-load as contour overlays`);
         }
 
-        // Match imaging scans to a hanging protocol
-        const { protocol, assignments, unmatched } = matchProtocol(imagingScans);
+        // Match imaging scans to a hanging protocol only when explicitly requested.
+        // Default to single layout — user can apply a protocol via the toolbar.
+        let protocolResult: ReturnType<typeof matchProtocol>;
+        if (options?.targetScanId) {
+          // Force a specific scan into panel 0 (used by recovery)
+          const targetScan = imagingScans.find((s) => s.id === options.targetScanId);
+          const singleProtocol = BUILT_IN_PROTOCOLS.find((p) => p.id === 'single')!;
+          const assignments = new Map<number, XnatScan>();
+          if (targetScan) assignments.set(0, targetScan);
+          protocolResult = {
+            protocol: singleProtocol,
+            assignments,
+            unmatched: imagingScans.filter((s) => s.id !== options.targetScanId),
+          };
+        } else if (options?.useHangingProtocol) {
+          protocolResult = matchProtocol(imagingScans);
+        } else {
+          protocolResult = matchProtocol(imagingScans, [BUILT_IN_PROTOCOLS.find((p) => p.id === 'single')!]);
+        }
+        const { protocol, assignments, unmatched } = protocolResult;
         console.log(
           `Matched protocol "${protocol.name}" (${protocol.layout}) — ` +
           `${assignments.size} assigned, ${unmatched.length} unmatched`
@@ -2482,11 +2508,13 @@ export default function App() {
   // ─── Recover backup from Settings → File Backup ─────────────────
   const handleRecoverBackup = useCallback(async (sessionId: string) => {
     try {
+      console.log(`[App] handleRecoverBackup: starting recovery for session ${sessionId}, current session: ${useViewerStore.getState().sessionId}`);
       const manifest = await backupService.getManifestForSession(sessionId);
       if (!manifest || manifest.entries.length === 0) {
         console.warn('[App] No backup entries to recover for', sessionId);
         return;
       }
+      console.log(`[App] handleRecoverBackup: ${manifest.entries.length} entries to recover`);
 
       // Build scanId → panelId + imageIds mapping from viewerStore
       let store = useViewerStore.getState();
@@ -2517,16 +2545,26 @@ export default function App() {
           return;
         }
 
+        // Discard current annotations before loading the new session so the
+        // unsaved-navigation prompt doesn't fire during recovery.
+        const segStore = useSegmentationStore.getState();
+        for (const seg of [...segStore.segmentations]) {
+          try { segmentationManager.removeSegmentation(seg.segmentationId); } catch { /* ok */ }
+        }
+        segStore._markClean();
+
         // Pre-mark as recovered so checkForAutoSaveRecovery (called at end of
         // loadSessionFromXnat) doesn't double-prompt for the same entries.
         markRecoveredSession(sessionId);
 
+        // Load the session with the specific source scan that the backup references
+        const targetScanId = manifest.entries[0]?.sourceScanId;
         await loadSessionFromXnat(sessionId, scans, {
           projectId,
           subjectId,
           sessionLabel: manifest.sessionLabel ?? sessionId,
           subjectLabel: manifest.subjectLabel,
-        });
+        }, { targetScanId });
 
         // Re-read store after session load
         store = useViewerStore.getState();
@@ -2544,7 +2582,49 @@ export default function App() {
         }
       }
 
+      // Remove existing segmentations for the source scans being recovered so
+      // the backup replaces them instead of appearing as duplicates.
+      // Capture the XNAT-derived scan IDs so we can register the recovered
+      // segmentation as the loaded overlay (preventing "available overlay" duplicates).
+      const recoverySourceScans = new Set(manifest.entries.map((e) => e.sourceScanId));
+      const derivedScanIdBySourceScan = new Map<string, string>();
+      {
+        const segStoreNow = useSegmentationStore.getState();
+        const originMap = segStoreNow.xnatOriginMap;
+        const localOriginMap = useSegmentationManagerStore.getState().localOriginBySegId;
+        for (const seg of [...segStoreNow.segmentations]) {
+          const xnatOrigin = originMap[seg.segmentationId];
+          if (xnatOrigin && recoverySourceScans.has(xnatOrigin.sourceScanId)) {
+            // Remember the XNAT annotation scan ID for this source scan
+            derivedScanIdBySourceScan.set(xnatOrigin.sourceScanId, xnatOrigin.scanId);
+            try {
+              segmentationManager.removeSegmentation(seg.segmentationId);
+              console.log(`[App] Removed XNAT segmentation ${seg.segmentationId} for source scan ${xnatOrigin.sourceScanId} before recovery`);
+            } catch (err) {
+              console.warn('[App] Failed to remove existing segmentation before recovery:', err);
+            }
+            continue;
+          }
+          // Check localOriginBySegId: composite key is "projectId/sessionId/scanId"
+          const localKey = localOriginMap[seg.segmentationId];
+          if (localKey) {
+            const parts = localKey.split('/');
+            const localSourceScan = parts[parts.length - 1];
+            if (recoverySourceScans.has(localSourceScan)) {
+              try {
+                segmentationManager.removeSegmentation(seg.segmentationId);
+                console.log(`[App] Removed local segmentation ${seg.segmentationId} for source scan ${localSourceScan} before recovery`);
+              } catch (err) {
+                console.warn('[App] Failed to remove existing segmentation before recovery:', err);
+              }
+            }
+          }
+        }
+      }
+
       let recoveredCount = 0;
+      const recoveredSegIds: string[] = [];
+      const recoveredBackupInfo = new Map<string, { sessionId: string; filename: string }>();
       for (const entry of manifest.entries) {
         const isRtStruct = entry.format === 'RTSTRUCT';
 
@@ -2594,10 +2674,28 @@ export default function App() {
           if (panelContext?.projectId) {
             const compositeKey = `${panelContext.projectId}/${panelContext.sessionId}/${entry.sourceScanId}`;
             useSegmentationManagerStore.getState().setLocalOrigin(recoveredSegId, compositeKey);
+
+            // Register the recovered seg as the loaded overlay for the XNAT-derived
+            // scan so it doesn't appear as a separate "available overlay" in the panel.
+            // Also set the XNAT origin so the save dialog offers overwrite vs new.
+            const derivedScanId = derivedScanIdBySourceScan.get(entry.sourceScanId);
+            if (derivedScanId) {
+              useSegmentationManagerStore.getState().recordLoaded(compositeKey, derivedScanId, {
+                segmentationId: recoveredSegId,
+                loadedAt: Date.now(),
+              });
+              useSegmentationManagerStore.getState().setLoadStatus(derivedScanId, 'loaded');
+              useSegmentationStore.getState().setXnatOrigin(recoveredSegId, {
+                scanId: derivedScanId,
+                sourceScanId: entry.sourceScanId,
+                projectId: panelContext.projectId,
+                sessionId: panelContext.sessionId,
+              });
+            }
           }
 
-          // Delete the recovered backup entry
-          await backupService.deleteBackupEntry(sessionId, entry.filename).catch(() => {});
+          recoveredSegIds.push(recoveredSegId);
+          recoveredBackupInfo.set(recoveredSegId, { sessionId, filename: entry.filename });
           recoveredCount++;
         } catch (err) {
           console.error(`[App] Recovery: failed to load "${entry.filename}":`, err);
@@ -2610,19 +2708,47 @@ export default function App() {
         const segStore = useSegmentationStore.getState();
         if (!segStore.showPanel) segStore.togglePanel();
 
+        // Navigate the browser panel to the recovered session with scans visible,
+        // but skip auto-loading to avoid reloading XNAT annotations on top of
+        // the just-recovered backup.
+        if (manifest.projectId && manifest.subjectId) {
+          setNavigateTo({
+            type: 'session',
+            projectId: manifest.projectId,
+            projectName: manifest.projectId,
+            subjectId: manifest.subjectId,
+            subjectLabel: manifest.subjectLabel ?? undefined,
+            sessionId: manifest.sessionId,
+            sessionLabel: manifest.sessionLabel ?? manifest.sessionId,
+            skipAutoLoad: true,
+          });
+        }
+
         // Dismiss the backup banner since we recovered
         setBackupBannerDismissed(true);
 
-        // Force re-sync after a microtask to ensure the panel is rendered
-        await new Promise((r) => setTimeout(r, 100));
+        // Force re-sync after a microtask to ensure the panel is rendered.
+        // The delay also ensures that the async clearAllDirty() triggered by
+        // _markClean() inside loadSegFromArrayBuffer has already completed,
+        // so the markDirty/markRecovered calls below are not wiped out.
+        await new Promise((r) => setTimeout(r, 150));
         segmentationService.sync();
+
+        // Mark recovered segmentations as dirty (unsaved) and recovered (UI highlight)
+        // AFTER the async _markClean/clearAllDirty cycle has settled.
+        const mgrStore = useSegmentationManagerStore.getState();
+        for (const segId of recoveredSegIds) {
+          mgrStore.markDirty(segId);
+          mgrStore.markRecovered(segId, recoveredBackupInfo.get(segId));
+        }
+        useSegmentationStore.getState()._markDirty();
       }
 
       console.log(`[App] Settings recovery: ${recoveredCount}/${manifest.entries.length} entries recovered`);
     } catch (err) {
       console.error('[App] Settings recovery failed:', err);
     }
-  }, [promptRecoveryConfirm, loadSessionFromXnat]);
+  }, [promptRecoveryConfirm, loadSessionFromXnat, setNavigateTo]);
 
   // ─── Error state ───────────────────────────────────────────────
 
@@ -2677,15 +2803,14 @@ export default function App() {
             <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z" clipRule="evenodd" />
           </svg>
           <span className="text-[11px] text-blue-200">
-            Found {backupBannerCount} backed-up annotation{backupBannerCount !== 1 ? 's' : ''} from a previous session.{' '}
+            There {backupBannerCount === 1 ? 'is' : 'are'} {backupBannerCount} session{backupBannerCount !== 1 ? 's' : ''} with annotations that have not been saved.{' '}
             <button
               type="button"
               onClick={() => setOpenSettingsToBackup(true)}
               className="underline text-blue-300 hover:text-blue-100 transition-colors"
             >
-              Open File Backup settings
+              Review now
             </button>
-            {' '}to review or recover.
           </span>
           <button
             type="button"

--- a/src/renderer/components/connection/XnatBrowser.tsx
+++ b/src/renderer/components/connection/XnatBrowser.tsx
@@ -364,8 +364,8 @@ export default function XnatBrowser({
           const data = await window.electronAPI.xnat.getScans(target.sessionId);
           setScans(data);
           maybeResolveSessionAssociations(target.sessionId, data);
-          // Auto-load session
-          if (onLoadSession && data.length > 0) {
+          // Auto-load session unless explicitly skipped
+          if (onLoadSession && data.length > 0 && !target.skipAutoLoad) {
             onLoadSession(target.sessionId, data, {
               projectId: target.projectId,
               subjectId: target.subjectId!,

--- a/src/renderer/components/settings/SettingsModal.tsx
+++ b/src/renderer/components/settings/SettingsModal.tsx
@@ -1032,7 +1032,7 @@ export default function SettingsModal({ open, onClose, onRecover, initialTab }: 
                                   >
                                     <div className="flex items-start justify-between gap-2">
                                       <div className="min-w-0">
-                                        <div className="text-[11px] text-zinc-300 leading-relaxed" title={session.sessionId}>
+                                        <div className="text-[11px] text-zinc-300 leading-relaxed">
                                           {displayLabel}
                                         </div>
                                         <div className="text-[10px] text-zinc-500 flex flex-wrap gap-x-2 mt-0.5">
@@ -1056,7 +1056,7 @@ export default function SettingsModal({ open, onClose, onRecover, initialTab }: 
                                               }
                                             }}
                                             className="px-2 py-1 rounded text-[11px] bg-green-900/50 text-green-300 hover:bg-green-900/70 transition-colors disabled:opacity-50"
-                                            title="Recover these annotations into the currently loaded session"
+
                                           >
                                             {recoveringSession === session.sessionId ? 'Recovering...' : 'Recover'}
                                           </button>
@@ -1068,7 +1068,7 @@ export default function SettingsModal({ open, onClose, onRecover, initialTab }: 
                                               window.electronAPI.shell.openExternal(xnatSessionUrl);
                                             }}
                                             className="px-2 py-1 rounded text-[11px] bg-zinc-800 text-blue-300 hover:bg-zinc-700 hover:text-blue-200 transition-colors"
-                                            title="Open session in XNAT"
+
                                           >
                                             Open
                                           </button>

--- a/src/renderer/components/viewer/SegmentationPanel.tsx
+++ b/src/renderer/components/viewer/SegmentationPanel.tsx
@@ -231,6 +231,7 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
   const localOriginBySegId = useSegmentationManagerStore((s) => s.localOriginBySegId);
   const loadStatusByDerivedScan = useSegmentationManagerStore((s) => s.loadStatus);
   const dirtySegIds = useSegmentationManagerStore((s) => s.dirtySegIds);
+  const recoveredSegIds = useSegmentationManagerStore((s) => s.recoveredSegIds);
   const presentation = useSegmentationManagerStore((s) => s.presentation);
 
   const activeSourceScanId = panelScanMap[activeViewportId] ?? null;
@@ -978,6 +979,12 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
       const result = await saveDicomByType(dicomType, base64, defaultName);
       if (result.ok && result.path) {
         setToast({ message: `Saved to ${result.path.split('/').pop()}`, type: 'success' });
+        const mgrState = useSegmentationManagerStore.getState();
+        const recoveredInfo = mgrState.recoveredSegIds[segmentationId];
+        mgrState.clearRecovered(segmentationId);
+        if (recoveredInfo && typeof recoveredInfo === 'object') {
+          backupService.deleteBackupEntry(recoveredInfo.sessionId, recoveredInfo.filename).catch(() => {});
+        }
       } else if (result.error) {
         setToast({ message: `Save failed: ${result.error}`, type: 'error' });
       }
@@ -1148,7 +1155,10 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
         }
 
         const mgrStore = useSegmentationManagerStore.getState();
+        // If this was a recovered segmentation, delete the original backup file
+        const recoveredInfo = mgrStore.recoveredSegIds[segmentationId];
         mgrStore.clearDirty(segmentationId);
+        mgrStore.clearRecovered(segmentationId);
         if (!mgrStore.hasDirtySegmentations()) {
           useSegmentationStore.getState()._markClean();
         }
@@ -1156,6 +1166,12 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
         try {
           await backupService.deleteEntriesForSegmentation(panelCtx.sessionId, segmentationId);
         } catch { /* ignore local backup cleanup errors */ }
+        // Also delete the original backup file if this was recovered (different segmentation ID)
+        if (recoveredInfo && typeof recoveredInfo === 'object') {
+          try {
+            await backupService.deleteBackupEntry(recoveredInfo.sessionId, recoveredInfo.filename);
+          } catch { /* ignore */ }
+        }
 
         // Clean up legacy XNAT temp files for this source scan
         try {
@@ -1457,14 +1473,18 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
               const origin = xnatOriginMap[seg.segmentationId];
               const rowDicomType = resolveSegRowDicomType(seg.segmentationId);
               const displayDicomType = rowDicomType;
-              const suffix = origin?.scanId ? `#${origin.scanId}` : 'unsaved';
+              const isDirty = !!dirtySegIds[seg.segmentationId];
+              const isRecovered = !!recoveredSegIds[seg.segmentationId];
+              const suffix = isDirty ? 'unsaved' : (origin?.scanId ? `#${origin.scanId}` : 'unsaved');
 
               return (
                 <div key={seg.segmentationId}>
                   {/* Segmentation row */}
                   <div
                     className={`group flex items-center gap-1.5 px-2 py-1.5 cursor-pointer transition-colors ${
-                      isActiveSeg ? 'bg-zinc-800/60' : 'hover:bg-zinc-800/40'
+                      isRecovered
+                        ? 'bg-amber-900/30 border-l-2 border-amber-500'
+                        : isActiveSeg ? 'bg-zinc-800/60' : 'hover:bg-zinc-800/40'
                     }`}
                     onClick={() => handleSelectSegmentationRow(seg.segmentationId)}
                   >
@@ -1504,7 +1524,7 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
                         title="Double-click to rename"
                       >
                         {seg.label}
-                        <span className="text-zinc-500 text-[10px] ml-1">({suffix})</span>
+                        <span className={`text-[10px] ml-1 ${isRecovered ? 'text-amber-400 font-medium' : 'text-zinc-500'}`}>({suffix})</span>
                       </span>
                     )}
 
@@ -1524,7 +1544,11 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
                           setSaveMenuOpen(saveMenuOpen === seg.segmentationId ? null : seg.segmentationId);
                         }}
                         disabled={saving}
-                        className="opacity-0 group-hover:opacity-100 text-zinc-500 hover:text-blue-400 transition-all p-0.5 rounded hover:bg-blue-900/20 disabled:opacity-30"
+                        className={`transition-all p-0.5 rounded disabled:opacity-30 ${
+                          isRecovered
+                            ? 'opacity-100 text-amber-400 hover:text-amber-300 hover:bg-amber-900/30'
+                            : 'opacity-0 group-hover:opacity-100 text-zinc-500 hover:text-blue-400 hover:bg-blue-900/20'
+                        }`}
                         title="Save segmentation"
                       >
                         <IconSave className="w-3.5 h-3.5" />
@@ -1931,8 +1955,8 @@ export default function SegmentationPanel({ sourceImageIds }: SegmentationPanelP
         )}
       </div>
 
-      {/* Backup status indicators */}
-      <div className="border-t border-zinc-800 px-3 py-2 space-y-2 shrink-0">
+      {/* Backup status indicators — fixed height to avoid shifting the toolbox */}
+      <div className="border-t border-zinc-800 px-3 py-1.5 shrink-0 h-7 flex items-center">
         {backupEnabled && autoSaveStatus !== 'idle' && (
           <div className="flex items-center gap-1">
             {autoSaveStatus === 'saving' && (

--- a/src/renderer/lib/pinnedItems.ts
+++ b/src/renderer/lib/pinnedItems.ts
@@ -59,6 +59,8 @@ export interface NavigateToTarget {
   subjectLabel?: string;
   sessionId?: string;
   sessionLabel?: string;
+  /** Navigate the browser tree without auto-loading the session. */
+  skipAutoLoad?: boolean;
 }
 
 // ─── Constants ────────────────────────────────────────────────────

--- a/src/renderer/pages/ViewerPage.tsx
+++ b/src/renderer/pages/ViewerPage.tsx
@@ -68,7 +68,7 @@ export default function ViewerPage({ panelImageIds, onApplyProtocol, onToggleMPR
   }, []);
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col flex-1 min-h-0">
       <Toolbar
         showDicomPanel={showDicomPanel}
         onToggleDicomPanel={toggleDicomPanel}

--- a/src/renderer/stores/segmentationManagerStore.ts
+++ b/src/renderer/stores/segmentationManagerStore.ts
@@ -58,6 +58,10 @@ interface SegmentationManagerState {
   /** Dirty tracking per segmentation ID */
   dirtySegIds: Record<string, boolean>;
 
+  /** Segmentation IDs recovered from backup (for UI highlighting until saved).
+   *  Value contains the backup session/filename so the entry can be deleted on save. */
+  recoveredSegIds: Record<string, { sessionId: string; filename: string } | true>;
+
   /** Timestamp of last manual save per segmentation ID */
   lastManualSaveAt: Record<string, number | null>;
 
@@ -83,6 +87,8 @@ interface SegmentationManagerState {
   setPresentation: (segId: string, segIdx: number, patch: Partial<{ color: RGBA; visible: boolean; locked: boolean }>) => void;
   markDirty: (segId: string) => void;
   clearDirty: (segId: string) => void;
+  markRecovered: (segId: string, backupInfo?: { sessionId: string; filename: string }) => void;
+  clearRecovered: (segId: string) => void;
   recordManualSave: (segId: string) => void;
   recordTempSaved: (sourceScanId: string) => void;
   setActiveSegmentationForPanel: (panelId: string, segId: string | null) => void;
@@ -106,6 +112,7 @@ const INITIAL_STATE = {
   loadStatus: {} as Record<string, LoadStatus>,
   presentation: {} as Record<string, PresentationState>,
   dirtySegIds: {} as Record<string, boolean>,
+  recoveredSegIds: {} as Record<string, { sessionId: string; filename: string } | true>,
   lastManualSaveAt: {} as Record<string, number | null>,
   lastTempSaveAtBySourceScan: {} as Record<string, number | null>,
   activeSegmentationIdByPanel: {} as Record<string, string | null>,
@@ -196,9 +203,19 @@ export const useSegmentationManagerStore = create<SegmentationManagerState>((set
       return { dirtySegIds: rest };
     }),
 
+  markRecovered: (segId, backupInfo) =>
+    set((s) => ({ recoveredSegIds: { ...s.recoveredSegIds, [segId]: backupInfo ?? true } })),
+
+  clearRecovered: (segId) =>
+    set((s) => {
+      const { [segId]: _, ...rest } = s.recoveredSegIds;
+      return { recoveredSegIds: rest };
+    }),
+
   recordManualSave: (segId) =>
     set((s) => ({
       dirtySegIds: (() => { const { [segId]: _, ...rest } = s.dirtySegIds; return rest; })(),
+      recoveredSegIds: (() => { const { [segId]: _, ...rest } = s.recoveredSegIds; return rest; })(),
       lastManualSaveAt: { ...s.lastManualSaveAt, [segId]: Date.now() },
     })),
 
@@ -251,6 +268,9 @@ export const useSegmentationManagerStore = create<SegmentationManagerState>((set
       // Remove dirty state
       const { [segmentationId]: _d, ...restDirty } = s.dirtySegIds;
 
+      // Remove recovered state
+      const { [segmentationId]: _r, ...restRecovered } = s.recoveredSegIds;
+
       // Remove manual save timestamp
       const { [segmentationId]: _m, ...restManualSave } = s.lastManualSaveAt;
 
@@ -259,6 +279,7 @@ export const useSegmentationManagerStore = create<SegmentationManagerState>((set
         presentation: restPresentation,
         localOriginBySegId: restLocalOrigin,
         dirtySegIds: restDirty,
+        recoveredSegIds: restRecovered,
         lastManualSaveAt: restManualSave,
       };
     }),


### PR DESCRIPTION
## Summary
- Fix banner to count sessions (not files) and update text to "There are N sessions with annotations that have not been saved. Review now."
- Remove redundant tooltips from Recover/Open buttons in settings panel
- Overhaul recovery flow: load the specific source scan, replace existing XNAT annotations instead of duplicating, set XNAT origin so save dialog offers overwrite/new, navigate browser without re-triggering session load
- Add amber highlighting and "unsaved" badge for recovered annotations with dedicated tracking that persists until save
- Delete backup files only after user explicitly saves (not on recovery), using original filename since recovered seg has a new ID
- Default to single layout on session load; hanging protocol only when explicitly applied via toolbar
- Fix layout overflow when banner is displayed (ViewerPage flex-1 min-h-0)
- Delete backup files when user confirms discarding unsaved changes
- Fixed-height backup status area to prevent toolbox shifting

## Test plan
- [ ] Connect to server with backed-up annotations → banner shows correct session count
- [ ] Click "Review now" → settings opens to backup tab
- [ ] Click Recover → session loads with source scan in single layout, browser shows session expanded
- [ ] Recovered annotation shows amber highlight and "unsaved" badge, save icon visible in amber
- [ ] Save recovered annotation → overwrite/new dialog appears, amber clears, backup file deleted
- [ ] Create annotation, navigate away confirming discard → backup file deleted, not in cached list
- [ ] No tooltips on Recover/Open buttons in settings
- [ ] Backup status indicator doesn't shift toolbox
- [ ] Run `npm run test` — all 424 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)