### PR TITLE
Fix Windows signtool config

### DIFF
--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -6,12 +6,16 @@ const win = {
   target: ['nsis', 'portable'],
 };
 
-if (windowsCertificateSha1) {
-  win.certificateSha1 = windowsCertificateSha1;
-}
+if (windowsCertificateSha1 || windowsCertificateSubjectName) {
+  win.signtoolOptions = {};
 
-if (windowsCertificateSubjectName) {
-  win.certificateSubjectName = windowsCertificateSubjectName;
+  if (windowsCertificateSha1) {
+    win.signtoolOptions.certificateSha1 = windowsCertificateSha1;
+  }
+
+  if (windowsCertificateSubjectName) {
+    win.signtoolOptions.certificateSubjectName = windowsCertificateSubjectName;
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- move the Windows certificate selector into `win.signtoolOptions`, which matches the current electron-builder schema

## Why
The latest release run got all the way through DigiCert KeyLocker auth and certificate sync, then failed in Electron Builder with:

- `configuration.win has an unknown property 'certificateSha1'`

This fix preserves the same thumbprint/subject selection behavior but places it where electron-builder 26 expects it.

## Validation
- `node -e "process.env.WIN_CSC_CERT_SHA1='ABC123'; const c=require('./electron-builder.config.js'); console.log(JSON.stringify(c.win,null,2))"`