### PR TITLE
Separate Windows artifact names

### DIFF
--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -56,6 +56,12 @@ module.exports = {
     notarize: true,
   },
   win,
+  nsis: {
+    artifactName: 'XNAT-Workstation-${version}-${arch}-setup.${ext}',
+  },
+  portable: {
+    artifactName: 'XNAT-Workstation-${version}-${arch}-portable.${ext}',
+  },
   linux: {
     maintainer: 'Daniel Marcus <dmarcus@wustl.edu>',
     target: ['AppImage', 'deb'],


### PR DESCRIPTION
## Summary
- give the Windows NSIS installer and portable build distinct artifact filenames

## Why
The `v0.6.0` release got all the way through signing and packaging, but publishing failed because both Windows targets produced the same filename (`XNAT-Workstation-0.6.0-x64.exe`). Electron Builder uploaded the NSIS installer first, then the portable target tried to upload a second file with the same name and eventually timed out after an overwrite conflict.

This change keeps both Windows targets enabled but names them distinctly:
- NSIS: `...-setup.exe`
- portable: `...-portable.exe`

## Validation
- `node -e "const c=require('./electron-builder.config.js'); console.log(JSON.stringify({nsis:c.nsis, portable:c.portable}, null, 2))"`