### PR TITLE
Pass KeyLocker env to smctl steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,12 +263,21 @@ jobs:
       - name: Verify DigiCert client connectivity
         if: steps.windows_signing.outputs.ready == 'true'
         shell: pwsh
+        env:
+          SM_HOST: ${{ vars.SM_HOST }}
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\sm-client-cert.p12
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
         run: smctl healthcheck
 
       - name: Sync Windows certificate store
         if: steps.windows_signing.outputs.ready == 'true'
         shell: pwsh
         env:
+          SM_HOST: ${{ vars.SM_HOST }}
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\sm-client-cert.p12
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
           SM_KEYPAIR_ALIAS: ${{ vars.SM_KEYPAIR_ALIAS }}
         run: |
           smctl windows certsync --keypair-alias="$env:SM_KEYPAIR_ALIAS"


### PR DESCRIPTION
## Summary
- pass the DigiCert KeyLocker environment variables into the Windows `smctl healthcheck` step
- pass the same KeyLocker environment variables into the Windows `smctl windows certsync` step

## Why
The previous merged workflow changes set up DigiCert tooling correctly, but the later `smctl` steps did not receive the KeyLocker env vars in their own process environment. That made `smctl healthcheck` report `Status: No credentials found.` even though the setup action had the secrets.

## Validation
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'yaml-ok'"
- verified branch contains commit `25e4086`