### PR TITLE
Use SHA-256 RFC3161 Windows signing

### DIFF
--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -16,6 +16,11 @@ if (windowsCertificateSha1 || windowsCertificateSubjectName) {
   if (windowsCertificateSubjectName) {
     win.signtoolOptions.certificateSubjectName = windowsCertificateSubjectName;
   }
+
+  // KeyLocker signing is more reliable with explicit RFC 3161 + SHA-256 settings.
+  win.signtoolOptions.rfc3161TimeStampServer = 'http://timestamp.digicert.com';
+  win.signtoolOptions.timeStampServer = null;
+  win.signtoolOptions.signingHashAlgorithms = ['sha256'];
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- force Windows KeyLocker signing to use RFC 3161 timestamping and SHA-256 digests via `win.signtoolOptions`

## Why
The latest Windows release run gets through KeyLocker auth, certificate sync, and certificate selection, but the actual SignTool invocation still fails with `SignerSign() failed (0x8009002d)`. DigiCert's KeyLocker SignTool examples use RFC 3161 timestamps and explicit SHA-256 flags (`/tr ... /td SHA256 /fd SHA256`), while the current electron-builder-generated command is still using `/t` without digest flags. This change aligns the generated SignTool configuration with DigiCert's documented pattern.

## Validation
- `node -e "process.env.WIN_CSC_CERT_SHA1='ABC123'; const c=require('./electron-builder.config.js'); console.log(JSON.stringify(c.win,null,2))"`