### PR TITLE
[codex] add in-app update install banner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xnat-viewer",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xnat-viewer",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xnat-viewer",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "XNAT Desktop Workstation with native Cornerstone3D rendering",
   "main": "dist/main/main/index.js",
   "scripts": {

--- a/src/renderer/App.test.tsx
+++ b/src/renderer/App.test.tsx
@@ -17,6 +17,7 @@ import { useSegmentationManagerStore } from './stores/segmentationManagerStore';
 import { clearRecoveredSessions } from './lib/app/appHelpers';
 import { cache, imageLoader, metaData } from '@cornerstonejs/core';
 import { BUILT_IN_PROTOCOLS } from '@shared/types/hangingProtocol';
+import type { UpdateStatus } from '@shared/types';
 
 const mocks = vi.hoisted(() => ({
   initCornerstone: vi.fn(),
@@ -77,6 +78,14 @@ const mocks = vi.hoisted(() => ({
     referencedSeriesUID: null,
     referencedSOPInstanceUIDs: [],
   })),
+  updater: {
+    getState: vi.fn(),
+    configure: vi.fn(),
+    checkForUpdates: vi.fn(),
+    quitAndInstall: vi.fn(),
+    onStatus: vi.fn(),
+  },
+  updaterStatusCallback: null as ((status: UpdateStatus) => void) | null,
 }));
 
 vi.mock('./pages/ViewerPage', () => ({
@@ -85,14 +94,17 @@ vi.mock('./pages/ViewerPage', () => ({
     browserSlot,
     onApplyProtocol,
     onToggleMPR,
+    settingsInitialTabRequest,
   }: {
     leftSlot: ReactNode;
     browserSlot: ReactNode;
     onApplyProtocol?: (protocolId: string) => void;
     onToggleMPR?: () => void;
+    settingsInitialTabRequest?: string;
   }) => (
     <div data-testid="viewer-page">
       <div data-testid="left-slot">{leftSlot}</div>
+      <div data-testid="settings-tab-request">{settingsInitialTabRequest ?? ''}</div>
       <div data-testid="panel-drop-target" data-panel-id="panel_1">panel target</div>
       <button onClick={() => onApplyProtocol?.(BUILT_IN_PROTOCOLS[0]?.id ?? 'default')}>Trigger Apply Protocol</button>
       <button onClick={() => onToggleMPR?.()}>Trigger Toggle MPR</button>
@@ -321,6 +333,32 @@ function setConnectedConnectionState(): void {
 }
 
 function setElectronApiMock(): void {
+  mocks.updaterStatusCallback = null;
+  mocks.updater.getState.mockResolvedValue({
+    phase: 'idle',
+    currentVersion: '0.5.4',
+    enabled: true,
+    autoDownload: true,
+    isPackaged: true,
+    availableVersion: null,
+    downloadedVersion: null,
+    downloadProgressPercent: null,
+    lastCheckedAt: null,
+    message: 'Automatic update checks are enabled.',
+    error: null,
+  } satisfies UpdateStatus);
+  mocks.updater.configure.mockResolvedValue({ ok: true });
+  mocks.updater.checkForUpdates.mockResolvedValue({ ok: true });
+  mocks.updater.quitAndInstall.mockResolvedValue({ ok: true });
+  mocks.updater.onStatus.mockImplementation((callback: (status: UpdateStatus) => void) => {
+    mocks.updaterStatusCallback = callback;
+    return () => {
+      if (mocks.updaterStatusCallback === callback) {
+        mocks.updaterStatusCallback = null;
+      }
+    };
+  });
+
   Object.defineProperty(window, 'electronAPI', {
     value: {
       xnat: {
@@ -330,6 +368,7 @@ function setElectronApiMock(): void {
         downloadScanFile: vi.fn(async () => ({ ok: true, data: '' })),
         getScans: vi.fn(async () => []),
       },
+      updater: mocks.updater,
       on: vi.fn(() => () => {}),
     },
     configurable: true,
@@ -344,6 +383,12 @@ function createDicomFile(contents: string, name: string): File {
     value: async () => new TextEncoder().encode(contents).buffer,
   });
   return file;
+}
+
+function emitUpdaterStatus(status: UpdateStatus): void {
+  act(() => {
+    mocks.updaterStatusCallback?.(status);
+  });
 }
 
 describe('App', () => {
@@ -455,6 +500,64 @@ describe('App', () => {
 
     await user.click(screen.getByTitle('Pin this session'));
     expect(mocks.addPinnedItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an update banner and routes to the Updates settings tab when an update is downloading', async () => {
+    const user = userEvent.setup();
+    setConnectedConnectionState();
+
+    render(<App />);
+    expect(await screen.findByTestId('viewer-page')).toBeInTheDocument();
+
+    emitUpdaterStatus({
+      phase: 'downloading',
+      currentVersion: '0.5.4',
+      enabled: true,
+      autoDownload: true,
+      isPackaged: true,
+      availableVersion: '0.5.5',
+      downloadedVersion: null,
+      downloadProgressPercent: 42,
+      lastCheckedAt: new Date().toISOString(),
+      message: 'Downloading update... 42%',
+      error: null,
+    });
+
+    expect(
+      screen.getByText('Update 0.5.5 is downloading in the background (42%).'),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Review in Settings' }));
+
+    expect(screen.getByTestId('settings-tab-request')).toHaveTextContent('updates');
+  });
+
+  it('shows a restart-and-install banner action when an update is downloaded', async () => {
+    const user = userEvent.setup();
+    setConnectedConnectionState();
+
+    render(<App />);
+    expect(await screen.findByTestId('viewer-page')).toBeInTheDocument();
+
+    emitUpdaterStatus({
+      phase: 'downloaded',
+      currentVersion: '0.5.4',
+      enabled: true,
+      autoDownload: true,
+      isPackaged: true,
+      availableVersion: '0.5.5',
+      downloadedVersion: '0.5.5',
+      downloadProgressPercent: 100,
+      lastCheckedAt: new Date().toISOString(),
+      message: 'Update downloaded.',
+      error: null,
+    });
+
+    expect(screen.getByText(/Update 0\.5\.5 is ready to install\./)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Restart and Install' }));
+
+    expect(mocks.updater.quitAndInstall).toHaveBeenCalledTimes(1);
   });
 
   it('shows drag overlay for file drags, but not for xnat scan drags', async () => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -15,6 +15,7 @@ import { matchProtocol, applyProtocol } from './lib/hangingProtocolService';
 import { panelId } from '@shared/types/viewer';
 import { BUILT_IN_PROTOCOLS } from '@shared/types/hangingProtocol';
 import type { XnatScan } from '@shared/types/xnat';
+import type { UpdateStatus } from '@shared/types';
 import { IconOpenFile, XnatLogo } from './components/icons';
 import { volumeService } from './lib/cornerstone/volumeService';
 import {
@@ -92,6 +93,39 @@ interface RecoveryConfirmDialogState {
 }
 // isSegScan, isRtStructScan, isDerivedScan imported from sessionDerivedIndexStore
 // getSegReferenceInfo imported from lib/dicom/segReferencedSeriesUid
+
+function isUpdateBannerPhase(phase: UpdateStatus['phase'] | undefined): phase is 'available' | 'downloading' | 'downloaded' {
+  return phase === 'available' || phase === 'downloading' || phase === 'downloaded';
+}
+
+function getUpdateBannerVersion(status: UpdateStatus | null): string | null {
+  if (!status || !isUpdateBannerPhase(status.phase)) return null;
+  return status.downloadedVersion ?? status.availableVersion ?? null;
+}
+
+function getUpdateBannerMessage(status: UpdateStatus | null): string | null {
+  if (!status || !isUpdateBannerPhase(status.phase)) return null;
+  const version = getUpdateBannerVersion(status);
+  switch (status.phase) {
+    case 'available':
+      return version
+        ? `Update ${version} is available.`
+        : 'An update is available.';
+    case 'downloading':
+      if (status.downloadProgressPercent === null) {
+        return version
+          ? `Update ${version} is downloading in the background.`
+          : 'An update is downloading in the background.';
+      }
+      return version
+        ? `Update ${version} is downloading in the background (${Math.round(status.downloadProgressPercent)}%).`
+        : `An update is downloading in the background (${Math.round(status.downloadProgressPercent)}%).`;
+    case 'downloaded':
+      return version
+        ? `Update ${version} is ready to install. Restart the app to apply it now.`
+        : 'An update is ready to install. Restart the app to apply it now.';
+  }
+}
 
 
 /**
@@ -655,7 +689,10 @@ export default function App() {
   const preferences = usePreferencesStore((s) => s.preferences);
   const [backupBannerCount, setBackupBannerCount] = useState(0);
   const [backupBannerDismissed, setBackupBannerDismissed] = useState(false);
-  const [openSettingsToBackup, setOpenSettingsToBackup] = useState(false);
+  const [settingsInitialTabRequest, setSettingsInitialTabRequest] = useState<string | undefined>(undefined);
+  const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>(null);
+  const [updateBannerDismissed, setUpdateBannerDismissed] = useState(false);
+  const [updateBannerBusy, setUpdateBannerBusy] = useState(false);
 
   // Connection state
   const connectionStatus = useConnectionStore((s) => s.status);
@@ -752,6 +789,48 @@ export default function App() {
   useEffect(() => {
     applyPreferences(preferences);
   }, [preferences]);
+
+  useEffect(() => {
+    const updaterApi = window.electronAPI?.updater;
+    if (!updaterApi) return;
+
+    let cancelled = false;
+    updaterApi.getState()
+      .then((status) => {
+        if (!cancelled) setUpdateStatus(status);
+      })
+      .catch(() => {});
+
+    const unsubscribe = updaterApi.onStatus((status) => {
+      if (!cancelled) setUpdateStatus(status);
+    }) ?? (() => {});
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, []);
+
+  const updateBannerKey = updateStatus && isUpdateBannerPhase(updateStatus.phase)
+    ? `${updateStatus.phase}:${getUpdateBannerVersion(updateStatus) ?? 'unknown'}`
+    : null;
+
+  useEffect(() => {
+    if (updateBannerKey) {
+      setUpdateBannerDismissed(false);
+    }
+  }, [updateBannerKey]);
+
+  const installDownloadedUpdate = useCallback(async () => {
+    const updaterApi = window.electronAPI?.updater;
+    if (!updaterApi) return;
+    setUpdateBannerBusy(true);
+    try {
+      await updaterApi.quitAndInstall();
+    } finally {
+      setUpdateBannerBusy(false);
+    }
+  }, []);
 
   useEffect(() => {
     if (connectionStatus === 'connected') {
@@ -2806,7 +2885,7 @@ export default function App() {
             There {backupBannerCount === 1 ? 'is' : 'are'} {backupBannerCount} session{backupBannerCount !== 1 ? 's' : ''} with annotations that have not been saved.{' '}
             <button
               type="button"
-              onClick={() => setOpenSettingsToBackup(true)}
+              onClick={() => setSettingsInitialTabRequest('backup')}
               className="underline text-blue-300 hover:text-blue-100 transition-colors"
             >
               Review now
@@ -2825,14 +2904,63 @@ export default function App() {
         </div>
       )}
 
+      {updateStatus && isUpdateBannerPhase(updateStatus.phase) && !updateBannerDismissed && (
+        <div className="shrink-0 bg-blue-950/60 border-b border-blue-800/50 px-3 py-1.5 flex items-center gap-2">
+          <svg className="w-3.5 h-3.5 text-blue-400 shrink-0" viewBox="0 0 20 20" fill="currentColor">
+            <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z" clipRule="evenodd" />
+          </svg>
+          <span className="text-[11px] text-blue-200">
+            {getUpdateBannerMessage(updateStatus)}{' '}
+            {updateStatus.phase === 'downloaded' ? (
+              <>
+                <button
+                  type="button"
+                  onClick={() => void installDownloadedUpdate()}
+                  disabled={updateBannerBusy}
+                  className="underline text-blue-300 hover:text-blue-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  {updateBannerBusy ? 'Restarting...' : 'Restart and Install'}
+                </button>
+                {' · '}
+                <button
+                  type="button"
+                  onClick={() => setSettingsInitialTabRequest('updates')}
+                  className="underline text-blue-300 hover:text-blue-100 transition-colors"
+                >
+                  Review in Settings
+                </button>
+              </>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setSettingsInitialTabRequest('updates')}
+                className="underline text-blue-300 hover:text-blue-100 transition-colors"
+              >
+                Review in Settings
+              </button>
+            )}
+          </span>
+          <button
+            type="button"
+            onClick={() => setUpdateBannerDismissed(true)}
+            className="ml-auto text-blue-400 hover:text-blue-200 transition-colors"
+            title="Dismiss"
+          >
+            <svg className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+            </svg>
+          </button>
+        </div>
+      )}
+
       {/* Full-width toolbar at top, then browser + viewer below */}
       <ViewerPage
         panelImageIds={panelImageIds}
         onApplyProtocol={handleApplyProtocol}
         onToggleMPR={handleToggleMPR}
         onRecoverBackup={handleRecoverBackup}
-        openSettingsToBackup={openSettingsToBackup}
-        onSettingsToBackupConsumed={() => setOpenSettingsToBackup(false)}
+        settingsInitialTabRequest={settingsInitialTabRequest}
+        onSettingsInitialTabRequestConsumed={() => setSettingsInitialTabRequest(undefined)}
         mprSourceImageIds={mprSourceImageIds}
         leftSlot={
           <>

--- a/src/renderer/components/viewer/Toolbar.tsx
+++ b/src/renderer/components/viewer/Toolbar.tsx
@@ -486,24 +486,34 @@ interface ToolbarProps {
   leftSlot?: React.ReactNode;
   /** Called when the user clicks "Recover" for a backup session in Settings. */
   onRecoverBackup?: (sessionId: string) => Promise<void> | void;
-  /** When true, open Settings directly to the File Backup tab. */
-  openSettingsToBackup?: boolean;
-  /** Called after the open-settings-to-backup request has been consumed. */
-  onSettingsToBackupConsumed?: () => void;
+  /** When set, open Settings directly to the requested tab. */
+  settingsInitialTabRequest?: string;
+  /** Called after the open-settings request has been consumed. */
+  onSettingsInitialTabRequestConsumed?: () => void;
 }
 
-export default function Toolbar({ showDicomPanel = false, onToggleDicomPanel, onApplyProtocol, onToggleMPR, hasImages = false, leftSlot, onRecoverBackup, openSettingsToBackup, onSettingsToBackupConsumed }: ToolbarProps) {
+export default function Toolbar({
+  showDicomPanel = false,
+  onToggleDicomPanel,
+  onApplyProtocol,
+  onToggleMPR,
+  hasImages = false,
+  leftSlot,
+  onRecoverBackup,
+  settingsInitialTabRequest,
+  onSettingsInitialTabRequestConsumed,
+}: ToolbarProps) {
   const [showSettings, setShowSettings] = useState(false);
   const [settingsInitialTab, setSettingsInitialTab] = useState<string | undefined>(undefined);
 
-  // Open Settings to Backup tab when requested by parent (e.g. banner link)
+  // Open Settings to a specific tab when requested by parent (e.g. banner link)
   useEffect(() => {
-    if (openSettingsToBackup) {
-      setSettingsInitialTab('backup');
+    if (settingsInitialTabRequest) {
+      setSettingsInitialTab(settingsInitialTabRequest);
       setShowSettings(true);
-      onSettingsToBackupConsumed?.();
+      onSettingsInitialTabRequestConsumed?.();
     }
-  }, [openSettingsToBackup, onSettingsToBackupConsumed]);
+  }, [settingsInitialTabRequest, onSettingsInitialTabRequestConsumed]);
 
   const activeTool = useViewerStore((s) => s.activeTool);
   const mprActive = useViewerStore((s) => s.mprActive);

--- a/src/renderer/pages/ViewerPage.tsx
+++ b/src/renderer/pages/ViewerPage.tsx
@@ -30,13 +30,23 @@ interface ViewerPageProps {
   browserSlot?: React.ReactNode;
   /** Called when the user clicks "Recover" for a backup session in Settings. */
   onRecoverBackup?: (sessionId: string) => Promise<void> | void;
-  /** When true, the Settings modal should open to the File Backup tab. */
-  openSettingsToBackup?: boolean;
-  /** Called after the Settings-to-backup request has been consumed. */
-  onSettingsToBackupConsumed?: () => void;
+  /** When set, the Settings modal should open to the requested tab. */
+  settingsInitialTabRequest?: string;
+  /** Called after a Settings-tab request has been consumed. */
+  onSettingsInitialTabRequestConsumed?: () => void;
 }
 
-export default function ViewerPage({ panelImageIds, onApplyProtocol, onToggleMPR, mprSourceImageIds, leftSlot, browserSlot, onRecoverBackup, openSettingsToBackup, onSettingsToBackupConsumed }: ViewerPageProps) {
+export default function ViewerPage({
+  panelImageIds,
+  onApplyProtocol,
+  onToggleMPR,
+  mprSourceImageIds,
+  leftSlot,
+  browserSlot,
+  onRecoverBackup,
+  settingsInitialTabRequest,
+  onSettingsInitialTabRequestConsumed,
+}: ViewerPageProps) {
   const showAnnotationPanel = useAnnotationStore((s) => s.showPanel);
   const showSegPanel = useSegmentationStore((s) => s.showPanel);
   const [showDicomPanel, setShowDicomPanel] = useState(false);
@@ -77,8 +87,8 @@ export default function ViewerPage({ panelImageIds, onApplyProtocol, onToggleMPR
         hasImages={hasImages}
         leftSlot={leftSlot}
         onRecoverBackup={onRecoverBackup}
-        openSettingsToBackup={openSettingsToBackup}
-        onSettingsToBackupConsumed={onSettingsToBackupConsumed}
+        settingsInitialTabRequest={settingsInitialTabRequest}
+        onSettingsInitialTabRequestConsumed={onSettingsInitialTabRequestConsumed}
       />
       <div className="flex-1 min-h-0 flex relative">
         {/* Optional browser sidebar (rendered by App) */}


### PR DESCRIPTION
## Summary
- surface update availability at the top of the app using the same banner styling as the backup recovery prompt
- add a direct `Restart and Install` action once an update has finished downloading
- generalize the Settings tab request flow so banners can jump directly to the relevant tab

## Validation
- `npm test -- src/renderer/App.test.tsx`
- `npm run build`