### PR TITLE
[codex] bump version to 0.5.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xnat-viewer",
-  "version": "0.5.2",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xnat-viewer",
-      "version": "0.5.2",
+      "version": "0.5.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xnat-viewer",
-  "version": "0.5.2",
+  "version": "0.5.4",
   "description": "XNAT Desktop Workstation with native Cornerstone3D rendering",
   "main": "dist/main/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump the app version from 0.5.2 to 0.5.4
- keep `package.json` and `package-lock.json` aligned for release metadata

## Validation
- verified `package.json` version is `0.5.4`
- verified `package-lock.json` root version is `0.5.4`