### PR TITLE
UI cleanup: browser navigation and settings panel

### DIFF
--- a/src/renderer/components/connection/XnatBrowser.test.tsx
+++ b/src/renderer/components/connection/XnatBrowser.test.tsx
@@ -209,12 +209,15 @@ describe('XnatBrowser', () => {
     );
   });
 
-  it('honors navigateTo session targets, auto-loads session, and refreshes scan level', async () => {
+  it('honors navigateTo session targets, auto-loads session, and shows expanded session at sessions level', async () => {
     const onLoadScan = vi.fn();
     const onLoadSession = vi.fn();
     const onNavigateComplete = vi.fn();
     const electronApi = setElectronApiMock({
       getProjects: vi.fn(async () => []),
+      getSessions: vi.fn(async () => [
+        { id: 'SESS9', label: 'Pinned Session', projectId: 'P9', subjectId: 'SUB9', scanCount: 2 },
+      ]),
       getScans: vi.fn(async () => [
         { id: '21', type: 'MR', modality: 'MR', seriesDescription: 'T1' },
         { id: '4001', type: 'RTSTRUCT', modality: 'RTSTRUCT', xsiType: 'xnat:otherDicomScanData', seriesDescription: 'RTSTRUCT' },
@@ -242,6 +245,8 @@ describe('XnatBrowser', () => {
     );
 
     await waitFor(() => expect(onNavigateComplete).toHaveBeenCalledTimes(1));
+
+    // Should auto-load the session
     expect(onLoadSession).toHaveBeenCalledWith(
       'SESS9',
       expect.arrayContaining([expect.objectContaining({ id: '21' })]),
@@ -251,13 +256,18 @@ describe('XnatBrowser', () => {
         sessionLabel: 'Pinned Session',
       }),
     );
+
+    // Should be at sessions level (not scans) with the session expanded showing its scans
+    expect(electronApi.xnat.getSessions).toHaveBeenCalledWith('P9', 'SUB9');
     expect(screen.getByText('Pinned Session')).toBeInTheDocument();
     expect(screen.getByText('T1')).toBeInTheDocument();
     expect(screen.queryByText('#4001 RTSTRUCT')).not.toBeInTheDocument();
 
-    await user.click(screen.getByTitle('Refresh scans'));
-    await waitFor(() => expect(electronApi.xnat.getScans).toHaveBeenCalledTimes(2));
+    // Refresh at sessions level
+    await user.click(screen.getByTitle('Refresh sessions'));
+    await waitFor(() => expect(electronApi.xnat.getSessions).toHaveBeenCalledTimes(2));
 
+    // Clicking a scan in the expanded session still works
     fireEvent.click(getClickableContaining(/T1/), { shiftKey: true });
     expect(onLoadScan).toHaveBeenLastCalledWith(
       'SESS9',
@@ -336,5 +346,76 @@ describe('XnatBrowser', () => {
 
     await user.click(screen.getByTitle('Refresh sessions'));
     expect(electronApi.xnat.getSessions).toHaveBeenCalledWith('P1', 'SUB1');
+  });
+
+  it('breadcrumb navigation fetches correct data after navigateTo switches session', async () => {
+    const onLoadSession = vi.fn();
+    const onNavigateComplete = vi.fn();
+
+    // First render: drill down into Project A / Subject A / Session A normally
+    const electronApi = setElectronApiMock({
+      getProjects: vi.fn(async () => [{ id: 'PA', name: 'Project A', subjectCount: 1, sessionCount: 1 }]),
+      getSubjects: vi.fn(async () => [{ id: 'SUBA', label: 'Subject-A', projectId: 'PA' }]),
+      getSessions: vi.fn(async () => [{ id: 'SESSA', label: 'Session-A', projectId: 'PA', subjectId: 'SUBA', scanCount: 1 }]),
+      getScans: vi.fn(async () => [{ id: '1', type: 'CT', modality: 'CT', seriesDescription: 'CT-A' }]),
+      getProjectSessions: vi.fn(async () => []),
+    });
+
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <XnatBrowser onLoadSession={onLoadSession} onNavigateComplete={onNavigateComplete} />,
+    );
+
+    // Drill down: Project A -> Subject A (sessions level)
+    await user.click(await screen.findByText('Project A'));
+    await user.click(await screen.findByText('Subject-A'));
+    await screen.findByText('Session-A');
+
+    // Now simulate pinned navigation to a different session in a different project/subject
+    electronApi.xnat.getScans = vi.fn(async () => [
+      { id: '2', type: 'MR', modality: 'MR', seriesDescription: 'MR-B' },
+    ]) as unknown as ElectronAPI['xnat']['getScans'];
+    electronApi.xnat.getSessions = vi.fn(async () => [
+      { id: 'SESSB', label: 'Session-B', projectId: 'PB', subjectId: 'SUBB', scanCount: 1 },
+    ]) as unknown as ElectronAPI['xnat']['getSessions'];
+    electronApi.xnat.getSubjects = vi.fn(async () => [
+      { id: 'SUBB', label: 'Subject-B', projectId: 'PB' },
+    ]) as unknown as ElectronAPI['xnat']['getSubjects'];
+
+    rerender(
+      <XnatBrowser
+        onLoadSession={onLoadSession}
+        onNavigateComplete={onNavigateComplete}
+        navigateTo={{
+          type: 'session',
+          serverUrl: 'https://xnat.example',
+          projectId: 'PB',
+          projectName: 'Project B',
+          subjectId: 'SUBB',
+          subjectLabel: 'Subject-B',
+          sessionId: 'SESSB',
+          sessionLabel: 'Session-B',
+          timestamp: Date.now(),
+        }}
+      />,
+    );
+
+    // Wait for pinned navigation to complete - now at sessions level with Session-B expanded
+    await waitFor(() => expect(onNavigateComplete).toHaveBeenCalled());
+
+    // navigateTo should have fetched sessions for the new subject (not stale Subject A)
+    expect(electronApi.xnat.getSessions).toHaveBeenCalledWith('PB', 'SUBB');
+    expect(screen.getByText('Session-B')).toBeInTheDocument();
+    // Expanded session should show its scans
+    expect(screen.getByText('MR-B')).toBeInTheDocument();
+
+    // Click project breadcrumb to navigate up to subjects level
+    await user.click(screen.getByText('Project B'));
+
+    // Verify that getSubjects was called with Project B (not stale Project A)
+    await waitFor(() => {
+      expect(electronApi.xnat.getSubjects).toHaveBeenCalledWith('PB');
+    });
+    expect(await screen.findByText('Subject-B')).toBeInTheDocument();
   });
 });

--- a/src/renderer/components/connection/XnatBrowser.tsx
+++ b/src/renderer/components/connection/XnatBrowser.tsx
@@ -420,23 +420,33 @@ export default function XnatBrowser({
           setSelectedProject(project);
           setSelectedSubject(subject);
           setSelectedSession(null);
+          setSubjects([]);
           setLevel('sessions');
           const data = await window.electronAPI.xnat.getSessions(target.projectId, target.subjectId);
           setSessions(data);
         } else if (target.type === 'session' && target.subjectId != null && target.sessionId != null) {
           const project: XnatProject = { id: target.projectId, name: target.projectName };
           const subject: XnatSubject = { id: target.subjectId, label: target.subjectLabel ?? '', projectId: target.projectId };
-          const session: XnatSession = { id: target.sessionId, label: target.sessionLabel ?? '', projectId: target.projectId, subjectId: target.subjectId };
           setSelectedProject(project);
           setSelectedSubject(subject);
-          setSelectedSession(session);
-          setLevel('scans');
-          const data = await window.electronAPI.xnat.getScans(target.sessionId);
-          setScans(data);
-          maybeResolveSessionAssociations(target.sessionId, data);
+          setSelectedSession(null);
+          setSubjects([]);
+          setSessions([]);
+          setLevel('sessions');
+
+          // Fetch the sessions list for this subject
+          const sessionsData = await window.electronAPI.xnat.getSessions(target.projectId, target.subjectId);
+          setSessions(sessionsData);
+
+          // Expand the target session and eagerly load its scans
+          setExpandedSessionIds({ [target.sessionId]: true });
+          const scansData = await window.electronAPI.xnat.getScans(target.sessionId);
+          setSessionScansById((prev) => ({ ...prev, [target.sessionId!]: scansData }));
+          maybeResolveSessionAssociations(target.sessionId, scansData);
+
           // Auto-load session unless explicitly skipped
-          if (onLoadSession && data.length > 0 && !target.skipAutoLoad) {
-            onLoadSession(target.sessionId, data, {
+          if (onLoadSession && scansData.length > 0 && !target.skipAutoLoad) {
+            onLoadSession(target.sessionId, scansData, {
               projectId: target.projectId,
               subjectId: target.subjectId!,
               sessionLabel: target.sessionLabel!,
@@ -1206,13 +1216,13 @@ export default function XnatBrowser({
                           <div className="min-w-0 flex-1">
                             <div className="text-sm text-zinc-200 font-medium truncate">
                               {session.label}
+                            </div>
+                            <div className="text-[11px] text-zinc-600 tabular-nums flex items-center gap-1.5">
                               {session.modality?.trim() && (
-                                <span className="ml-2 text-[10px] bg-zinc-700/80 text-zinc-300 px-1.5 py-0.5 rounded font-normal">
+                                <span className="text-[10px] bg-zinc-700/80 text-zinc-300 px-1.5 py-0.5 rounded">
                                   {session.modality.trim()}
                                 </span>
                               )}
-                            </div>
-                            <div className="text-[11px] text-zinc-600 tabular-nums">
                               {session.date && <span>{session.date}</span>}
                               {session.date && session.scanCount != null && ' · '}
                               {session.scanCount != null && `${session.scanCount} scans`}

--- a/src/renderer/components/settings/SettingsModal.tsx
+++ b/src/renderer/components/settings/SettingsModal.tsx
@@ -1032,8 +1032,34 @@ export default function SettingsModal({ open, onClose, onRecover, initialTab }: 
                                   >
                                     <div className="flex items-start justify-between gap-2">
                                       <div className="min-w-0">
-                                        <div className="text-[11px] text-zinc-300 leading-relaxed">
+                                        <div className="text-[11px] text-zinc-300 leading-relaxed flex items-center gap-1">
                                           {displayLabel}
+                                          {xnatSessionUrl && (
+                                            <button
+                                              type="button"
+                                              title="Open session in XNAT"
+                                              aria-label="Open session in XNAT"
+                                              onClick={() => {
+                                                window.electronAPI.shell.openExternal(xnatSessionUrl);
+                                              }}
+                                              className="inline-flex items-center text-blue-400 hover:text-blue-300 transition-colors shrink-0"
+                                            >
+                                              <svg
+                                                className="w-3.5 h-3.5"
+                                                viewBox="0 0 16 16"
+                                                fill="none"
+                                                stroke="currentColor"
+                                                strokeWidth="1.5"
+                                                strokeLinecap="round"
+                                                strokeLinejoin="round"
+                                                aria-hidden="true"
+                                              >
+                                                <path d="M9.5 2.5H13.5V6.5" />
+                                                <path d="M7 9L13.5 2.5" />
+                                                <path d="M13 9.5V12.5C13 13.0523 12.5523 13.5 12 13.5H3.5C2.94772 13.5 2.5 13.0523 2.5 12.5V4C2.5 3.44772 2.94772 3 3.5 3H6.5" />
+                                              </svg>
+                                            </button>
+                                          )}
                                         </div>
                                         <div className="text-[10px] text-zinc-500 flex flex-wrap gap-x-2 mt-0.5">
                                           <span>{session.entryCount} file{session.entryCount !== 1 ? 's' : ''}</span>
@@ -1059,18 +1085,6 @@ export default function SettingsModal({ open, onClose, onRecover, initialTab }: 
 
                                           >
                                             {recoveringSession === session.sessionId ? 'Recovering...' : 'Recover'}
-                                          </button>
-                                        )}
-                                        {xnatSessionUrl && (
-                                          <button
-                                            type="button"
-                                            onClick={() => {
-                                              window.electronAPI.shell.openExternal(xnatSessionUrl);
-                                            }}
-                                            className="px-2 py-1 rounded text-[11px] bg-zinc-800 text-blue-300 hover:bg-zinc-700 hover:text-blue-200 transition-colors"
-
-                                          >
-                                            Open
                                           </button>
                                         )}
                                         <button


### PR DESCRIPTION
## Summary
- Moved session modality badge from the label row to the date row to prevent truncation when session labels are long
- Replaced the "Open" button in the backup recovery panel with an inline external link icon next to the session breadcrumb, matching the icon used in the XNAT browser panel
- Changed pinned session and recovery navigation to land at the sessions level with the target session expanded in the tree, rather than drilling down to the individual scan level
- Fixed a bug where breadcrumb navigation after a pinned session switch showed stale data from the previously loaded session
- Added tests covering breadcrumb navigation correctness after navigateTo session switches

## Test plan
- [x] All 4 XnatBrowser tests pass
- [x] Click a pinned session — browser shows sessions list with target session expanded
- [x] Recover from backup — browser shows sessions list with target session expanded
- [x] Click breadcrumbs after pinned navigation — correct data loads
- [x] Verify modality badge displays on date row without truncation
- [x] Verify linkout icon appears next to recovery breadcrumb and opens XNAT

🤖 Generated with [Claude Code](https://claude.com/claude-code)