### PR TITLE
[codex] stabilize GitHub Actions build memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  NODE_OPTIONS: --max-old-space-size=4096
+
 jobs:
   test-and-build:
     name: Test and build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - 'codex/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-and-build:
+    name: Test and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run test suite
+        run: npm test
+
+      - name: Build application
+        run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,234 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish artifacts to GitHub Releases
+        required: false
+        type: boolean
+        default: false
+      build_windows:
+        description: Attempt Windows packaging if signing secrets are configured
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-macos:
+    name: Release macOS
+    runs-on: macos-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        run: npm run build
+
+      - name: Determine publish mode
+        id: publish_mode
+        shell: bash
+        env:
+          PUBLISH_INPUT: ${{ inputs.publish }}
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "mode=always" >> "$GITHUB_OUTPUT"
+          elif [[ "${PUBLISH_INPUT}" == "true" ]]; then
+            echo "mode=always" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=never" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Prepare Apple signing inputs
+        id: apple_signing
+        shell: bash
+        env:
+          MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+        run: |
+          if [[ -z "${MACOS_CERT_P12_BASE64}" || -z "${MACOS_CERT_PASSWORD}" || -z "${APPLE_API_KEY_P8_BASE64}" || -z "${APPLE_API_KEY_ID}" || -z "${APPLE_API_ISSUER}" ]]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "$MACOS_CERT_P12_BASE64" | base64 --decode > "$RUNNER_TEMP/macos-signing.p12"
+          echo "$APPLE_API_KEY_P8_BASE64" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+      - name: Require Apple secrets for tagged releases
+        if: startsWith(github.ref, 'refs/tags/') && steps.apple_signing.outputs.ready != 'true'
+        shell: bash
+        run: |
+          echo "Missing required macOS signing/notarization secrets." >&2
+          echo "Set MACOS_CERT_P12_BASE64, MACOS_CERT_PASSWORD, APPLE_API_KEY_P8_BASE64, APPLE_API_KEY_ID, and APPLE_API_ISSUER." >&2
+          exit 1
+
+      - name: Build and publish macOS artifacts
+        if: steps.apple_signing.outputs.ready == 'true'
+        shell: bash
+        env:
+          CSC_LINK: ${{ runner.temp }}/macos-signing.p12
+          CSC_KEY_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          APPLE_API_KEY: ${{ runner.temp }}/AuthKey.p8
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run package -- --mac --publish "${{ steps.publish_mode.outputs.mode }}"
+
+      - name: Upload macOS artifacts for manual dry runs
+        if: steps.apple_signing.outputs.ready == 'true' && steps.publish_mode.outputs.mode != 'always'
+        uses: actions/upload-artifact@v4
+        with:
+          name: xnat-workstation-macos
+          path: release/
+          if-no-files-found: error
+
+  release-linux:
+    name: Release Linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        run: npm run build
+
+      - name: Determine publish mode
+        id: publish_mode
+        shell: bash
+        env:
+          PUBLISH_INPUT: ${{ inputs.publish }}
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "mode=always" >> "$GITHUB_OUTPUT"
+          elif [[ "${PUBLISH_INPUT}" == "true" ]]; then
+            echo "mode=always" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=never" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and publish Linux artifacts
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run package -- --linux --publish "${{ steps.publish_mode.outputs.mode }}"
+
+      - name: Upload Linux artifacts for manual dry runs
+        if: steps.publish_mode.outputs.mode != 'always'
+        uses: actions/upload-artifact@v4
+        with:
+          name: xnat-workstation-linux
+          path: release/
+          if-no-files-found: error
+
+  release-windows:
+    name: Release Windows
+    runs-on: windows-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        run: npm run build
+
+      - name: Determine publish mode
+        id: publish_mode
+        shell: bash
+        env:
+          PUBLISH_INPUT: ${{ inputs.publish }}
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "mode=always" >> "$GITHUB_OUTPUT"
+          elif [[ "${PUBLISH_INPUT}" == "true" ]]; then
+            echo "mode=always" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=never" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Prepare Windows signing inputs
+        id: windows_signing
+        shell: pwsh
+        env:
+          WIN_CSC_P12_BASE64: ${{ secrets.WIN_CSC_P12_BASE64 }}
+          WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:WIN_CSC_P12_BASE64) -or [string]::IsNullOrWhiteSpace($env:WIN_CSC_KEY_PASSWORD)) {
+            "ready=false" >> $env:GITHUB_OUTPUT
+            exit 0
+          }
+
+          [IO.File]::WriteAllBytes(
+            "$env:RUNNER_TEMP\windows-signing.p12",
+            [Convert]::FromBase64String($env:WIN_CSC_P12_BASE64)
+          )
+          "ready=true" >> $env:GITHUB_OUTPUT
+
+      - name: Require Windows secrets when manually requested
+        if: github.event_name == 'workflow_dispatch' && inputs.build_windows && steps.windows_signing.outputs.ready != 'true'
+        shell: pwsh
+        run: |
+          Write-Error "Missing WIN_CSC_P12_BASE64 or WIN_CSC_KEY_PASSWORD."
+          exit 1
+
+      - name: Build and publish Windows artifacts
+        if: steps.windows_signing.outputs.ready == 'true'
+        shell: pwsh
+        env:
+          CSC_LINK: ${{ runner.temp }}\windows-signing.p12
+          CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run package -- --win --publish "${{ steps.publish_mode.outputs.mode }}"
+
+      - name: Upload Windows artifacts for manual dry runs
+        if: steps.windows_signing.outputs.ready == 'true' && steps.publish_mode.outputs.mode != 'always'
+        uses: actions/upload-artifact@v4
+        with:
+          name: xnat-workstation-windows
+          path: release/
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  NODE_OPTIONS: --max-old-space-size=4096
+
 jobs:
   release-macos:
     name: Release macOS

