### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xnat-viewer",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xnat-viewer",
-      "version": "0.5.6",
+      "version": "0.6.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xnat-viewer",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "XNAT Desktop Workstation with native Cornerstone3D rendering",
   "main": "dist/main/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump the app version from `0.5.6` to `0.6.0` in `package.json` and the root package metadata in `package-lock.json`

## Why
This prepares the next tagged release as `v0.6.0`.

## Validation
- verified `package.json` reports `0.6.0`
- verified the root package entries in `package-lock.json` report `0.6.0`