### PR TITLE
[codex] fix Linux release package metadata

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -35,6 +35,7 @@ win:
     - nsis
     - portable
 linux:
+  maintainer: Daniel Marcus <dmarcus@wustl.edu>
   target:
     - AppImage
     - deb


### PR DESCRIPTION
## Summary
- add Debian maintainer metadata for Linux packaging
- keep the fix narrowly scoped to electron-builder config

## Root cause
The release workflow reached the Linux packaging step and failed while building the `.deb` with:

`Please specify author 'email' in the application package.json`

Electron Builder accepts either an author email in `package.json` or an explicit Linux maintainer value. This change uses the explicit Linux maintainer field.

## Validation
- inspected failed Actions run `23822853454`
- confirmed macOS and Windows jobs were otherwise healthy
- YAML parse check for `electron-builder.yml`