### PR TITLE
[codex] revive configurable auto-update support

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,8 +1,14 @@
 appId: com.xnat.workstation
 productName: XNAT Workstation
+artifactName: XNAT-Workstation-${version}-${arch}.${ext}
 directories:
   buildResources: build
   output: release
+publish:
+  provider: github
+  owner: danielmarcus
+  repo: xnat-workstation
+  releaseType: release
 files:
   - dist/**/*
   - package.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@cornerstonejs/tools": "^4.16.1",
         "@xmldom/xmldom": "^0.8.11",
         "dicom-parser": "^1.8.21",
+        "electron-updater": "^6.8.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "zustand": "^5.0.11"
@@ -4870,7 +4871,6 @@
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
       "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
-      "dev": true,
       "dependencies": {
         "debug": "^4.3.4",
         "sax": "^1.2.4"
@@ -6150,6 +6150,80 @@
       "version": "1.5.286",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A=="
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
+      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+      "dependencies": {
+        "builder-util-runtime": "9.5.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/electron-updater/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-updater/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/electron-updater/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-updater/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
@@ -7619,8 +7693,7 @@
     "node_modules/lazy-val": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
-      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true
+      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q=="
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -7694,11 +7767,22 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "peer": true
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
+    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead."
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead."
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -9341,7 +9425,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
       "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
-      "dev": true,
       "engines": {
         "node": ">=11.0.0"
       }
@@ -10131,6 +10214,11 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@cornerstonejs/tools": "^4.16.1",
     "@xmldom/xmldom": "^0.8.11",
     "dicom-parser": "^1.8.21",
+    "electron-updater": "^6.8.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "zustand": "^5.0.11"

--- a/src/main/index.test.ts
+++ b/src/main/index.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => {
   const app = {
     name: '',
     isPackaged: false,
+    getVersion: vi.fn(() => '0.5.2'),
     whenReady: vi.fn(() => Promise.resolve()),
     on: vi.fn((event: string, cb: () => void) => {
       appHandlers[event] = cb;
@@ -65,6 +66,11 @@ const mocks = vi.hoisted(() => {
     registerUploadHandlers: vi.fn(),
     registerBackupHandlers: vi.fn(),
     registerDiagnosticsHandlers: vi.fn(),
+    registerUpdateHandlers: vi.fn(),
+    autoUpdateService: {
+      initialize: vi.fn(),
+      dispose: vi.fn(),
+    },
     installMainLogCapture: vi.fn(),
   };
 });
@@ -102,6 +108,14 @@ vi.mock('./ipc/diagnosticsHandlers', () => ({
   registerDiagnosticsHandlers: mocks.registerDiagnosticsHandlers,
 }));
 
+vi.mock('./ipc/updateHandlers', () => ({
+  registerUpdateHandlers: mocks.registerUpdateHandlers,
+}));
+
+vi.mock('./updater/autoUpdateService', () => ({
+  autoUpdateService: mocks.autoUpdateService,
+}));
+
 vi.mock('./diagnostics/mainLogBuffer', () => ({
   installMainLogCapture: mocks.installMainLogCapture,
 }));
@@ -131,6 +145,8 @@ describe('main/index bootstrap', () => {
     expect(mocks.registerUploadHandlers).toHaveBeenCalledTimes(1);
     expect(mocks.registerBackupHandlers).toHaveBeenCalledTimes(1);
     expect(mocks.registerDiagnosticsHandlers).toHaveBeenCalledTimes(1);
+    expect(mocks.registerUpdateHandlers).toHaveBeenCalledTimes(1);
+    expect(mocks.autoUpdateService.initialize).toHaveBeenCalledTimes(1);
     expect(mocks.installMainLogCapture).toHaveBeenCalledTimes(1);
 
     expect(mocks.app.name).toBe('XNAT');
@@ -163,5 +179,8 @@ describe('main/index bootstrap', () => {
     } else {
       expect(mocks.app.quit).not.toHaveBeenCalled();
     }
+
+    mocks.appHandlers['before-quit']?.();
+    expect(mocks.autoUpdateService.dispose).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,8 +6,10 @@ import { registerExportHandlers } from './ipc/exportHandlers';
 import { registerUploadHandlers } from './ipc/uploadHandlers';
 import { registerBackupHandlers } from './ipc/backupHandlers';
 import { registerDiagnosticsHandlers } from './ipc/diagnosticsHandlers';
+import { registerUpdateHandlers } from './ipc/updateHandlers';
 import { installMainLogCapture } from './diagnostics/mainLogBuffer';
 import { IPC } from '../shared/ipcChannels';
+import { autoUpdateService } from './updater/autoUpdateService';
 
 installMainLogCapture();
 
@@ -201,6 +203,8 @@ app.whenReady().then(() => {
   registerUploadHandlers();
   registerBackupHandlers();
   registerDiagnosticsHandlers();
+  registerUpdateHandlers();
+  autoUpdateService.initialize();
 
   // Shell: open URL in system browser
   ipcMain.handle(IPC.SHELL_OPEN_EXTERNAL, async (_event, url: string) => {
@@ -245,6 +249,10 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit();
   }
+});
+
+app.on('before-quit', () => {
+  autoUpdateService.dispose();
 });
 
 app.on('activate', () => {

--- a/src/main/ipc/updateHandlers.test.ts
+++ b/src/main/ipc/updateHandlers.test.ts
@@ -1,0 +1,104 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IPC } from '../../shared/ipcChannels';
+import { createIpcMainMock } from '../../test/ipc/ipcMocks';
+
+const ipcMainMock = createIpcMainMock();
+
+const updateServiceMock = {
+  getState: vi.fn(),
+  configure: vi.fn(),
+  checkForUpdates: vi.fn(),
+  quitAndInstall: vi.fn(),
+};
+
+let registerUpdateHandlers: (typeof import('./updateHandlers'))['registerUpdateHandlers'];
+
+beforeAll(async () => {
+  vi.doMock('electron', () => ({
+    ipcMain: ipcMainMock.ipcMain,
+  }));
+
+  vi.doMock('../updater/autoUpdateService', () => ({
+    autoUpdateService: updateServiceMock,
+  }));
+
+  ({ registerUpdateHandlers } = await import('./updateHandlers'));
+});
+
+describe('registerUpdateHandlers', () => {
+  beforeEach(() => {
+    ipcMainMock.handlers.clear();
+    ipcMainMock.listeners.clear();
+    ipcMainMock.ipcMain.handle.mockClear();
+    vi.clearAllMocks();
+    updateServiceMock.getState.mockReturnValue({
+      phase: 'idle',
+      currentVersion: '0.5.2',
+      enabled: true,
+      autoDownload: true,
+      isPackaged: true,
+      availableVersion: null,
+      downloadedVersion: null,
+      downloadProgressPercent: null,
+      lastCheckedAt: null,
+      message: null,
+      error: null,
+    });
+    updateServiceMock.configure.mockResolvedValue({
+      ok: true,
+      status: updateServiceMock.getState(),
+    });
+    updateServiceMock.checkForUpdates.mockResolvedValue({
+      ok: true,
+      status: updateServiceMock.getState(),
+    });
+    updateServiceMock.quitAndInstall.mockResolvedValue({ ok: true });
+  });
+
+  it('registers the updater IPC contract', () => {
+    registerUpdateHandlers();
+
+    const channels = ipcMainMock.ipcMain.handle.mock.calls.map((call) => call[0]);
+    expect(channels).toEqual([
+      IPC.UPDATER_GET_STATE,
+      IPC.UPDATER_CONFIGURE,
+      IPC.UPDATER_CHECK_FOR_UPDATES,
+      IPC.UPDATER_QUIT_AND_INSTALL,
+    ]);
+  });
+
+  it('forwards valid updater requests to the service', async () => {
+    registerUpdateHandlers();
+
+    await expect(ipcMainMock.invoke(IPC.UPDATER_GET_STATE)).resolves.toEqual(updateServiceMock.getState());
+    await expect(
+      ipcMainMock.invoke(IPC.UPDATER_CONFIGURE, { enabled: false, autoDownload: false }),
+    ).resolves.toEqual({
+      ok: true,
+      status: updateServiceMock.getState(),
+    });
+    await expect(ipcMainMock.invoke(IPC.UPDATER_CHECK_FOR_UPDATES)).resolves.toEqual({
+      ok: true,
+      status: updateServiceMock.getState(),
+    });
+    await expect(ipcMainMock.invoke(IPC.UPDATER_QUIT_AND_INSTALL)).resolves.toEqual({ ok: true });
+
+    expect(updateServiceMock.configure).toHaveBeenCalledWith({ enabled: false, autoDownload: false });
+    expect(updateServiceMock.checkForUpdates).toHaveBeenCalledWith({ manual: true });
+    expect(updateServiceMock.quitAndInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects invalid updater configuration payloads with a stable error shape', async () => {
+    registerUpdateHandlers();
+
+    await expect(
+      ipcMainMock.invoke(IPC.UPDATER_CONFIGURE, { enabled: 'yes', autoDownload: false }),
+    ).resolves.toEqual({
+      ok: false,
+      status: updateServiceMock.getState(),
+      error: `Invalid payload for ${IPC.UPDATER_CONFIGURE}: expected boolean enabled and autoDownload values`,
+    });
+
+    expect(updateServiceMock.configure).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/ipc/updateHandlers.ts
+++ b/src/main/ipc/updateHandlers.ts
@@ -1,0 +1,38 @@
+import { ipcMain } from 'electron';
+import { IPC } from '../../shared/ipcChannels';
+import type { ConfigureUpdaterRequest } from '../../shared/types/updater';
+import {
+  autoUpdateService,
+  type AutoUpdateService,
+} from '../updater/autoUpdateService';
+
+function isConfigureUpdaterRequest(value: unknown): value is ConfigureUpdaterRequest {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<ConfigureUpdaterRequest>;
+  return typeof candidate.enabled === 'boolean' && typeof candidate.autoDownload === 'boolean';
+}
+
+export function registerUpdateHandlers(
+  service: AutoUpdateService = autoUpdateService,
+): void {
+  ipcMain.handle(IPC.UPDATER_GET_STATE, () => service.getState());
+
+  ipcMain.handle(IPC.UPDATER_CONFIGURE, async (_event, config: unknown) => {
+    if (!isConfigureUpdaterRequest(config)) {
+      return {
+        ok: false,
+        status: service.getState(),
+        error: `Invalid payload for ${IPC.UPDATER_CONFIGURE}: expected boolean enabled and autoDownload values`,
+      };
+    }
+    return service.configure(config);
+  });
+
+  ipcMain.handle(IPC.UPDATER_CHECK_FOR_UPDATES, async () => {
+    return service.checkForUpdates({ manual: true });
+  });
+
+  ipcMain.handle(IPC.UPDATER_QUIT_AND_INSTALL, async () => {
+    return service.quitAndInstall();
+  });
+}

--- a/src/main/updater/autoUpdateService.test.ts
+++ b/src/main/updater/autoUpdateService.test.ts
@@ -1,0 +1,159 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IPC } from '../../shared/ipcChannels';
+
+type Listener = (...args: any[]) => void;
+
+function createFakeUpdater() {
+  const listeners = new Map<string, Set<Listener>>();
+  return {
+    autoDownload: true,
+    autoInstallOnAppQuit: true,
+    checkForUpdates: vi.fn(async () => undefined),
+    quitAndInstall: vi.fn(),
+    on(event: string, listener: Listener) {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)?.add(listener);
+      return this;
+    },
+    removeListener(event: string, listener: Listener) {
+      listeners.get(event)?.delete(listener);
+      return this;
+    },
+    emit(event: string, ...args: unknown[]) {
+      for (const listener of listeners.get(event) ?? []) {
+        listener(...args);
+      }
+    },
+    listenerCount(event: string) {
+      return listeners.get(event)?.size ?? 0;
+    },
+  };
+}
+
+const sendMock = vi.fn();
+const electronMocks = {
+  app: {
+    isPackaged: true,
+    getVersion: vi.fn(() => '0.5.2'),
+  },
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => [
+      {
+        isDestroyed: () => false,
+        webContents: {
+          send: sendMock,
+        },
+      },
+    ]),
+  },
+};
+
+let createAutoUpdateService: (typeof import('./autoUpdateService'))['createAutoUpdateService'];
+
+beforeAll(async () => {
+  vi.doMock('electron', () => electronMocks);
+  vi.doMock('electron-updater', () => ({
+    autoUpdater: createFakeUpdater(),
+  }));
+
+  ({ createAutoUpdateService } = await import('./autoUpdateService'));
+});
+
+describe('autoUpdateService', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    electronMocks.app.isPackaged = true;
+  });
+
+  it('schedules automatic checks when initialized in packaged builds', async () => {
+    const updater = createFakeUpdater();
+    const service = createAutoUpdateService(updater as any);
+
+    service.initialize();
+    expect(updater.autoDownload).toBe(true);
+    expect(updater.autoInstallOnAppQuit).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(1);
+
+    service.dispose();
+    expect(updater.listenerCount('checking-for-update')).toBe(0);
+  });
+
+  it('tracks update lifecycle events and broadcasts status snapshots', () => {
+    const updater = createFakeUpdater();
+    const service = createAutoUpdateService(updater as any);
+    service.initialize();
+
+    updater.emit('update-available', { version: '0.5.3' });
+    expect(service.getState().phase).toBe('downloading');
+    expect(service.getState().availableVersion).toBe('0.5.3');
+
+    updater.emit('download-progress', { percent: 42.4 });
+    expect(service.getState().phase).toBe('downloading');
+    expect(service.getState().downloadProgressPercent).toBeCloseTo(42.4);
+
+    updater.emit('update-downloaded', { version: '0.5.3' });
+    expect(service.getState().phase).toBe('downloaded');
+    expect(service.getState().downloadedVersion).toBe('0.5.3');
+
+    expect(sendMock).toHaveBeenCalledWith(
+      IPC.UPDATER_STATUS,
+      expect.objectContaining({
+        phase: 'downloaded',
+        downloadedVersion: '0.5.3',
+      }),
+    );
+
+    service.dispose();
+  });
+
+  it('applies configuration updates and stops automatic checks when disabled', async () => {
+    const updater = createFakeUpdater();
+    const service = createAutoUpdateService(updater as any);
+    service.initialize();
+
+    const result = await service.configure({ enabled: false, autoDownload: false });
+    expect(result.ok).toBe(true);
+    expect(service.getState().enabled).toBe(false);
+    expect(service.getState().autoDownload).toBe(false);
+    expect(service.getState().phase).toBe('disabled');
+    expect(updater.autoDownload).toBe(false);
+    expect(updater.autoInstallOnAppQuit).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(updater.checkForUpdates).not.toHaveBeenCalled();
+
+    service.dispose();
+  });
+
+  it('returns unsupported errors for development builds', async () => {
+    electronMocks.app.isPackaged = false;
+    const updater = createFakeUpdater();
+    const service = createAutoUpdateService(updater as any);
+
+    const result = await service.checkForUpdates({ manual: true });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('packaged builds');
+    expect(service.getState().phase).toBe('unsupported');
+    expect(updater.checkForUpdates).not.toHaveBeenCalled();
+  });
+
+  it('only installs after an update has been downloaded', async () => {
+    const updater = createFakeUpdater();
+    const service = createAutoUpdateService(updater as any);
+    service.initialize();
+
+    await expect(service.quitAndInstall()).resolves.toEqual({
+      ok: false,
+      error: 'No downloaded update is ready to install.',
+    });
+
+    updater.emit('update-downloaded', { version: '0.5.3' });
+    await expect(service.quitAndInstall()).resolves.toEqual({ ok: true });
+    expect(updater.quitAndInstall).toHaveBeenCalledWith(false, true);
+
+    service.dispose();
+  });
+});

--- a/src/main/updater/autoUpdateService.ts
+++ b/src/main/updater/autoUpdateService.ts
@@ -1,0 +1,302 @@
+import { app, BrowserWindow } from 'electron';
+import { autoUpdater } from 'electron-updater';
+import { IPC } from '../../shared/ipcChannels';
+import {
+  DEFAULT_UPDATE_PREFERENCES,
+  type CheckForUpdatesResponse,
+  type ConfigureUpdaterRequest,
+  type ConfigureUpdaterResponse,
+  type QuitAndInstallResponse,
+  type UpdateStatus,
+} from '../../shared/types/updater';
+
+const AUTO_UPDATE_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const INITIAL_CHECK_DELAY_MS = 3 * 1000;
+
+type UpdaterLike = {
+  autoDownload: boolean;
+  autoInstallOnAppQuit: boolean;
+  on(event: string, listener: (...args: any[]) => void): unknown;
+  removeListener(event: string, listener: (...args: any[]) => void): unknown;
+  checkForUpdates(): Promise<unknown>;
+  quitAndInstall(isSilent?: boolean, isForceRunAfter?: boolean): void;
+};
+
+type UpdateInfoLike = {
+  version?: string | null;
+};
+
+type ProgressInfoLike = {
+  percent?: number | null;
+};
+
+export interface AutoUpdateService {
+  initialize(): void;
+  dispose(): void;
+  getState(): UpdateStatus;
+  configure(config: ConfigureUpdaterRequest): Promise<ConfigureUpdaterResponse>;
+  checkForUpdates(options?: { manual?: boolean }): Promise<CheckForUpdatesResponse>;
+  quitAndInstall(): Promise<QuitAndInstallResponse>;
+}
+
+function createInitialStatus(): UpdateStatus {
+  const isPackaged = app.isPackaged;
+  return {
+    phase: isPackaged ? 'idle' : 'unsupported',
+    currentVersion: app.getVersion(),
+    enabled: DEFAULT_UPDATE_PREFERENCES.enabled,
+    autoDownload: DEFAULT_UPDATE_PREFERENCES.autoDownload,
+    isPackaged,
+    availableVersion: null,
+    downloadedVersion: null,
+    downloadProgressPercent: null,
+    lastCheckedAt: null,
+    message: isPackaged ? 'Automatic update checks are enabled.' : 'Auto-update is only available in packaged builds.',
+    error: null,
+  };
+}
+
+export function createAutoUpdateService(
+  updater: UpdaterLike = autoUpdater,
+): AutoUpdateService {
+  let initialized = false;
+  let startupTimer: ReturnType<typeof setTimeout> | null = null;
+  let intervalTimer: ReturnType<typeof setInterval> | null = null;
+  let checkInFlight = false;
+  let status = createInitialStatus();
+  const listeners = new Map<string, (...args: any[]) => void>();
+
+  function emitStatus(): void {
+    for (const window of BrowserWindow.getAllWindows()) {
+      if (window.isDestroyed()) continue;
+      window.webContents.send(IPC.UPDATER_STATUS, status);
+    }
+  }
+
+  function setStatus(next: Partial<UpdateStatus>): void {
+    status = {
+      ...status,
+      ...next,
+      currentVersion: app.getVersion(),
+      isPackaged: app.isPackaged,
+    };
+    emitStatus();
+  }
+
+  function clearTimers(): void {
+    if (startupTimer) {
+      clearTimeout(startupTimer);
+      startupTimer = null;
+    }
+    if (intervalTimer) {
+      clearInterval(intervalTimer);
+      intervalTimer = null;
+    }
+  }
+
+  async function runCheck(manual: boolean): Promise<CheckForUpdatesResponse> {
+    if (!app.isPackaged) {
+      setStatus({
+        phase: 'unsupported',
+        message: 'Auto-update is only available in packaged builds.',
+        error: null,
+      });
+      return {
+        ok: false,
+        status,
+        error: 'Auto-update is only available in packaged builds.',
+      };
+    }
+
+    if (checkInFlight) {
+      return { ok: true, status };
+    }
+
+    checkInFlight = true;
+    setStatus({
+      phase: 'checking',
+      lastCheckedAt: new Date().toISOString(),
+      downloadProgressPercent: null,
+      message: manual ? 'Checking for updates...' : 'Checking for updates in the background...',
+      error: null,
+    });
+
+    try {
+      await updater.checkForUpdates();
+      return { ok: true, status };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setStatus({
+        phase: 'error',
+        message: 'Update check failed.',
+        error: message,
+      });
+      return { ok: false, status, error: message };
+    } finally {
+      checkInFlight = false;
+    }
+  }
+
+  function scheduleAutomaticChecks(): void {
+    clearTimers();
+    if (!app.isPackaged || !status.enabled) {
+      if (!app.isPackaged) {
+        setStatus({
+          phase: 'unsupported',
+          message: 'Auto-update is only available in packaged builds.',
+          error: null,
+        });
+      } else if (status.phase !== 'downloaded') {
+        setStatus({
+          phase: 'disabled',
+          message: 'Automatic update checks are disabled.',
+          error: null,
+        });
+      }
+      return;
+    }
+
+    if (status.phase === 'disabled') {
+      setStatus({
+        phase: 'idle',
+        message: 'Automatic update checks are enabled.',
+        error: null,
+      });
+    }
+
+    startupTimer = setTimeout(() => {
+      void runCheck(false);
+    }, INITIAL_CHECK_DELAY_MS);
+    intervalTimer = setInterval(() => {
+      void runCheck(false);
+    }, AUTO_UPDATE_INTERVAL_MS);
+  }
+
+  function bindUpdaterListeners(): void {
+    const subscriptions: Array<[string, (...args: any[]) => void]> = [
+      ['checking-for-update', () => {
+        setStatus({
+          phase: 'checking',
+          lastCheckedAt: new Date().toISOString(),
+          message: 'Checking for updates...',
+          error: null,
+        });
+      }],
+      ['update-available', (info: UpdateInfoLike) => {
+        const version = info?.version ?? null;
+        setStatus({
+          phase: status.autoDownload ? 'downloading' : 'available',
+          availableVersion: version,
+          downloadedVersion: null,
+          downloadProgressPercent: status.autoDownload ? 0 : null,
+          message: status.autoDownload
+            ? `Update ${version ?? 'available'} found. Downloading...`
+            : `Update ${version ?? 'available'} is ready to download.`,
+          error: null,
+        });
+      }],
+      ['update-not-available', () => {
+        setStatus({
+          phase: status.enabled ? 'upToDate' : 'disabled',
+          availableVersion: null,
+          downloadedVersion: null,
+          downloadProgressPercent: null,
+          message: 'You are running the latest version.',
+          error: null,
+        });
+      }],
+      ['download-progress', (progress: ProgressInfoLike) => {
+        const percent = typeof progress?.percent === 'number' && Number.isFinite(progress.percent)
+          ? Math.max(0, Math.min(100, progress.percent))
+          : null;
+        setStatus({
+          phase: 'downloading',
+          downloadProgressPercent: percent,
+          message: percent === null
+            ? 'Downloading update...'
+            : `Downloading update... ${Math.round(percent)}%`,
+          error: null,
+        });
+      }],
+      ['update-downloaded', (info: UpdateInfoLike) => {
+        const version = info?.version ?? status.availableVersion;
+        setStatus({
+          phase: 'downloaded',
+          availableVersion: version ?? null,
+          downloadedVersion: version ?? null,
+          downloadProgressPercent: 100,
+          message: `Update ${version ?? 'ready'} downloaded. Restart to install.`,
+          error: null,
+        });
+      }],
+      ['error', (error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        setStatus({
+          phase: 'error',
+          downloadProgressPercent: null,
+          message: 'Auto-update encountered an error.',
+          error: message,
+        });
+      }],
+    ];
+
+    for (const [eventName, listener] of subscriptions) {
+      listeners.set(eventName, listener);
+      updater.on(eventName, listener);
+    }
+  }
+
+  return {
+    initialize() {
+      if (initialized) return;
+      initialized = true;
+      updater.autoDownload = status.autoDownload;
+      updater.autoInstallOnAppQuit = status.autoDownload;
+      bindUpdaterListeners();
+      scheduleAutomaticChecks();
+    },
+
+    dispose() {
+      clearTimers();
+      for (const [eventName, listener] of listeners) {
+        updater.removeListener(eventName, listener);
+      }
+      listeners.clear();
+      initialized = false;
+    },
+
+    getState() {
+      return status;
+    },
+
+    async configure(config) {
+      status = {
+        ...status,
+        enabled: config.enabled,
+        autoDownload: config.autoDownload,
+      };
+      updater.autoDownload = config.autoDownload;
+      updater.autoInstallOnAppQuit = config.autoDownload;
+      scheduleAutomaticChecks();
+      emitStatus();
+      return { ok: true, status };
+    },
+
+    async checkForUpdates(options = {}) {
+      return runCheck(!!options.manual);
+    },
+
+    async quitAndInstall() {
+      if (status.phase !== 'downloaded') {
+        return {
+          ok: false,
+          error: 'No downloaded update is ready to install.',
+        };
+      }
+      updater.quitAndInstall(false, true);
+      return { ok: true };
+    },
+  };
+}
+
+export const autoUpdateService = createAutoUpdateService();

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -84,6 +84,10 @@ describe('preload bridge', () => {
     await api.export.saveDicomRtStruct('ZmFrZQ==', 'rtstruct.dcm');
     await api.export.saveViewportCapture({ x: 1, y: 2, width: 3, height: 4 }, 'capture.png');
     await api.diagnostics.getMainSnapshot();
+    await api.updater.getState();
+    await api.updater.configure({ enabled: true, autoDownload: false });
+    await api.updater.checkForUpdates();
+    await api.updater.quitAndInstall();
 
     expect(mocks.invoke).toHaveBeenCalledWith(IPC.XNAT_BROWSER_LOGIN, 'https://xnat.example');
     expect(mocks.invoke).toHaveBeenCalledWith(IPC.XNAT_LOGOUT);
@@ -151,6 +155,10 @@ describe('preload bridge', () => {
       'capture.png',
     );
     expect(mocks.invoke).toHaveBeenCalledWith(IPC.DIAGNOSTICS_GET_MAIN_SNAPSHOT);
+    expect(mocks.invoke).toHaveBeenCalledWith(IPC.UPDATER_GET_STATE);
+    expect(mocks.invoke).toHaveBeenCalledWith(IPC.UPDATER_CONFIGURE, { enabled: true, autoDownload: false });
+    expect(mocks.invoke).toHaveBeenCalledWith(IPC.UPDATER_CHECK_FOR_UPDATES);
+    expect(mocks.invoke).toHaveBeenCalledWith(IPC.UPDATER_QUIT_AND_INSTALL);
   });
 
   it('allows only whitelisted event channels and unsubscribes listeners', () => {
@@ -178,5 +186,19 @@ describe('preload bridge', () => {
     );
     expect(() => off()).not.toThrow();
     warnSpy.mockRestore();
+  });
+
+  it('subscribes and unsubscribes updater status listeners', () => {
+    const api = mocks.exposed.api;
+    const callback = vi.fn();
+    const off = api.updater.onStatus(callback);
+
+    expect(mocks.on).toHaveBeenCalledWith(IPC.UPDATER_STATUS, expect.any(Function));
+    const wrapped = mocks.getOnHandler(IPC.UPDATER_STATUS);
+    wrapped?.({} as any, { phase: 'checking' });
+    expect(callback).toHaveBeenCalledWith({ phase: 'checking' });
+
+    off();
+    expect(mocks.removeListener).toHaveBeenCalledWith(IPC.UPDATER_STATUS, expect.any(Function));
   });
 });

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -170,6 +170,24 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke(IPC.DIAGNOSTICS_GET_MAIN_SNAPSHOT),
   },
 
+  updater: {
+    getState: () =>
+      ipcRenderer.invoke(IPC.UPDATER_GET_STATE),
+    configure: (config: { enabled: boolean; autoDownload: boolean }) =>
+      ipcRenderer.invoke(IPC.UPDATER_CONFIGURE, config),
+    checkForUpdates: () =>
+      ipcRenderer.invoke(IPC.UPDATER_CHECK_FOR_UPDATES),
+    quitAndInstall: () =>
+      ipcRenderer.invoke(IPC.UPDATER_QUIT_AND_INSTALL),
+    onStatus: (callback: (status: unknown) => void) => {
+      const wrappedCallback = (_event: Electron.IpcRendererEvent, status: unknown) => callback(status);
+      ipcRenderer.on(IPC.UPDATER_STATUS, wrappedCallback);
+      return () => {
+        ipcRenderer.removeListener(IPC.UPDATER_STATUS, wrappedCallback);
+      };
+    },
+  },
+
   // E2E testing: direct login bypass (only registered when E2E_TESTING=1)
   e2e: {
     directLogin: (serverUrl: string, username: string, password: string) =>

--- a/src/renderer/components/settings/SettingsModal.test.tsx
+++ b/src/renderer/components/settings/SettingsModal.test.tsx
@@ -5,12 +5,18 @@ import { DEFAULT_PREFERENCES } from '@shared/types/preferences';
 import SettingsModal from './SettingsModal';
 import { usePreferencesStore } from '../../stores/preferencesStore';
 import type { MainDiagnosticsSnapshot } from '@shared/types/diagnostics';
+import type { UpdateStatus } from '@shared/types';
 
 function resetPreferencesStore(): void {
   usePreferencesStore.setState(usePreferencesStore.getInitialState(), true);
 }
 
 const clipboardWriteTextMock = vi.fn(async () => undefined);
+const updaterGetStateMock = vi.fn<[], Promise<UpdateStatus>>();
+const updaterConfigureMock = vi.fn();
+const updaterCheckMock = vi.fn();
+const updaterQuitAndInstallMock = vi.fn();
+const updaterOnStatusMock = vi.fn();
 
 describe('SettingsModal', () => {
   beforeEach(() => {
@@ -61,6 +67,13 @@ describe('SettingsModal', () => {
             } satisfies MainDiagnosticsSnapshot,
           })),
         },
+        updater: {
+          getState: updaterGetStateMock,
+          configure: updaterConfigureMock,
+          checkForUpdates: updaterCheckMock,
+          quitAndInstall: updaterQuitAndInstallMock,
+          onStatus: updaterOnStatusMock,
+        },
       },
     });
     Object.defineProperty(navigator, 'clipboard', {
@@ -72,6 +85,42 @@ describe('SettingsModal', () => {
     });
     (navigator as any).clipboard = { writeText: clipboardWriteTextMock };
     clipboardWriteTextMock.mockClear();
+    updaterGetStateMock.mockReset();
+    updaterConfigureMock.mockReset();
+    updaterCheckMock.mockReset();
+    updaterQuitAndInstallMock.mockReset();
+    updaterOnStatusMock.mockReset();
+    updaterGetStateMock.mockResolvedValue({
+      phase: 'upToDate',
+      currentVersion: '0.5.2',
+      enabled: true,
+      autoDownload: true,
+      isPackaged: true,
+      availableVersion: null,
+      downloadedVersion: null,
+      downloadProgressPercent: null,
+      lastCheckedAt: '2026-03-05T12:00:00.000Z',
+      message: 'You are running the latest version.',
+      error: null,
+    });
+    updaterCheckMock.mockResolvedValue({
+      ok: true,
+      status: {
+        phase: 'checking',
+        currentVersion: '0.5.2',
+        enabled: true,
+        autoDownload: true,
+        isPackaged: true,
+        availableVersion: null,
+        downloadedVersion: null,
+        downloadProgressPercent: null,
+        lastCheckedAt: '2026-03-05T12:30:00.000Z',
+        message: 'Checking for updates...',
+        error: null,
+      } satisfies UpdateStatus,
+    });
+    updaterQuitAndInstallMock.mockResolvedValue({ ok: true });
+    updaterOnStatusMock.mockImplementation(() => () => {});
   });
 
   it('opens, switches tabs, and closes via Escape/backdrop', async () => {
@@ -207,12 +256,52 @@ describe('SettingsModal', () => {
     expect(prefs.interpolation.algorithm).toBe('linear');
     expect(prefs.interpolation.linearThreshold).toBeCloseTo(0.85);
 
+    await user.click(screen.getByRole('button', { name: 'Updates' }));
+    await user.click(screen.getByRole('checkbox', { name: 'Enable automatic update checks' }));
+    await user.click(screen.getByRole('checkbox', { name: 'Download updates automatically when found' }));
+
+    prefs = usePreferencesStore.getState().preferences;
+    expect(prefs.updates.enabled).toBe(false);
+    expect(prefs.updates.autoDownload).toBe(false);
+
     await user.click(screen.getByRole('button', { name: 'Reset All Preferences' }));
     prefs = usePreferencesStore.getState().preferences;
     expect(prefs.overlay.showViewportContextOverlay).toBe(DEFAULT_PREFERENCES.overlay.showViewportContextOverlay);
     expect(prefs.annotation.defaultBrushSize).toBe(DEFAULT_PREFERENCES.annotation.defaultBrushSize);
     expect(prefs.annotation.defaultColorSequence).toEqual(DEFAULT_PREFERENCES.annotation.defaultColorSequence);
+    expect(prefs.updates).toEqual(DEFAULT_PREFERENCES.updates);
     expect(prefs.interpolation).toEqual(DEFAULT_PREFERENCES.interpolation);
+  });
+
+  it('shows updater status and supports manual update actions', async () => {
+    const user = userEvent.setup();
+    updaterGetStateMock.mockResolvedValueOnce({
+      phase: 'downloaded',
+      currentVersion: '0.5.2',
+      enabled: true,
+      autoDownload: true,
+      isPackaged: true,
+      availableVersion: '0.5.3',
+      downloadedVersion: '0.5.3',
+      downloadProgressPercent: 100,
+      lastCheckedAt: '2026-03-05T12:00:00.000Z',
+      message: 'Update downloaded.',
+      error: null,
+    });
+
+    render(<SettingsModal open onClose={() => {}} />);
+    await user.click(screen.getByRole('button', { name: 'Updates' }));
+
+    expect(await screen.findByText('Current version')).toBeInTheDocument();
+    expect(screen.getByText('Update 0.5.3 is ready to install.')).toBeInTheDocument();
+    expect(updaterGetStateMock).toHaveBeenCalledTimes(1);
+    expect(updaterOnStatusMock).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: 'Restart and Install' }));
+    expect(updaterQuitAndInstallMock).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: 'Check Now' }));
+    expect(updaterCheckMock).toHaveBeenCalledTimes(1);
   });
 
   it('returns null when closed', () => {

--- a/src/renderer/components/settings/SettingsModal.tsx
+++ b/src/renderer/components/settings/SettingsModal.tsx
@@ -6,6 +6,7 @@ import type {
   InterpolationAlgorithm,
   ScissorStrategyMode,
 } from '@shared/types/preferences';
+import type { UpdateStatus } from '@shared/types';
 import {
   INTERPOLATION_ALGORITHM_LABELS,
   INTERPOLATION_ALGORITHM_DESCRIPTIONS,
@@ -21,7 +22,7 @@ import { IconClose } from '../icons';
 declare const __APP_VERSION__: string;
 const APP_VERSION = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev';
 
-type SettingsTab = 'hotkeys' | 'overlay' | 'annotation' | 'interpolation' | 'backup' | 'issue' | 'about';
+type SettingsTab = 'hotkeys' | 'overlay' | 'annotation' | 'updates' | 'interpolation' | 'backup' | 'issue' | 'about';
 
 interface SettingsModalProps {
   open: boolean;
@@ -36,6 +37,7 @@ const TAB_ITEMS: Array<{ id: SettingsTab; label: string }> = [
   { id: 'hotkeys', label: 'Hotkeys' },
   { id: 'overlay', label: 'Overlay' },
   { id: 'annotation', label: 'Annotation' },
+  { id: 'updates', label: 'Updates' },
   { id: 'interpolation', label: 'Interpolation' },
   { id: 'backup', label: 'File Backup' },
   { id: 'issue', label: 'Issue Report' },
@@ -173,10 +175,43 @@ function bindingToDraft(binding: HotkeyBinding): { key: string; modifiers: Requi
   };
 }
 
+function formatUpdateStatus(status: UpdateStatus | null): string {
+  if (!status) return 'Loading updater status...';
+  switch (status.phase) {
+    case 'disabled':
+      return 'Automatic update checks are disabled.';
+    case 'idle':
+      return 'Automatic update checks are enabled.';
+    case 'checking':
+      return 'Checking for updates...';
+    case 'available':
+      return status.availableVersion
+        ? `Update ${status.availableVersion} is available.`
+        : 'An update is available.';
+    case 'downloading':
+      return status.downloadProgressPercent === null
+        ? 'Downloading update...'
+        : `Downloading update... ${Math.round(status.downloadProgressPercent)}%`;
+    case 'downloaded':
+      return status.downloadedVersion
+        ? `Update ${status.downloadedVersion} is ready to install.`
+        : 'An update is ready to install.';
+    case 'upToDate':
+      return 'You are running the latest version.';
+    case 'unsupported':
+      return 'Auto-update is only available in packaged builds.';
+    case 'error':
+      return status.error ? `Update error: ${status.error}` : 'Update check failed.';
+    default:
+      return status.message ?? 'Updater status unavailable.';
+  }
+}
+
 export default function SettingsModal({ open, onClose, onRecover, initialTab }: SettingsModalProps) {
   const overrides = usePreferencesStore((s) => s.preferences.hotkeys.overrides);
   const overlayPrefs = usePreferencesStore((s) => s.preferences.overlay);
   const annotationPrefs = usePreferencesStore((s) => s.preferences.annotation);
+  const updatePrefs = usePreferencesStore((s) => s.preferences.updates);
   const interpPrefs = usePreferencesStore((s) => s.preferences.interpolation);
   const setHotkeyOverride = usePreferencesStore((s) => s.setHotkeyOverride);
   const clearHotkeyOverride = usePreferencesStore((s) => s.clearHotkeyOverride);
@@ -195,6 +230,8 @@ export default function SettingsModal({ open, onClose, onRecover, initialTab }: 
   const setScissorDefaultStrategy = usePreferencesStore((s) => s.setScissorDefaultStrategy);
   const setScissorPreviewEnabled = usePreferencesStore((s) => s.setScissorPreviewEnabled);
   const setScissorPreviewColor = usePreferencesStore((s) => s.setScissorPreviewColor);
+  const setUpdateChecksEnabled = usePreferencesStore((s) => s.setUpdateChecksEnabled);
+  const setUpdateAutoDownloadEnabled = usePreferencesStore((s) => s.setUpdateAutoDownloadEnabled);
   const setInterpolationEnabled = usePreferencesStore((s) => s.setInterpolationEnabled);
   const setInterpolationAlgorithm = usePreferencesStore((s) => s.setInterpolationAlgorithm);
   const setLinearThreshold = usePreferencesStore((s) => s.setLinearThreshold);
@@ -246,6 +283,8 @@ export default function SettingsModal({ open, onClose, onRecover, initialTab }: 
   const [issueReport, setIssueReport] = useState('');
   const [issueLoading, setIssueLoading] = useState(false);
   const [issueCopyStatus, setIssueCopyStatus] = useState<'idle' | 'copied' | 'error'>('idle');
+  const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>(null);
+  const [updateBusy, setUpdateBusy] = useState(false);
 
   useEffect(() => {
     if (!open) return;
@@ -283,6 +322,47 @@ export default function SettingsModal({ open, onClose, onRecover, initialTab }: 
       cancelled = true;
     };
   }, [activeTab, open]);
+
+  useEffect(() => {
+    if (activeTab !== 'updates' || !open) return;
+    const updaterApi = window.electronAPI?.updater;
+    if (!updaterApi) {
+      setUpdateStatus(null);
+      return;
+    }
+
+    let cancelled = false;
+    updaterApi.getState()
+      .then((status) => {
+        if (!cancelled) setUpdateStatus(status);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        const message = error instanceof Error ? error.message : String(error);
+        setUpdateStatus({
+          phase: 'error',
+          currentVersion: 'unknown',
+          enabled: updatePrefs.enabled,
+          autoDownload: updatePrefs.autoDownload,
+          isPackaged: false,
+          availableVersion: null,
+          downloadedVersion: null,
+          downloadProgressPercent: null,
+          lastCheckedAt: null,
+          message: 'Failed to load updater state.',
+          error: message,
+        });
+      });
+
+    const unsubscribe = updaterApi.onStatus((status) => {
+      if (!cancelled) setUpdateStatus(status);
+    }) ?? (() => {});
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [activeTab, open, updatePrefs.autoDownload, updatePrefs.enabled]);
 
   useEffect(() => {
     if (!actionOptions.length) return;
@@ -393,6 +473,29 @@ export default function SettingsModal({ open, onClose, onRecover, initialTab }: 
     } catch {
       setIssueCopyStatus('error');
       window.setTimeout(() => setIssueCopyStatus('idle'), 3000);
+    }
+  };
+
+  const checkForUpdatesNow = async () => {
+    const updaterApi = window.electronAPI?.updater;
+    if (!updaterApi) return;
+    setUpdateBusy(true);
+    try {
+      const result = await updaterApi.checkForUpdates();
+      setUpdateStatus(result.status);
+    } finally {
+      setUpdateBusy(false);
+    }
+  };
+
+  const installDownloadedUpdate = async () => {
+    const updaterApi = window.electronAPI?.updater;
+    if (!updaterApi) return;
+    setUpdateBusy(true);
+    try {
+      await updaterApi.quitAndInstall();
+    } finally {
+      setUpdateBusy(false);
     }
   };
 
@@ -807,6 +910,89 @@ export default function SettingsModal({ open, onClose, onRecover, initialTab }: 
 
                   <p className="text-[11px] text-zinc-500">
                     Hold Shift while using a scissors tool to temporarily toggle to the alternate mode.
+                  </p>
+                </div>
+              </>
+            )}
+
+            {activeTab === 'updates' && (
+              <>
+                <div className="text-xs text-zinc-400">
+                  Configure background update checks for packaged releases. Manual checks are always available.
+                </div>
+
+                <div className="rounded-lg border border-zinc-800 bg-zinc-950/40 p-4 space-y-4">
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <div className="rounded border border-zinc-800 bg-zinc-900/60 px-3 py-2">
+                      <div className="text-[11px] text-zinc-500">Current version</div>
+                      <div className="text-sm text-zinc-100 font-mono">
+                        {updateStatus?.currentVersion ?? 'Loading...'}
+                      </div>
+                    </div>
+                    <div className="rounded border border-zinc-800 bg-zinc-900/60 px-3 py-2">
+                      <div className="text-[11px] text-zinc-500">Last checked</div>
+                      <div className="text-sm text-zinc-100">
+                        {updateStatus?.lastCheckedAt
+                          ? new Date(updateStatus.lastCheckedAt).toLocaleString()
+                          : 'Not checked yet'}
+                      </div>
+                    </div>
+                  </div>
+
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={updatePrefs.enabled}
+                      onChange={(e) => setUpdateChecksEnabled(e.target.checked)}
+                      className="w-3.5 h-3.5 rounded border-zinc-600 bg-zinc-800 accent-blue-500"
+                    />
+                    <span className="text-xs text-zinc-300">Enable automatic update checks</span>
+                  </label>
+
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={updatePrefs.autoDownload}
+                      onChange={(e) => setUpdateAutoDownloadEnabled(e.target.checked)}
+                      className="w-3.5 h-3.5 rounded border-zinc-600 bg-zinc-800 accent-blue-500"
+                    />
+                    <span className="text-xs text-zinc-300">Download updates automatically when found</span>
+                  </label>
+
+                  <div className="rounded border border-zinc-800 bg-zinc-900/60 px-3 py-2 space-y-1">
+                    <div className="text-[11px] text-zinc-500">Status</div>
+                    <div className="text-xs text-zinc-200">{formatUpdateStatus(updateStatus)}</div>
+                    {updateStatus?.availableVersion && (
+                      <div className="text-[11px] text-zinc-400">
+                        Available version: <span className="font-mono">{updateStatus.availableVersion}</span>
+                      </div>
+                    )}
+                    {updateStatus?.error && (
+                      <div className="text-[11px] text-red-400">{updateStatus.error}</div>
+                    )}
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => void checkForUpdatesNow()}
+                      disabled={updateBusy}
+                      className="px-2.5 py-1.5 rounded bg-zinc-800 text-zinc-200 text-xs hover:bg-zinc-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    >
+                      {updateBusy && updateStatus?.phase === 'checking' ? 'Checking...' : 'Check Now'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => void installDownloadedUpdate()}
+                      disabled={updateBusy || updateStatus?.phase !== 'downloaded'}
+                      className="px-2.5 py-1.5 rounded bg-blue-600 text-white text-xs hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    >
+                      Restart and Install
+                    </button>
+                  </div>
+
+                  <p className="text-[11px] text-zinc-500">
+                    Automatic updates require packaged builds published with update metadata. Development builds will report that updates are unavailable.
                   </p>
                 </div>
               </>

--- a/src/renderer/lib/preferences/applyPreferences.ts
+++ b/src/renderer/lib/preferences/applyPreferences.ts
@@ -36,6 +36,7 @@ export function applyPreferences(preferences: PreferencesV1): void {
   const colorSequence = (annotationPrefs.defaultColorSequence ?? DEFAULT_PREFERENCES.annotation.defaultColorSequence)
     .map((hex) => hexToRgba(hex))
     .filter((color): color is [number, number, number, number] => color !== null);
+  const updatePrefs = preferences.updates ?? DEFAULT_PREFERENCES.updates;
 
   hotkeyService.setHotkeyMap(DEFAULT_HOTKEY_MAP);
   hotkeyService.mergeOverrides(hotkeyOverrides);
@@ -53,4 +54,12 @@ export function applyPreferences(preferences: PreferencesV1): void {
   segmentationService.updateStyle(segmentOpacity, annotationPrefs.defaultMaskOutlines);
   segmentationService.updateContourStyle(contourThickness);
   toolService.applyScissorPreferences();
+
+  const updaterSync = window.electronAPI?.updater?.configure?.({
+    enabled: updatePrefs.enabled,
+    autoDownload: updatePrefs.autoDownload,
+  });
+  updaterSync?.catch((error) => {
+    console.error('[Preferences] Failed to sync updater preferences:', error);
+  });
 }

--- a/src/renderer/stores/preferencesStore.test.ts
+++ b/src/renderer/stores/preferencesStore.test.ts
@@ -121,11 +121,16 @@ describe('usePreferencesStore', () => {
   });
 
   it('clamps interpolation values and resets all settings', () => {
+    usePreferencesStore.getState().setUpdateChecksEnabled(false);
+    usePreferencesStore.getState().setUpdateAutoDownloadEnabled(false);
     usePreferencesStore.getState().setInterpolationEnabled(false);
     usePreferencesStore.getState().setInterpolationAlgorithm('linear');
     usePreferencesStore.getState().setLinearThreshold(-5);
 
     let interpolation = usePreferencesStore.getState().preferences.interpolation;
+    let updates = usePreferencesStore.getState().preferences.updates;
+    expect(updates.enabled).toBe(false);
+    expect(updates.autoDownload).toBe(false);
     expect(interpolation.enabled).toBe(false);
     expect(interpolation.algorithm).toBe('linear');
     expect(interpolation.linearThreshold).toBe(0);
@@ -168,6 +173,10 @@ describe('usePreferencesStore', () => {
               previewColor: '#00AAFF',
             },
           },
+          updates: {
+            enabled: false,
+            autoDownload: false,
+          },
           interpolation: {
             enabled: false,
             algorithm: 'not-a-real-algorithm',
@@ -192,11 +201,32 @@ describe('usePreferencesStore', () => {
     expect(merged.preferences.annotation.scissors.defaultStrategy).toBe('fill');
     expect(merged.preferences.annotation.scissors.previewEnabled).toBe(true);
     expect(merged.preferences.annotation.scissors.previewColor).toBe('#00AAFF');
+    expect(merged.preferences.updates.enabled).toBe(false);
+    expect(merged.preferences.updates.autoDownload).toBe(false);
 
     expect(merged.preferences.interpolation.enabled).toBe(false);
     expect(merged.preferences.interpolation.algorithm).toBe(
       DEFAULT_INTERPOLATION_PREFERENCES.algorithm,
     );
     expect(merged.preferences.interpolation.linearThreshold).toBe(1);
+  });
+
+  it('falls back to default updater preferences when persisted values are malformed', () => {
+    const merge = persistApi().getOptions().merge;
+    const currentState = usePreferencesStore.getInitialState();
+
+    const merged = merge(
+      {
+        preferences: {
+          updates: {
+            enabled: 'yes',
+            autoDownload: null,
+          },
+        },
+      },
+      currentState,
+    ) as ReturnType<typeof usePreferencesStore.getState>;
+
+    expect(merged.preferences.updates).toEqual(DEFAULT_PREFERENCES.updates);
   });
 });

--- a/src/renderer/stores/preferencesStore.ts
+++ b/src/renderer/stores/preferencesStore.ts
@@ -18,6 +18,8 @@ import {
   type OverlayFieldKey,
   type OverlayPreferences,
   type PreferencesV1,
+  DEFAULT_UPDATE_PREFERENCES,
+  type UpdatePreferences,
 } from '@shared/types/preferences';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
@@ -41,6 +43,8 @@ interface PreferencesStore {
   setScissorDefaultStrategy: (strategy: ScissorStrategyMode) => void;
   setScissorPreviewEnabled: (enabled: boolean) => void;
   setScissorPreviewColor: (color: string) => void;
+  setUpdateChecksEnabled: (enabled: boolean) => void;
+  setUpdateAutoDownloadEnabled: (enabled: boolean) => void;
   // ─── Interpolation ─────────────────────────────────────
   setInterpolationEnabled: (enabled: boolean) => void;
   setInterpolationAlgorithm: (algorithm: InterpolationAlgorithm) => void;
@@ -121,9 +125,28 @@ function makeDefaultPreferences(): PreferencesV1 {
         previewColor: DEFAULT_PREFERENCES.annotation.scissors.previewColor,
       },
     },
+    updates: { ...DEFAULT_UPDATE_PREFERENCES },
     interpolation: { ...DEFAULT_INTERPOLATION_PREFERENCES },
     backup: { ...DEFAULT_BACKUP_PREFERENCES },
     deletion: { ...DEFAULT_DELETION_PREFERENCES },
+  };
+}
+
+function mergeUpdatePreferences(current: UpdatePreferences, incoming: unknown): UpdatePreferences {
+  if (!incoming || typeof incoming !== 'object') {
+    return { ...current };
+  }
+
+  const candidate = incoming as Partial<UpdatePreferences>;
+  return {
+    enabled:
+      typeof candidate.enabled === 'boolean'
+        ? candidate.enabled
+        : current.enabled,
+    autoDownload:
+      typeof candidate.autoDownload === 'boolean'
+        ? candidate.autoDownload
+        : current.autoDownload,
   };
 }
 
@@ -465,6 +488,28 @@ export const usePreferencesStore = create<PreferencesStore>()(
           },
         })),
 
+      setUpdateChecksEnabled: (enabled) =>
+        set((state) => ({
+          preferences: {
+            ...state.preferences,
+            updates: {
+              ...state.preferences.updates,
+              enabled,
+            },
+          },
+        })),
+
+      setUpdateAutoDownloadEnabled: (enabled) =>
+        set((state) => ({
+          preferences: {
+            ...state.preferences,
+            updates: {
+              ...state.preferences.updates,
+              autoDownload: enabled,
+            },
+          },
+        })),
+
       // ─── Interpolation ────────────────────────────────────
 
       setInterpolationEnabled: (enabled) =>
@@ -600,6 +645,7 @@ export const usePreferencesStore = create<PreferencesStore>()(
             },
             overlay: mergeOverlayPreferences(base.preferences.overlay, incoming.overlay),
             annotation: mergeAnnotationPreferences(base.preferences.annotation, incoming.annotation),
+            updates: mergeUpdatePreferences(base.preferences.updates, incoming.updates),
             interpolation: mergedInterpolation,
             backup: mergedBackup,
             deletion: mergedDeletion,

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -1,6 +1,13 @@
 import { IPC } from '../ipcChannels';
 import type { XnatLoginResult, ProxiedFetchResult } from '../types/xnat';
 import type { MainDiagnosticsSnapshotResult } from '../types/diagnostics';
+import type {
+  CheckForUpdatesResponse,
+  ConfigureUpdaterRequest,
+  ConfigureUpdaterResponse,
+  QuitAndInstallResponse,
+  UpdateStatus,
+} from '../types/updater';
 
 export interface ViewportBounds {
   x: number;
@@ -42,6 +49,22 @@ export interface IpcInvokeContracts {
     request: Record<string, never>;
     response: MainDiagnosticsSnapshotResult;
   };
+  [IPC.UPDATER_GET_STATE]: {
+    request: Record<string, never>;
+    response: UpdateStatus;
+  };
+  [IPC.UPDATER_CONFIGURE]: {
+    request: ConfigureUpdaterRequest;
+    response: ConfigureUpdaterResponse;
+  };
+  [IPC.UPDATER_CHECK_FOR_UPDATES]: {
+    request: Record<string, never>;
+    response: CheckForUpdatesResponse;
+  };
+  [IPC.UPDATER_QUIT_AND_INSTALL]: {
+    request: Record<string, never>;
+    response: QuitAndInstallResponse;
+  };
 }
 
 export type IpcInvokeChannel = keyof IpcInvokeContracts;
@@ -58,5 +81,10 @@ export const IPC_CHANNELS = {
   downloadScanFile: IPC.XNAT_DOWNLOAD_SCAN_FILE,
   saveViewportCapture: IPC.EXPORT_SAVE_VIEWPORT_CAPTURE,
   getMainDiagnosticsSnapshot: IPC.DIAGNOSTICS_GET_MAIN_SNAPSHOT,
+  getUpdaterState: IPC.UPDATER_GET_STATE,
+  configureUpdater: IPC.UPDATER_CONFIGURE,
+  checkForUpdates: IPC.UPDATER_CHECK_FOR_UPDATES,
+  quitAndInstallUpdate: IPC.UPDATER_QUIT_AND_INSTALL,
+  updaterStatus: IPC.UPDATER_STATUS,
   sessionExpired: IPC.XNAT_SESSION_EXPIRED,
 } as const;

--- a/src/shared/ipcChannels.ts
+++ b/src/shared/ipcChannels.ts
@@ -77,6 +77,13 @@ export const IPC = {
 
   // Diagnostics (renderer → main)
   DIAGNOSTICS_GET_MAIN_SNAPSHOT: 'diagnostics:get-main-snapshot',
+
+  // Auto-update (renderer → main / main → renderer)
+  UPDATER_GET_STATE: 'updater:get-state',
+  UPDATER_CONFIGURE: 'updater:configure',
+  UPDATER_CHECK_FOR_UPDATES: 'updater:check-for-updates',
+  UPDATER_QUIT_AND_INSTALL: 'updater:quit-and-install',
+  UPDATER_STATUS: 'updater:status',
 } as const;
 
 export type IpcChannel = (typeof IPC)[keyof typeof IPC];

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -5,6 +5,7 @@ export * from './xnat';
 export * from './preferences';
 export * from './backup';
 export * from './diagnostics';
+export * from './updater';
 
 import type {
   XnatLoginResult,
@@ -18,6 +19,13 @@ import type {
   XnatUploadResult,
 } from './xnat';
 import type { MainDiagnosticsSnapshotResult } from './diagnostics';
+import type {
+  CheckForUpdatesResponse,
+  ConfigureUpdaterRequest,
+  ConfigureUpdaterResponse,
+  QuitAndInstallResponse,
+  UpdateStatus,
+} from './updater';
 
 export interface ElectronAPI {
   platform: string;
@@ -181,6 +189,13 @@ export interface ElectronAPI {
   };
   diagnostics?: {
     getMainSnapshot(): Promise<MainDiagnosticsSnapshotResult>;
+  };
+  updater?: {
+    getState(): Promise<UpdateStatus>;
+    configure(config: ConfigureUpdaterRequest): Promise<ConfigureUpdaterResponse>;
+    checkForUpdates(): Promise<CheckForUpdatesResponse>;
+    quitAndInstall(): Promise<QuitAndInstallResponse>;
+    onStatus(callback: (status: UpdateStatus) => void): () => void;
   };
   on(channel: string, callback: (...args: unknown[]) => void): () => void;
 }

--- a/src/shared/types/preferences.ts
+++ b/src/shared/types/preferences.ts
@@ -1,4 +1,11 @@
 import type { HotkeyMap } from './hotkeys';
+import {
+  DEFAULT_UPDATE_PREFERENCES,
+  type UpdatePreferences,
+} from './updater';
+
+export { DEFAULT_UPDATE_PREFERENCES };
+export type { UpdatePreferences };
 
 export type OverlayCornerId = 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
 export type HexColor = `#${string}`;
@@ -119,6 +126,7 @@ export interface PreferencesV1 {
   };
   overlay: OverlayPreferences;
   annotation: AnnotationToolPreferences;
+  updates: UpdatePreferences;
   interpolation: InterpolationPreferences;
   backup: BackupPreferences;
   deletion: DeletionPreferences;
@@ -190,6 +198,7 @@ export const DEFAULT_PREFERENCES: PreferencesV1 = {
       previewColor: '#FFFFFF',
     },
   },
+  updates: { ...DEFAULT_UPDATE_PREFERENCES },
   interpolation: { ...DEFAULT_INTERPOLATION_PREFERENCES },
   backup: { ...DEFAULT_BACKUP_PREFERENCES },
   deletion: { ...DEFAULT_DELETION_PREFERENCES },

--- a/src/shared/types/updater.ts
+++ b/src/shared/types/updater.ts
@@ -1,0 +1,53 @@
+export interface UpdatePreferences {
+  enabled: boolean;
+  autoDownload: boolean;
+}
+
+export const DEFAULT_UPDATE_PREFERENCES: UpdatePreferences = {
+  enabled: true,
+  autoDownload: true,
+};
+
+export type UpdatePhase =
+  | 'disabled'
+  | 'idle'
+  | 'checking'
+  | 'available'
+  | 'downloading'
+  | 'downloaded'
+  | 'upToDate'
+  | 'error'
+  | 'unsupported';
+
+export interface UpdateStatus {
+  phase: UpdatePhase;
+  currentVersion: string;
+  enabled: boolean;
+  autoDownload: boolean;
+  isPackaged: boolean;
+  availableVersion: string | null;
+  downloadedVersion: string | null;
+  downloadProgressPercent: number | null;
+  lastCheckedAt: string | null;
+  message: string | null;
+  error: string | null;
+}
+
+export interface ConfigureUpdaterRequest extends UpdatePreferences {}
+
+export interface ConfigureUpdaterResponse {
+  ok: boolean;
+  status: UpdateStatus;
+  error?: string;
+}
+
+export interface CheckForUpdatesResponse {
+  ok: boolean;
+  status: UpdateStatus;
+  error?: string;
+}
+
+export interface QuitAndInstallResponse {
+  ok: boolean;
+  error?: string;
+}

--- a/src/test/ipc/ipcMocks.ts
+++ b/src/test/ipc/ipcMocks.ts
@@ -116,6 +116,13 @@ export function createWindowElectronApiMock() {
       saveDicomRtStruct: vi.fn(),
       saveViewportCapture: vi.fn(),
     },
+    updater: {
+      getState: vi.fn(),
+      configure: vi.fn(),
+      checkForUpdates: vi.fn(),
+      quitAndInstall: vi.fn(),
+      onStatus: vi.fn(),
+    },
     on: vi.fn(),
   };
 }


### PR DESCRIPTION
## Summary
- revive the configurable auto-update implementation on top of current `main`
- restore the main-process updater service, IPC/preload bridge, persisted update preferences, and Settings UI
- add GitHub publish metadata back to `electron-builder.yml` without replaying stale unrelated branch diffs

## Why
- the earlier auto-update work existed on a stale branch and was no longer merge-ready against current `main`
- this ports the updater feature forward so it can be productionized for the next release

## User Impact
- packaged builds can check for updates automatically or manually
- users can configure automatic update checks and auto-download behavior from Settings
- downloaded updates can be installed via restart from the app UI

## Validation
- `npx vitest run src/main/updater/autoUpdateService.test.ts src/main/ipc/updateHandlers.test.ts src/preload/index.test.ts src/renderer/components/settings/SettingsModal.test.tsx src/renderer/stores/preferencesStore.test.ts src/main/index.test.ts`
- `npm test`
- `npm run build`

## Notes
- branch revived from stale `codex/autoupdate` work onto current `main`
- version was intentionally left at the current `main` value so the next release can bump cleanly