--- a/README.md
+++ b/README.md
@@ -187,6 +187,31 @@ Creates distributable installers in `release/`:
 - **Windows** — NSIS installer, portable EXE
 - **Linux** — AppImage, DEB
 
+### GitHub Actions CI and Releases
+
+This repo can be managed through GitHub Actions in `.github/workflows/`:
+
+- `ci.yml` runs `npm test` and `npm run build` on pull requests and pushes to `main` and `codex/*`.
+- `release.yml` publishes release artifacts when you push a version tag like `v0.5.4`.
+
+Required GitHub Actions secrets:
+
+- `MACOS_CERT_P12_BASE64` — base64-encoded Developer ID Application `.p12`
+- `MACOS_CERT_PASSWORD` — password for the macOS signing certificate
+- `APPLE_API_KEY_P8_BASE64` — base64-encoded App Store Connect API key `.p8`
+- `APPLE_API_KEY_ID` — App Store Connect API key ID
+- `APPLE_API_ISSUER` — App Store Connect issuer UUID
+- `WIN_CSC_P12_BASE64` — base64-encoded Windows code-signing `.p12` or `.pfx`
+- `WIN_CSC_KEY_PASSWORD` — password for the Windows signing certificate
+
+Recommended release flow:
+
+1. Update the app version in `package.json` and `package-lock.json`.
+2. Merge the release-ready PR into `main`.
+3. Push a tag like `v0.5.4`.
+4. Let `release.yml` publish the signed macOS release and Linux artifacts automatically.
+5. Enable the Windows job once the DigiCert signing certificate secrets are configured.
+
 ### Signed macOS Package (Developer ID)
 
 To avoid Gatekeeper "unidentified developer" warnings, build with Apple signing + notarization credentials:


### PR DESCRIPTION
## Summary
- add a shared Node heap setting to GitHub Actions workflows
- keep the CI test command unchanged and focus the fix on the build OOM
- carry the release workflow scaffold and the memory fix together for review

## Root cause
The failing CI run for commit 95ec392 did not fail in tests. The GitHub Actions log showed `npm run build` aborting during `vite build` with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`, which produced exit code 134.

## Validation
- reproduced the renderer build failure locally with `NODE_OPTIONS=--max-old-space-size=2048 npm run build`
- `npm test`
- `NODE_OPTIONS=--max-old-space-size=4096 npm run build`
- YAML parse check for `.github/workflows/*.yml`