### PR TITLE
Tighten KeyLocker workflow diagnostics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,6 +199,7 @@ jobs:
         shell: pwsh
         env:
           SM_HOST: ${{ vars.SM_HOST }}
+          SM_KEYPAIR_ALIAS: ${{ vars.SM_KEYPAIR_ALIAS }}
           SM_API_KEY: ${{ secrets.SM_API_KEY }}
           SM_CLIENT_CERT_FILE_B64: ${{ secrets.SM_CLIENT_CERT_FILE_B64 }}
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
@@ -206,7 +207,15 @@ jobs:
           WIN_CSC_SUBJECT_NAME: ${{ vars.WIN_CSC_SUBJECT_NAME }}
         run: |
           $hasCertSelector = -not [string]::IsNullOrWhiteSpace($env:SM_CODE_SIGNING_CERT_SHA1_HASH) -or -not [string]::IsNullOrWhiteSpace($env:WIN_CSC_SUBJECT_NAME)
-          if ([string]::IsNullOrWhiteSpace($env:SM_HOST) -or [string]::IsNullOrWhiteSpace($env:SM_API_KEY) -or [string]::IsNullOrWhiteSpace($env:SM_CLIENT_CERT_FILE_B64) -or [string]::IsNullOrWhiteSpace($env:SM_CLIENT_CERT_PASSWORD) -or -not $hasCertSelector) {
+          $hasKeypairAlias = -not [string]::IsNullOrWhiteSpace($env:SM_KEYPAIR_ALIAS)
+          "has_sm_host=$(-not [string]::IsNullOrWhiteSpace($env:SM_HOST))" >> $env:GITHUB_OUTPUT
+          "has_sm_keypair_alias=$hasKeypairAlias" >> $env:GITHUB_OUTPUT
+          "has_sm_api_key=$(-not [string]::IsNullOrWhiteSpace($env:SM_API_KEY))" >> $env:GITHUB_OUTPUT
+          "has_sm_client_cert=$(-not [string]::IsNullOrWhiteSpace($env:SM_CLIENT_CERT_FILE_B64))" >> $env:GITHUB_OUTPUT
+          "has_sm_client_cert_password=$(-not [string]::IsNullOrWhiteSpace($env:SM_CLIENT_CERT_PASSWORD))" >> $env:GITHUB_OUTPUT
+          "has_cert_selector=$hasCertSelector" >> $env:GITHUB_OUTPUT
+
+          if ([string]::IsNullOrWhiteSpace($env:SM_HOST) -or -not $hasKeypairAlias -or [string]::IsNullOrWhiteSpace($env:SM_API_KEY) -or [string]::IsNullOrWhiteSpace($env:SM_CLIENT_CERT_FILE_B64) -or [string]::IsNullOrWhiteSpace($env:SM_CLIENT_CERT_PASSWORD) -or -not $hasCertSelector) {
             "ready=false" >> $env:GITHUB_OUTPUT
             exit 0
           }
@@ -221,8 +230,26 @@ jobs:
         if: github.event_name == 'workflow_dispatch' && inputs.build_windows && steps.windows_signing.outputs.ready != 'true'
         shell: pwsh
         run: |
-          Write-Error "Missing DigiCert KeyLocker configuration. Set SM_HOST, SM_API_KEY, SM_CLIENT_CERT_FILE_B64, SM_CLIENT_CERT_PASSWORD, and SM_CODE_SIGNING_CERT_SHA1_HASH or WIN_CSC_SUBJECT_NAME."
+          Write-Host "SM_HOST present: ${{ steps.windows_signing.outputs.has_sm_host }}"
+          Write-Host "SM_KEYPAIR_ALIAS present: ${{ steps.windows_signing.outputs.has_sm_keypair_alias }}"
+          Write-Host "SM_API_KEY present: ${{ steps.windows_signing.outputs.has_sm_api_key }}"
+          Write-Host "SM_CLIENT_CERT_FILE_B64 present: ${{ steps.windows_signing.outputs.has_sm_client_cert }}"
+          Write-Host "SM_CLIENT_CERT_PASSWORD present: ${{ steps.windows_signing.outputs.has_sm_client_cert_password }}"
+          Write-Host "Windows cert selector present: ${{ steps.windows_signing.outputs.has_cert_selector }}"
+          Write-Error "Missing DigiCert KeyLocker configuration. Set SM_HOST, SM_KEYPAIR_ALIAS, SM_API_KEY, SM_CLIENT_CERT_FILE_B64, SM_CLIENT_CERT_PASSWORD, and SM_CODE_SIGNING_CERT_SHA1_HASH or WIN_CSC_SUBJECT_NAME."
           exit 1
+
+      - name: Log Windows signing configuration
+        if: steps.windows_signing.outputs.ready == 'true'
+        shell: pwsh
+        env:
+          SM_HOST: ${{ vars.SM_HOST }}
+          SM_KEYPAIR_ALIAS: ${{ vars.SM_KEYPAIR_ALIAS }}
+          WIN_CSC_SUBJECT_NAME: ${{ vars.WIN_CSC_SUBJECT_NAME }}
+        run: |
+          Write-Host "SM_HOST: $env:SM_HOST"
+          Write-Host "SM_KEYPAIR_ALIAS present: $(-not [string]::IsNullOrWhiteSpace($env:SM_KEYPAIR_ALIAS))"
+          Write-Host "WIN_CSC_SUBJECT_NAME present: $(-not [string]::IsNullOrWhiteSpace($env:WIN_CSC_SUBJECT_NAME))"
 
       - name: Set up DigiCert KeyLocker tools
         if: steps.windows_signing.outputs.ready == 'true'
@@ -244,12 +271,7 @@ jobs:
         env:
           SM_KEYPAIR_ALIAS: ${{ vars.SM_KEYPAIR_ALIAS }}
         run: |
-          if ([string]::IsNullOrWhiteSpace($env:SM_KEYPAIR_ALIAS)) {
-            smctl windows certsync
-          }
-          else {
-            smctl windows certsync --keypair-alias="$env:SM_KEYPAIR_ALIAS"
-          }
+          smctl windows certsync --keypair-alias="$env:SM_KEYPAIR_ALIAS"
 
       - name: Build and publish Windows artifacts
         if: steps.windows_signing.outputs.ready == 'true'

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Required GitHub Actions variables:
 
 Optional GitHub Actions variables:
 
-- `SM_KEYPAIR_ALIAS` — preferred DigiCert keypair alias for `smctl windows certsync`
+- `SM_KEYPAIR_ALIAS` — DigiCert keypair alias used for `smctl windows certsync`
 - `WIN_CSC_SUBJECT_NAME` — fallback Windows certificate subject name if you prefer subject lookup over thumbprint
 
 Recommended release flow:
@@ -227,7 +227,7 @@ Recommended release flow:
 
 Windows signing is handled in GitHub Actions on `windows-latest`; no local Windows machine is required.
 
-The release workflow uses DigiCert's GitHub Action to install KeyLocker tooling, runs `smctl healthcheck`, syncs the certificate into the Windows user certificate store with `smctl windows certsync`, and then packages the app with Electron Builder using the synced certificate thumbprint or subject name.
+The release workflow uses DigiCert's GitHub Action to install KeyLocker tooling, runs `smctl healthcheck`, syncs the certificate into the Windows user certificate store with `smctl windows certsync --keypair-alias=...`, and then packages the app with Electron Builder using the synced certificate thumbprint or subject name.
 
 `npm run package:win` is intended for Windows CI or a Windows developer machine that already has the DigiCert KeyLocker environment configured. It expects:
 


### PR DESCRIPTION
## Summary
- require SM_KEYPAIR_ALIAS before the Windows KeyLocker job proceeds
- log safe presence checks for the expected KeyLocker inputs
- always run cert sync with the provided keypair alias

## Why
The first Windows dry run failed with a DigiCert 403 during cert sync. This follow-up makes the workflow fail earlier with clearer diagnostics so the next run tells us whether the alias and KeyLocker inputs are actually reaching the runner.

## Validation
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'yaml-ok'"