### PR TITLE
Fix Windows package helper launch

### DIFF
--- a/scripts/package-win.js
+++ b/scripts/package-win.js
@@ -32,7 +32,7 @@ const executable = path.join(
   process.cwd(),
   'node_modules',
   '.bin',
-  process.platform === 'win32' ? 'electron-builder.cmd' : 'electron-builder',
+  'electron-builder.cmd',
 );
 
 const result = spawnSync(
@@ -41,6 +41,7 @@ const result = spawnSync(
   {
     stdio: 'inherit',
     env: process.env,
+    shell: true,
   },
 );
 


### PR DESCRIPTION
## Summary
- fix the Windows packaging helper so it launches `electron-builder.cmd` correctly on GitHub Actions Windows runners

## Why
The release workflow got past DigiCert KeyLocker auth and cert sync, then failed in `scripts/package-win.js` with `spawnSync ... electron-builder.cmd EINVAL`. On Windows, spawning a `.cmd` wrapper directly from Node requires shell execution semantics.

## Validation
- `node --check scripts/package-win.js`