### PR TITLE
[codex] add shift-scroll anatomical viewport sync

### DIFF
--- a/src/renderer/components/viewer/CornerstoneViewport.test.tsx
+++ b/src/renderer/components/viewer/CornerstoneViewport.test.tsx
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   getEpoch: vi.fn(() => 7),
   markReady: vi.fn(),
   syncCrosshair: vi.fn(),
+  syncFromClientPoint: vi.fn(),
   wireCrosshairPointerHandlers: vi.fn(),
   removeSegsFromViewport: vi.fn(),
   attachVisibleSegsToViewport: vi.fn(async () => undefined),
@@ -81,6 +82,7 @@ vi.mock('../../lib/cornerstone/viewportReadyService', () => ({
 vi.mock('../../lib/cornerstone/crosshairSyncService', () => ({
   crosshairSyncService: {
     syncFromViewport: mocks.syncCrosshair,
+    syncFromClientPoint: mocks.syncFromClientPoint,
   },
 }));
 
@@ -239,6 +241,78 @@ describe('CornerstoneViewport', () => {
     );
     expect(mocks.scrollToIndex).toHaveBeenCalledWith(panelId, 0);
     expect(useViewerStore.getState().viewports[panelId].requestedImageIndex).toBe(0);
+  });
+
+  it('syncs compatible viewports after the shifted stack scroll renders the new slice', async () => {
+    mocks.getViewport.mockReturnValue({
+      getCurrentImageIdIndex: () => 0,
+      getImageIds: () => ['img-1', 'img-2', 'img-3'],
+      getCurrentImageId: () => 'img-1',
+      getImageData: () => ({ dimensions: [320, 240] }),
+      getProperties: () => ({ voiRange: { lower: 20, upper: 120 } }),
+      resetCamera: vi.fn(),
+      render: vi.fn(),
+    });
+
+    render(<CornerstoneViewport panelId={panelId} imageIds={['img-1', 'img-2', 'img-3']} />);
+    await waitFor(() => expect(mocks.createViewport).toHaveBeenCalled());
+
+    const canvas = screen.getByTestId(`cornerstone-viewport-canvas:${panelId}`);
+
+    fireEvent(
+      canvas,
+      new WheelEvent('wheel', {
+        deltaY: 120,
+        shiftKey: true,
+        cancelable: true,
+      }),
+    );
+    expect(mocks.syncFromClientPoint).not.toHaveBeenCalled();
+
+    fireEvent(
+      canvas,
+      new CustomEvent('STACK_NEW_IMAGE', {
+        detail: { imageIdIndex: 2, imageId: 'img-3' },
+      }),
+    );
+
+    expect(mocks.syncFromClientPoint).toHaveBeenCalledWith(panelId, 0, 0);
+  });
+
+  it('uses horizontal wheel deltas for shift-scroll trackpad gestures', async () => {
+    mocks.getViewport.mockReturnValue({
+      getCurrentImageIdIndex: () => 1,
+      getImageIds: () => ['img-1', 'img-2', 'img-3', 'img-4'],
+      getCurrentImageId: () => 'img-2',
+      getImageData: () => ({ dimensions: [320, 240] }),
+      getProperties: () => ({ voiRange: { lower: 20, upper: 120 } }),
+      resetCamera: vi.fn(),
+      render: vi.fn(),
+    });
+
+    render(<CornerstoneViewport panelId={panelId} imageIds={['img-1', 'img-2', 'img-3', 'img-4']} />);
+    await waitFor(() => expect(mocks.createViewport).toHaveBeenCalled());
+
+    const canvas = screen.getByTestId(`cornerstone-viewport-canvas:${panelId}`);
+
+    fireEvent(
+      canvas,
+      new WheelEvent('wheel', {
+        deltaX: 120,
+        deltaY: 0,
+        shiftKey: true,
+        cancelable: true,
+      }),
+    );
+
+    expect(mocks.scrollToIndex).toHaveBeenCalledWith(panelId, 3);
+    fireEvent(
+      canvas,
+      new CustomEvent('STACK_NEW_IMAGE', {
+        detail: { imageIdIndex: 3, imageId: 'img-4' },
+      }),
+    );
+    expect(mocks.syncFromClientPoint).toHaveBeenCalledWith(panelId, 0, 0);
   });
 
   it('shows error UI when setup fails and skips ready signaling', async () => {

--- a/src/renderer/components/viewer/CornerstoneViewport.tsx
+++ b/src/renderer/components/viewer/CornerstoneViewport.tsx
@@ -249,6 +249,7 @@ export default function CornerstoneViewport({ panelId, imageIds }: CornerstoneVi
 
 function wireEvents(element: HTMLDivElement, panelId: string): () => void {
   const Events = Enums.Events;
+  let pendingShiftScrollSync: { clientX: number; clientY: number } | null = null;
 
   // VOI changed (user dragged W/L or preset applied)
   element.addEventListener(Events.VOI_MODIFIED, ((e: Event) => {
@@ -280,6 +281,12 @@ function wireEvents(element: HTMLDivElement, panelId: string): () => void {
         useViewerStore.getState().setPanelNativeOrientation(panelId, nativeOrientation);
       }
     }
+
+    if (pendingShiftScrollSync) {
+      const { clientX, clientY } = pendingShiftScrollSync;
+      pendingShiftScrollSync = null;
+      crosshairSyncService.syncFromClientPoint(panelId, clientX, clientY);
+    }
   }) as EventListener);
 
   // Camera modified (zoom, pan, rotation changed)
@@ -300,7 +307,11 @@ function wireEvents(element: HTMLDivElement, panelId: string): () => void {
 
     e.preventDefault();
 
-    wheelAccum += e.deltaY;
+    const scrollDelta =
+      Math.abs(e.deltaY) >= Math.abs(e.deltaX)
+        ? e.deltaY
+        : (e.shiftKey ? e.deltaX : 0);
+    wheelAccum += scrollDelta;
 
     if (Math.abs(wheelAccum) >= WHEEL_THRESHOLD) {
       const steps = Math.trunc(wheelAccum / WHEEL_THRESHOLD);
@@ -321,6 +332,7 @@ function wireEvents(element: HTMLDivElement, panelId: string): () => void {
         0;
       const targetIndex = Math.max(0, Math.min(total - 1, baseIndex + steps));
       if (targetIndex !== baseIndex) {
+        pendingShiftScrollSync = e.shiftKey ? { clientX: e.clientX, clientY: e.clientY } : null;
         state._requestImageIndex(panelId, targetIndex, total);
         viewportService.scrollToIndex(panelId, targetIndex);
       }

--- a/src/renderer/components/viewer/MPRViewport.test.tsx
+++ b/src/renderer/components/viewer/MPRViewport.test.tsx
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   removeViewport: vi.fn(),
   resize: vi.fn(),
   syncFromViewport: vi.fn(),
+  syncFromClientPoint: vi.fn(),
   wireCrosshairPointerHandlers: vi.fn(),
 }));
 
@@ -64,6 +65,7 @@ vi.mock('../../lib/cornerstone/viewportService', () => ({
 vi.mock('../../lib/cornerstone/crosshairSyncService', () => ({
   crosshairSyncService: {
     syncFromViewport: mocks.syncFromViewport,
+    syncFromClientPoint: mocks.syncFromClientPoint,
   },
 }));
 
@@ -209,6 +211,48 @@ describe('MPRViewport', () => {
       }),
     );
     expect(mocks.scroll).toHaveBeenCalledTimes(1);
+  });
+
+  it('syncs compatible viewports after the shifted MPR scroll updates the slice', async () => {
+    render(<MPRViewport panelId={panelId} volumeId="vol-1" plane="SAGITTAL" />);
+    await waitFor(() => expect(mocks.createViewport).toHaveBeenCalled());
+
+    const canvas = screen.getByTestId(`mpr-viewport-canvas:${panelId}`);
+
+    fireEvent(
+      canvas,
+      new WheelEvent('wheel', {
+        deltaY: 120,
+        shiftKey: true,
+        cancelable: true,
+      }),
+    );
+    expect(mocks.syncFromClientPoint).not.toHaveBeenCalled();
+
+    fireEvent(canvas, new CustomEvent('CAMERA_MODIFIED'));
+
+    expect(mocks.syncFromClientPoint).toHaveBeenCalledWith(panelId, 0, 0);
+  });
+
+  it('uses horizontal wheel deltas for shift-scroll MPR trackpad gestures', async () => {
+    render(<MPRViewport panelId={panelId} volumeId="vol-1" plane="SAGITTAL" />);
+    await waitFor(() => expect(mocks.createViewport).toHaveBeenCalled());
+
+    const canvas = screen.getByTestId(`mpr-viewport-canvas:${panelId}`);
+
+    fireEvent(
+      canvas,
+      new WheelEvent('wheel', {
+        deltaX: -120,
+        deltaY: 0,
+        shiftKey: true,
+        cancelable: true,
+      }),
+    );
+
+    expect(mocks.scroll).toHaveBeenCalledWith(panelId, -2);
+    fireEvent(canvas, new CustomEvent('CAMERA_MODIFIED'));
+    expect(mocks.syncFromClientPoint).toHaveBeenCalledWith(panelId, 0, 0);
   });
 
   it('shows MPR error overlay when setup fails and performs cleanup on unmount', async () => {

--- a/src/renderer/components/viewer/MPRViewport.tsx
+++ b/src/renderer/components/viewer/MPRViewport.tsx
@@ -216,6 +216,7 @@ export default function MPRViewport({ panelId, volumeId, plane }: MPRViewportPro
 
 function wireEvents(element: HTMLDivElement, panelId: string): () => void {
   const Events = Enums.Events;
+  let pendingShiftScrollSync: { clientX: number; clientY: number } | null = null;
 
   // VOI changed (user dragged W/L)
   element.addEventListener(Events.VOI_MODIFIED, ((e: Event) => {
@@ -237,6 +238,12 @@ function wireEvents(element: HTMLDivElement, panelId: string): () => void {
 
     // Update zoom
     useViewerStore.getState()._updateZoom(panelId, mprService.getZoom(panelId));
+
+    if (pendingShiftScrollSync) {
+      const { clientX, clientY } = pendingShiftScrollSync;
+      pendingShiftScrollSync = null;
+      crosshairSyncService.syncFromClientPoint(panelId, clientX, clientY);
+    }
   }) as EventListener);
 
   // ─── Trackpad / smooth scroll support ───────────────────────
@@ -247,11 +254,18 @@ function wireEvents(element: HTMLDivElement, panelId: string): () => void {
     if (e.ctrlKey || e.metaKey) return;
     e.preventDefault();
 
-    wheelAccum += e.deltaY;
+    const scrollDelta =
+      Math.abs(e.deltaY) >= Math.abs(e.deltaX)
+        ? e.deltaY
+        : (e.shiftKey ? e.deltaX : 0);
+    wheelAccum += scrollDelta;
 
     if (Math.abs(wheelAccum) >= WHEEL_THRESHOLD) {
       const steps = Math.trunc(wheelAccum / WHEEL_THRESHOLD);
       wheelAccum -= steps * WHEEL_THRESHOLD;
+      pendingShiftScrollSync = e.shiftKey && steps !== 0
+        ? { clientX: e.clientX, clientY: e.clientY }
+        : null;
       mprService.scroll(panelId, steps);
     }
   }, { passive: false });

--- a/src/renderer/components/viewer/OrientedViewport.test.tsx
+++ b/src/renderer/components/viewer/OrientedViewport.test.tsx
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   attachVisibleSegsToViewport: vi.fn(async () => undefined),
   wireCrosshairPointerHandlers: vi.fn(),
   syncFromViewport: vi.fn(),
+  syncFromClientPoint: vi.fn(),
 }));
 
 vi.mock('@cornerstonejs/core', async (importOriginal) => {
@@ -98,6 +99,7 @@ vi.mock('../../lib/cornerstone/crosshairGeometry', () => ({
 vi.mock('../../lib/cornerstone/crosshairSyncService', () => ({
   crosshairSyncService: {
     syncFromViewport: mocks.syncFromViewport,
+    syncFromClientPoint: mocks.syncFromClientPoint,
   },
 }));
 
@@ -232,6 +234,48 @@ describe('OrientedViewport', () => {
       }),
     );
     expect(mocks.mprScroll).toHaveBeenCalledTimes(1);
+  });
+
+  it('syncs compatible viewports after the shifted oriented scroll updates the slice', async () => {
+    render(<OrientedViewport panelId={panelId} imageIds={['img-1', 'img-2']} plane="SAGITTAL" />);
+    await waitFor(() => expect(mocks.mprCreateViewport).toHaveBeenCalled());
+
+    const canvas = screen.getByTestId(`oriented-viewport-canvas:${panelId}`);
+
+    fireEvent(
+      canvas,
+      new WheelEvent('wheel', {
+        deltaY: 130,
+        shiftKey: true,
+        cancelable: true,
+      }),
+    );
+    expect(mocks.syncFromClientPoint).not.toHaveBeenCalled();
+
+    fireEvent(canvas, new CustomEvent('CAMERA_MODIFIED'));
+
+    expect(mocks.syncFromClientPoint).toHaveBeenCalledWith(panelId, 0, 0);
+  });
+
+  it('uses horizontal wheel deltas for shift-scroll oriented trackpad gestures', async () => {
+    render(<OrientedViewport panelId={panelId} imageIds={['img-1', 'img-2']} plane="SAGITTAL" />);
+    await waitFor(() => expect(mocks.mprCreateViewport).toHaveBeenCalled());
+
+    const canvas = screen.getByTestId(`oriented-viewport-canvas:${panelId}`);
+
+    fireEvent(
+      canvas,
+      new WheelEvent('wheel', {
+        deltaX: 130,
+        deltaY: 0,
+        shiftKey: true,
+        cancelable: true,
+      }),
+    );
+
+    expect(mocks.mprScroll).toHaveBeenCalledWith(panelId, 2);
+    fireEvent(canvas, new CustomEvent('CAMERA_MODIFIED'));
+    expect(mocks.syncFromClientPoint).toHaveBeenCalledWith(panelId, 0, 0);
   });
 
   it('shows error overlay when setup fails', async () => {

--- a/src/renderer/components/viewer/OrientedViewport.tsx
+++ b/src/renderer/components/viewer/OrientedViewport.tsx
@@ -173,6 +173,7 @@ function syncSliceState(panelId: string): void {
 
 function wireEvents(element: HTMLDivElement, panelId: string): () => void {
   const Events = Enums.Events;
+  let pendingShiftScrollSync: { clientX: number; clientY: number } | null = null;
 
   element.addEventListener(Events.VOI_MODIFIED, ((e: Event) => {
     const detail = (e as CustomEvent).detail;
@@ -186,6 +187,12 @@ function wireEvents(element: HTMLDivElement, panelId: string): () => void {
 
   element.addEventListener(Events.CAMERA_MODIFIED, (() => {
     syncSliceState(panelId);
+
+    if (pendingShiftScrollSync) {
+      const { clientX, clientY } = pendingShiftScrollSync;
+      pendingShiftScrollSync = null;
+      crosshairSyncService.syncFromClientPoint(panelId, clientX, clientY);
+    }
   }) as EventListener);
 
   let wheelAccum = 0;
@@ -194,11 +201,18 @@ function wireEvents(element: HTMLDivElement, panelId: string): () => void {
   element.addEventListener('wheel', (e: WheelEvent) => {
     if (e.ctrlKey || e.metaKey) return;
     e.preventDefault();
-    wheelAccum += e.deltaY;
+    const scrollDelta =
+      Math.abs(e.deltaY) >= Math.abs(e.deltaX)
+        ? e.deltaY
+        : (e.shiftKey ? e.deltaX : 0);
+    wheelAccum += scrollDelta;
 
     if (Math.abs(wheelAccum) >= WHEEL_THRESHOLD) {
       const steps = Math.trunc(wheelAccum / WHEEL_THRESHOLD);
       wheelAccum -= steps * WHEEL_THRESHOLD;
+      pendingShiftScrollSync = e.shiftKey && steps !== 0
+        ? { clientX: e.clientX, clientY: e.clientY }
+        : null;
       mprService.scroll(panelId, steps);
     }
   }, { passive: false });

--- a/src/renderer/lib/cornerstone/__tests__/crosshairSyncService.test.ts
+++ b/src/renderer/lib/cornerstone/__tests__/crosshairSyncService.test.ts
@@ -3,7 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const metaDataGetMock = vi.hoisted(() => vi.fn());
 const scrollToIndexMock = vi.hoisted(() => vi.fn());
+const stackGetViewportMock = vi.hoisted(() => vi.fn(() => null));
 const mprScrollToIndexMock = vi.hoisted(() => vi.fn());
+const mprGetViewportMock = vi.hoisted(() => vi.fn(() => null));
+const mprGetSliceInfoMock = vi.hoisted(() => vi.fn(() => ({ sliceIndex: 0, totalSlices: 0 })));
 const getPanelDisplayPointForWorldMock = vi.hoisted(() => vi.fn());
 const getViewportForPanelMock = vi.hoisted(() => vi.fn());
 const getWorldPointFromClientPointMock = vi.hoisted(() => vi.fn());
@@ -81,13 +84,15 @@ vi.mock('@cornerstonejs/dicom-image-loader', () => ({
 
 vi.mock('../viewportService', () => ({
   viewportService: {
+    getViewport: stackGetViewportMock,
     scrollToIndex: scrollToIndexMock,
   },
 }));
 
 vi.mock('../mprService', () => ({
   mprService: {
-    getViewport: vi.fn(() => null),
+    getViewport: mprGetViewportMock,
+    getSliceInfo: mprGetSliceInfoMock,
     scrollToIndex: mprScrollToIndexMock,
   },
 }));
@@ -123,6 +128,9 @@ describe('crosshairSyncService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     viewerStoreMock.reset();
+    stackGetViewportMock.mockReturnValue(null);
+    mprGetViewportMock.mockReturnValue(null);
+    mprGetSliceInfoMock.mockReturnValue({ sliceIndex: 0, totalSlices: 0 });
     getPanelDisplayPointForWorldMock.mockReturnValue([1, 1]);
     getWorldPointFromClientPointMock.mockReturnValue([0, 0, 0]);
     // Invalidate any leftover metadata-loaded state from previous tests.
@@ -157,6 +165,65 @@ describe('crosshairSyncService', () => {
     expect(targetViewport.jumpToWorld).toHaveBeenCalledWith([10, 20, 30]);
     expect(state.viewports.panel_1?.requestedImageIndex).toBe(2);
     expect(scrollToIndexMock).not.toHaveBeenCalled();
+  });
+
+  it('syncs from the center of the source panel when requested', () => {
+    setMetadata({
+      'imagePlaneModule|img-source': { frameOfReferenceUID: 'FOR-1' },
+      'generalSeriesModule|img-source': { seriesInstanceUID: 'SER-1' },
+      'imagePlaneModule|img-target-a': { frameOfReferenceUID: 'FOR-1' },
+      'generalSeriesModule|img-target-a': { seriesInstanceUID: 'SER-1' },
+    });
+
+    const panelEl = document.createElement('div');
+    panelEl.setAttribute('data-panel-id', 'panel_0');
+    Object.defineProperty(panelEl, 'getBoundingClientRect', {
+      value: () => ({ left: 10, top: 20, width: 120, height: 80 }),
+    });
+    document.body.appendChild(panelEl);
+
+    const targetViewport = {
+      type: 'orthogonal',
+      jumpToWorld: vi.fn(() => true),
+      getCurrentImageIdIndex: vi.fn(() => 1),
+      render: vi.fn(),
+    };
+    getViewportForPanelMock.mockImplementation((panelId: string) => (
+      panelId === 'panel_1' ? targetViewport : null
+    ));
+    getWorldPointFromClientPointMock.mockReturnValue([7, 8, 9]);
+
+    crosshairSyncService.syncFromPanelCenter('panel_0');
+
+    expect(getWorldPointFromClientPointMock).toHaveBeenCalledWith('panel_0', 70, 60);
+    expect(targetViewport.jumpToWorld).toHaveBeenCalledWith([7, 8, 9]);
+    expect(viewerStoreMock.getState().crosshairWorldPoint).toEqual([7, 8, 9]);
+  });
+
+  it('syncs from an explicit client point inside the source panel', () => {
+    setMetadata({
+      'imagePlaneModule|img-source': { frameOfReferenceUID: 'FOR-1' },
+      'generalSeriesModule|img-source': { seriesInstanceUID: 'SER-1' },
+      'imagePlaneModule|img-target-a': { frameOfReferenceUID: 'FOR-1' },
+      'generalSeriesModule|img-target-a': { seriesInstanceUID: 'SER-1' },
+    });
+
+    const targetViewport = {
+      type: 'orthogonal',
+      jumpToWorld: vi.fn(() => true),
+      getCurrentImageIdIndex: vi.fn(() => 1),
+      render: vi.fn(),
+    };
+    getViewportForPanelMock.mockImplementation((panelId: string) => (
+      panelId === 'panel_1' ? targetViewport : null
+    ));
+    getWorldPointFromClientPointMock.mockReturnValue([4, 5, 6]);
+
+    crosshairSyncService.syncFromClientPoint('panel_0', 123, 456);
+
+    expect(getWorldPointFromClientPointMock).toHaveBeenCalledWith('panel_0', 123, 456);
+    expect(targetViewport.jumpToWorld).toHaveBeenCalledWith([4, 5, 6]);
+    expect(viewerStoreMock.getState().crosshairWorldPoint).toEqual([4, 5, 6]);
   });
 
   it('skips target panels that do not match frame-of-reference/series compatibility', () => {

--- a/src/renderer/lib/cornerstone/crosshairSyncService.ts
+++ b/src/renderer/lib/cornerstone/crosshairSyncService.ts
@@ -338,6 +338,38 @@ export const crosshairSyncService = {
   },
 
   /**
+   * Sync from a client-space point inside the source panel.
+   * Used for cursor-anchored shift-scroll anatomical alignment.
+   */
+  syncFromClientPoint(sourcePanelId: string, clientX: number, clientY: number): void {
+    const worldPoint = getWorldPointFromClientPoint(sourcePanelId, clientX, clientY);
+    if (!worldPoint) return;
+
+    crosshairSyncService.syncFromViewport(sourcePanelId, worldPoint);
+  },
+
+  /**
+   * Sync from the visual center of a panel's currently displayed slice.
+   * Used for temporary "hold Shift while scrolling" slice sync.
+   */
+  syncFromPanelCenter(sourcePanelId: string): void {
+    const panelEl = document.querySelector(`[data-panel-id="${sourcePanelId}"]`) as HTMLElement | null;
+    if (!panelEl) return;
+
+    const rect = panelEl.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return;
+
+    const worldPoint = getWorldPointFromClientPoint(
+      sourcePanelId,
+      rect.left + rect.width / 2,
+      rect.top + rect.height / 2,
+    );
+    if (!worldPoint) return;
+
+    crosshairSyncService.syncFromViewport(sourcePanelId, worldPoint);
+  },
+
+  /**
    * Publish crosshair coordinate globally and sync compatible viewports.
    *
    * For MPR/volume viewports: uses viewport-native `jumpToWorld`.


### PR DESCRIPTION
## Summary
- add Shift-scroll slice syncing for stack, MPR, and oriented viewports
- route Shift-scroll through the same anatomical world-point sync path used by crosshair clicks
- handle trackpad cases where holding Shift reports horizontal wheel deltas
- add focused tests for stack, MPR, oriented, and crosshair sync behaviors

## Why
Shift-scroll should let users move through slices while keeping the other viewports anatomically aligned. The initial linked-slice approach moved panels together, but it did not preserve anatomical correspondence.

## Root cause
The wheel interaction was syncing raw slice deltas instead of syncing from a shared anatomical point. On top of that, some Shift-scroll gestures can arrive through `deltaX` rather than `deltaY`, which made the behavior inconsistent on trackpads.

## User impact
- holding `Shift` while scrolling now updates other viewports in the same anatomically aligned way as clicking with crosshairs
- the interaction works more reliably for both mouse wheel and trackpad scrolling
- normal scrolling behavior without `Shift` is unchanged

## Validation
- `npm test -- src/renderer/components/viewer/CornerstoneViewport.test.tsx src/renderer/components/viewer/MPRViewport.test.tsx src/renderer/components/viewer/OrientedViewport.test.tsx src/renderer/lib/cornerstone/__tests__/crosshairSyncService.test.ts`
- manual dev launch and live verification setup in Electron
