### PR TITLE
[codex] Improve mammography tomo workflows

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -735,7 +735,6 @@ export default function App() {
     setNavigateTo,
     showBookmarks,
     setShowBookmarks,
-    bookmarksRef,
     refreshBookmarks,
     handleTogglePin,
     handleBookmarkNavigate,
@@ -2981,7 +2980,7 @@ export default function App() {
             </label>
             {/* Export — icon only */}
             <ExportDropdown />
-            <div ref={bookmarksRef} className="relative">
+            <div className="relative">
               <BookmarksDropdown
                 pinnedItems={pinnedItems}
                 recentSessions={recentSessions}

--- a/src/renderer/components/app/BookmarksDropdown.tsx
+++ b/src/renderer/components/app/BookmarksDropdown.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { NavigateToTarget, PinnedItem, RecentSession } from '../../lib/pinnedItems';
 import { IconChevronDown, IconPin } from '../icons';
 
@@ -21,11 +22,39 @@ export default function BookmarksDropdown({
   onNavigate,
 }: BookmarksDropdownProps) {
   const hasBookmarks = pinnedItems.length > 0 || recentSessions.length > 0;
+  const [dropdownPos, setDropdownPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!showBookmarks) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        buttonRef.current?.contains(e.target as Node) ||
+        dropdownRef.current?.contains(e.target as Node)
+      ) return;
+      onToggleBookmarks();
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [onToggleBookmarks, showBookmarks]);
+
+  const handleToggle = useCallback(() => {
+    if (!hasBookmarks) return;
+    if (!showBookmarks && buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      const dropdownWidth = 288;
+      const maxLeft = window.innerWidth - dropdownWidth - 8;
+      setDropdownPos({ top: rect.bottom + 4, left: Math.min(rect.left, maxLeft) });
+    }
+    onToggleBookmarks();
+  }, [hasBookmarks, onToggleBookmarks, showBookmarks]);
 
   return (
     <>
       <button
-        onClick={() => hasBookmarks && onToggleBookmarks()}
+        ref={buttonRef}
+        onClick={handleToggle}
         className={`flex items-center gap-1 text-xs font-medium px-2 py-1.5 rounded whitespace-nowrap transition-colors ${
           !hasBookmarks
             ? 'bg-zinc-800 text-zinc-600 cursor-default'
@@ -40,7 +69,11 @@ export default function BookmarksDropdown({
       </button>
 
       {showBookmarks && hasBookmarks && (
-        <div className="absolute top-full left-0 mt-1 w-72 bg-zinc-900 border border-zinc-700 rounded-lg shadow-xl z-50 py-1 max-h-80 overflow-y-auto">
+        <div
+          ref={dropdownRef}
+          className="fixed z-50 w-72 bg-zinc-900 border border-zinc-700 rounded-lg shadow-xl py-1 max-h-80 overflow-y-auto"
+          style={{ top: dropdownPos.top, left: dropdownPos.left }}
+        >
           {pinnedItems.length > 0 && (
             <>
               <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">

--- a/src/renderer/components/connection/xnatBrowserUtils.test.ts
+++ b/src/renderer/components/connection/xnatBrowserUtils.test.ts
@@ -51,11 +51,23 @@ describe('xnatBrowserUtils', () => {
 
   it('filters source scans by excluding derived and structured-report rows', () => {
     expect(isBrowsableSourceScan(makeScan({ modality: 'CT', type: 'AXIAL' }))).toBe(true);
+    expect(
+      isBrowsableSourceScan(
+        makeScan({
+          xsiType: 'xnat:otherDicomScanData',
+          modality: 'MG',
+          type: 'Breast Tomosynthesis',
+          seriesDescription: 'R CC Breast Tomosynthesis Image',
+        }),
+      ),
+    ).toBe(true);
     expect(isBrowsableSourceScan(makeScan({ type: 'SEG', xsiType: 'xnat:segScanData' }))).toBe(false);
     expect(isBrowsableSourceScan(makeScan({ type: 'RTSTRUCT', xsiType: 'xnat:otherDicomScanData' }))).toBe(false);
     expect(isBrowsableSourceScan(makeScan({ type: 'SR' }))).toBe(false);
     expect(isBrowsableSourceScan(makeScan({ sopClassUID: '1.2.840.10008.5.1.4.1.1.88.33' }))).toBe(false);
-    expect(isBrowsableSourceScan(makeScan({ xsiType: 'xnat:otherDicomScanData', type: 'Secondary Capture' }))).toBe(false);
+    expect(isBrowsableSourceScan(makeScan({ xsiType: 'xnat:otherDicomScanData', type: 'Secondary Capture' }))).toBe(true);
+    expect(isBrowsableSourceScan(makeScan({ xsiType: 'xnat:otherDicomScanData', modality: 'PR' }))).toBe(false);
+    expect(isBrowsableSourceScan(makeScan({ xsiType: 'xnat:otherDicomScanData', type: 'RTDOSE' }))).toBe(false);
   });
 
   it('extracts numeric values safely from scalar and array inputs', () => {

--- a/src/renderer/components/connection/xnatBrowserUtils.ts
+++ b/src/renderer/components/connection/xnatBrowserUtils.ts
@@ -18,6 +18,15 @@ const NON_THUMB_MODALITIES = new Set([
   'PR',
 ]);
 
+const NON_BROWSABLE_SOURCE_MODALITIES = new Set([
+  'RTPLAN',
+  'RTDOSE',
+  'RTRECORD',
+  'REG',
+  'KO',
+  'PR',
+]);
+
 const NON_THUMB_SOP_CLASS_UID_PREFIXES = [
   '1.2.840.10008.5.1.4.1.1.88.',  // SR family
   '1.2.840.10008.5.1.4.1.1.11.',  // Presentation State family
@@ -89,10 +98,11 @@ export function isStructuredReportScan(scan: XnatScan): boolean {
 }
 
 export function isBrowsableSourceScan(scan: XnatScan): boolean {
-  const xsiType = (scan.xsiType ?? '').trim().toLowerCase();
-  // xnat:otherDicomScanData may include RTSTRUCT (handled as derived) and
-  // other non-primary SOP classes. Filter non-derived "other DICOM" for now.
-  if (xsiType === 'xnat:otherdicomscandata' && !isRtStructScan(scan)) return false;
+  const modality = (scan.modality ?? '').trim().toUpperCase();
+  const type = (scan.type ?? '').trim().toUpperCase();
+  if (NON_BROWSABLE_SOURCE_MODALITIES.has(modality) || NON_BROWSABLE_SOURCE_MODALITIES.has(type)) {
+    return false;
+  }
   return !isDerivedScan(scan) && !isStructuredReportScan(scan);
 }
 

--- a/src/renderer/components/viewer/CornerstoneViewport.test.tsx
+++ b/src/renderer/components/viewer/CornerstoneViewport.test.tsx
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   getEpoch: vi.fn(() => 7),
   markReady: vi.fn(),
   syncCrosshair: vi.fn(),
+  syncFromClientPoint: vi.fn(),
   wireCrosshairPointerHandlers: vi.fn(),
   removeSegsFromViewport: vi.fn(),
   attachVisibleSegsToViewport: vi.fn(async () => undefined),
@@ -81,6 +82,7 @@ vi.mock('../../lib/cornerstone/viewportReadyService', () => ({
 vi.mock('../../lib/cornerstone/crosshairSyncService', () => ({
   crosshairSyncService: {
     syncFromViewport: mocks.syncCrosshair,
+    syncFromClientPoint: mocks.syncFromClientPoint,
   },
 }));
 
@@ -239,6 +241,78 @@ describe('CornerstoneViewport', () => {
     );
     expect(mocks.scrollToIndex).toHaveBeenCalledWith(panelId, 0);
     expect(useViewerStore.getState().viewports[panelId].requestedImageIndex).toBe(0);
+  });
+
+  it('syncs compatible viewports after the shifted stack scroll renders the new slice', async () => {
+    mocks.getViewport.mockReturnValue({
+      getCurrentImageIdIndex: () => 0,
+      getImageIds: () => ['img-1', 'img-2', 'img-3'],
+      getCurrentImageId: () => 'img-1',
+      getImageData: () => ({ dimensions: [320, 240] }),
+      getProperties: () => ({ voiRange: { lower: 20, upper: 120 } }),
+      resetCamera: vi.fn(),
+      render: vi.fn(),
+    });
+
+    render(<CornerstoneViewport panelId={panelId} imageIds={['img-1', 'img-2', 'img-3']} />);
+    await waitFor(() => expect(mocks.createViewport).toHaveBeenCalled());
+
+    const canvas = screen.getByTestId(`cornerstone-viewport-canvas:${panelId}`);
+
+    fireEvent(
+      canvas,
+      new WheelEvent('wheel', {
+        deltaY: 120,
+        shiftKey: true,
+        cancelable: true,
+      }),
+    );
+    expect(mocks.syncFromClientPoint).not.toHaveBeenCalled();
+
+    fireEvent(
+      canvas,
+      new CustomEvent('STACK_NEW_IMAGE', {
+        detail: { imageIdIndex: 2, imageId: 'img-3' },
+      }),
+    );
+
+    expect(mocks.syncFromClientPoint).toHaveBeenCalledWith(panelId, 0, 0);
+  });
+
+  it('uses horizontal wheel deltas for shift-scroll trackpad gestures', async () => {
+    mocks.getViewport.mockReturnValue({
+      getCurrentImageIdIndex: () => 1,
+      getImageIds: () => ['img-1', 'img-2', 'img-3', 'img-4'],
+      getCurrentImageId: () => 'img-2',
+      getImageData: () => ({ dimensions: [320, 240] }),
+      getProperties: () => ({ voiRange: { lower: 20, upper: 120 } }),
+      resetCamera: vi.fn(),
+      render: vi.fn(),
+    });
+
+    render(<CornerstoneViewport panelId={panelId} imageIds={['img-1', 'img-2', 'img-3', 'img-4']} />);
+    await waitFor(() => expect(mocks.createViewport).toHaveBeenCalled());
+
+    const canvas = screen.getByTestId(`cornerstone-viewport-canvas:${panelId}`);
+
+    fireEvent(
+      canvas,
+      new WheelEvent('wheel', {
+        deltaX: 120,
+        deltaY: 0,
+        shiftKey: true,
+        cancelable: true,
+      }),
+    );
+
+    expect(mocks.scrollToIndex).toHaveBeenCalledWith(panelId, 3);
+    fireEvent(
+      canvas,
+      new CustomEvent('STACK_NEW_IMAGE', {
+        detail: { imageIdIndex: 3, imageId: 'img-4' },
+      }),
+    );
+    expect(mocks.syncFromClientPoint).toHaveBeenCalledWith(panelId, 0, 0);
   });
 
   it('shows error UI when setup fails and skips ready signaling', async () => {

--- a/src/renderer/components/viewer/CornerstoneViewport.tsx
+++ b/src/renderer/components/viewer/CornerstoneViewport.tsx
@@ -249,6 +249,7 @@ export default function CornerstoneViewport({ panelId, imageIds }: CornerstoneVi
 
 function wireEvents(element: HTMLDivElement, panelId: string): () => void {
   const Events = Enums.Events;
+  let pendingShiftScrollSync: { clientX: number; clientY: number } | null = null;
 
   // VOI changed (user dragged W/L or preset applied)
   element.addEventListener(Events.VOI_MODIFIED, ((e: Event) => {
@@ -280,6 +281,12 @@ function wireEvents(element: HTMLDivElement, panelId: string): () => void {
         useViewerStore.getState().setPanelNativeOrientation(panelId, nativeOrientation);
       }
     }
+
+    if (pendingShiftScrollSync) {
+      const { clientX, clientY } = pendingShiftScrollSync;
+      pendingShiftScrollSync = null;
+      crosshairSyncService.syncFromClientPoint(panelId, clientX, clientY);
+    }
   }) as EventListener);
 
   // Camera modified (zoom, pan, rotation changed)
@@ -300,7 +307,11 @@ function wireEvents(element: HTMLDivElement, panelId: string): () => void {
 
     e.preventDefault();
 
-    wheelAccum += e.deltaY;
+    const scrollDelta =
+      Math.abs(e.deltaY) >= Math.abs(e.deltaX)
+        ? e.deltaY
+        : (e.shiftKey ? e.deltaX : 0);
+    wheelAccum += scrollDelta;
 
     if (Math.abs(wheelAccum) >= WHEEL_THRESHOLD) {
       const steps = Math.trunc(wheelAccum / WHEEL_THRESHOLD);
@@ -321,6 +332,7 @@ function wireEvents(element: HTMLDivElement, panelId: string): () => void {
         0;
       const targetIndex = Math.max(0, Math.min(total - 1, baseIndex + steps));
       if (targetIndex !== baseIndex) {
+        pendingShiftScrollSync = e.shiftKey ? { clientX: e.clientX, clientY: e.clientY } : null;
         state._requestImageIndex(panelId, targetIndex, total);
         viewportService.scrollToIndex(panelId, targetIndex);
       }

--- a/src/renderer/components/viewer/MPRViewport.test.tsx
+++ b/src/renderer/components/viewer/MPRViewport.test.tsx
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   removeViewport: vi.fn(),
   resize: vi.fn(),
   syncFromViewport: vi.fn(),
+  syncFromClientPoint: vi.fn(),
   wireCrosshairPointerHandlers: vi.fn(),
 }));
 
@@ -64,6 +65,7 @@ vi.mock('../../lib/cornerstone/viewportService', () => ({
 vi.mock('../../lib/cornerstone/crosshairSyncService', () => ({
   crosshairSyncService: {
     syncFromViewport: mocks.syncFromViewport,
+    syncFromClientPoint: mocks.syncFromClientPoint,
   },
 }));
 
@@ -209,6 +211,48 @@ describe('MPRViewport', () => {
       }),
     );
     expect(mocks.scroll).toHaveBeenCalledTimes(1);
+  });
+
+  it('syncs compatible viewports after the shifted MPR scroll updates the slice', async () => {
+    render(<MPRViewport panelId={panelId} volumeId="vol-1" plane="SAGITTAL" />);
+    await waitFor(() => expect(mocks.createViewport).toHaveBeenCalled());
+
+    const canvas = screen.getByTestId(`mpr-viewport-canvas:${panelId}`);
+
+    fireEvent(
+      canvas,
+      new WheelEvent('wheel', {
+        deltaY: 120,
+        shiftKey: true,
+        cancelable: true,
+      }),
+    );
+    expect(mocks.syncFromClientPoint).not.toHaveBeenCalled();
+
+    fireEvent(canvas, new CustomEvent('CAMERA_MODIFIED'));
+
+    expect(mocks.syncFromClientPoint).toHaveBeenCalledWith(panelId, 0, 0);
+  });
+
+  it('uses horizontal wheel deltas for shift-scroll MPR trackpad gestures', async () => {
+    render(<MPRViewport panelId={panelId} volumeId="vol-1" plane="SAGITTAL" />);
+    await waitFor(() => expect(mocks.createViewport).toHaveBeenCalled());
+
+    const canvas = screen.getByTestId(`mpr-viewport-canvas:${panelId}`);
+
+    fireEvent(
+      canvas,
+      new WheelEvent('wheel', {
+        deltaX: -120,
+        deltaY: 0,
+        shiftKey: true,
+        cancelable: true,
+      }),
+    );
+
+    expect(mocks.scroll).toHaveBeenCalledWith(panelId, -2);
+    fireEvent(canvas, new CustomEvent('CAMERA_MODIFIED'));
+    expect(mocks.syncFromClientPoint).toHaveBeenCalledWith(panelId, 0, 0);
   });
 
   it('shows MPR error overlay when setup fails and performs cleanup on unmount', async () => {

--- a/src/renderer/components/viewer/MPRViewport.tsx
+++ b/src/renderer/components/viewer/MPRViewport.tsx
@@ -216,6 +216,7 @@ export default function MPRViewport({ panelId, volumeId, plane }: MPRViewportPro
 
 function wireEvents(element: HTMLDivElement, panelId: string): () => void {
   const Events = Enums.Events;
+  let pendingShiftScrollSync: { clientX: number; clientY: number } | null = null;
 
   // VOI changed (user dragged W/L)
   element.addEventListener(Events.VOI_MODIFIED, ((e: Event) => {
@@ -237,6 +238,12 @@ function wireEvents(element: HTMLDivElement, panelId: string): () => void {
 
     // Update zoom
     useViewerStore.getState()._updateZoom(panelId, mprService.getZoom(panelId));
+
+    if (pendingShiftScrollSync) {
+      const { clientX, clientY } = pendingShiftScrollSync;
+      pendingShiftScrollSync = null;
+      crosshairSyncService.syncFromClientPoint(panelId, clientX, clientY);
+    }
   }) as EventListener);
 
   // ─── Trackpad / smooth scroll support ───────────────────────
@@ -247,11 +254,18 @@ function wireEvents(element: HTMLDivElement, panelId: string): () => void {
     if (e.ctrlKey || e.metaKey) return;
     e.preventDefault();
 
-    wheelAccum += e.deltaY;
+    const scrollDelta =
+      Math.abs(e.deltaY) >= Math.abs(e.deltaX)
+        ? e.deltaY
+        : (e.shiftKey ? e.deltaX : 0);
+    wheelAccum += scrollDelta;
 
     if (Math.abs(wheelAccum) >= WHEEL_THRESHOLD) {
       const steps = Math.trunc(wheelAccum / WHEEL_THRESHOLD);
       wheelAccum -= steps * WHEEL_THRESHOLD;
+      pendingShiftScrollSync = e.shiftKey && steps !== 0
+        ? { clientX: e.clientX, clientY: e.clientY }
+        : null;
       mprService.scroll(panelId, steps);
     }
   }, { passive: false });

--- a/src/renderer/components/viewer/OrientedViewport.test.tsx
+++ b/src/renderer/components/viewer/OrientedViewport.test.tsx
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   attachVisibleSegsToViewport: vi.fn(async () => undefined),
   wireCrosshairPointerHandlers: vi.fn(),
   syncFromViewport: vi.fn(),
+  syncFromClientPoint: vi.fn(),
 }));
 
 vi.mock('@cornerstonejs/core', async (importOriginal) => {
@@ -98,6 +99,7 @@ vi.mock('../../lib/cornerstone/crosshairGeometry', () => ({
 vi.mock('../../lib/cornerstone/crosshairSyncService', () => ({
   crosshairSyncService: {
     syncFromViewport: mocks.syncFromViewport,
+    syncFromClientPoint: mocks.syncFromClientPoint,
   },
 }));
 
@@ -232,6 +234,48 @@ describe('OrientedViewport', () => {
       }),
     );
     expect(mocks.mprScroll).toHaveBeenCalledTimes(1);
+  });
+
+  it('syncs compatible viewports after the shifted oriented scroll updates the slice', async () => {
+    render(<OrientedViewport panelId={panelId} imageIds={['img-1', 'img-2']} plane="SAGITTAL" />);
+    await waitFor(() => expect(mocks.mprCreateViewport).toHaveBeenCalled());
+
+    const canvas = screen.getByTestId(`oriented-viewport-canvas:${panelId}`);
+
+    fireEvent(
+      canvas,
+      new WheelEvent('wheel', {
+        deltaY: 130,
+        shiftKey: true,
+        cancelable: true,
+      }),
+    );
+    expect(mocks.syncFromClientPoint).not.toHaveBeenCalled();
+
+    fireEvent(canvas, new CustomEvent('CAMERA_MODIFIED'));
+
+    expect(mocks.syncFromClientPoint).toHaveBeenCalledWith(panelId, 0, 0);
+  });
+
+  it('uses horizontal wheel deltas for shift-scroll oriented trackpad gestures', async () => {
+    render(<OrientedViewport panelId={panelId} imageIds={['img-1', 'img-2']} plane="SAGITTAL" />);
+    await waitFor(() => expect(mocks.mprCreateViewport).toHaveBeenCalled());
+
+    const canvas = screen.getByTestId(`oriented-viewport-canvas:${panelId}`);
+
+    fireEvent(
+      canvas,
+      new WheelEvent('wheel', {
+        deltaX: 130,
+        deltaY: 0,
+        shiftKey: true,
+        cancelable: true,
+      }),
+    );
+
+    expect(mocks.mprScroll).toHaveBeenCalledWith(panelId, 2);
+    fireEvent(canvas, new CustomEvent('CAMERA_MODIFIED'));
+    expect(mocks.syncFromClientPoint).toHaveBeenCalledWith(panelId, 0, 0);
   });
 
   it('shows error overlay when setup fails', async () => {

--- a/src/renderer/components/viewer/OrientedViewport.tsx
+++ b/src/renderer/components/viewer/OrientedViewport.tsx
@@ -173,6 +173,7 @@ function syncSliceState(panelId: string): void {
 
 function wireEvents(element: HTMLDivElement, panelId: string): () => void {
   const Events = Enums.Events;
+  let pendingShiftScrollSync: { clientX: number; clientY: number } | null = null;
 
   element.addEventListener(Events.VOI_MODIFIED, ((e: Event) => {
     const detail = (e as CustomEvent).detail;
@@ -186,6 +187,12 @@ function wireEvents(element: HTMLDivElement, panelId: string): () => void {
 
   element.addEventListener(Events.CAMERA_MODIFIED, (() => {
     syncSliceState(panelId);
+
+    if (pendingShiftScrollSync) {
+      const { clientX, clientY } = pendingShiftScrollSync;
+      pendingShiftScrollSync = null;
+      crosshairSyncService.syncFromClientPoint(panelId, clientX, clientY);
+    }
   }) as EventListener);
 
   let wheelAccum = 0;
@@ -194,11 +201,18 @@ function wireEvents(element: HTMLDivElement, panelId: string): () => void {
   element.addEventListener('wheel', (e: WheelEvent) => {
     if (e.ctrlKey || e.metaKey) return;
     e.preventDefault();
-    wheelAccum += e.deltaY;
+    const scrollDelta =
+      Math.abs(e.deltaY) >= Math.abs(e.deltaX)
+        ? e.deltaY
+        : (e.shiftKey ? e.deltaX : 0);
+    wheelAccum += scrollDelta;
 
     if (Math.abs(wheelAccum) >= WHEEL_THRESHOLD) {
       const steps = Math.trunc(wheelAccum / WHEEL_THRESHOLD);
       wheelAccum -= steps * WHEEL_THRESHOLD;
+      pendingShiftScrollSync = e.shiftKey && steps !== 0
+        ? { clientX: e.clientX, clientY: e.clientY }
+        : null;
       mprService.scroll(panelId, steps);
     }
   }, { passive: false });

--- a/src/renderer/components/viewer/Toolbar.test.tsx
+++ b/src/renderer/components/viewer/Toolbar.test.tsx
@@ -135,6 +135,27 @@ describe('Toolbar', () => {
     expect(setActiveTool).toHaveBeenCalledWith(ToolName.WindowLevel);
   });
 
+  it('keeps the protocol picker visible but disabled when there is no session data', async () => {
+    const user = userEvent.setup();
+    const onApplyProtocol = vi.fn();
+
+    useViewerStore.setState({
+      ...useViewerStore.getState(),
+      sessionScans: null,
+    });
+
+    render(<Toolbar hasImages onApplyProtocol={onApplyProtocol} />);
+
+    const protocolButton = screen.getByRole('button', { name: /protocol/i });
+    expect(protocolButton).toBeDisabled();
+    expect(protocolButton).toHaveAttribute('title', 'No applicable hanging protocols');
+
+    await user.click(protocolButton);
+
+    expect(screen.queryByRole('button', { name: new RegExp(BUILT_IN_PROTOCOLS[0].name) })).not.toBeInTheDocument();
+    expect(onApplyProtocol).not.toHaveBeenCalled();
+  });
+
   it('handles undo/redo enablement and settings modal lifecycle', async () => {
     const user = userEvent.setup();
 

--- a/src/renderer/components/viewer/Toolbar.tsx
+++ b/src/renderer/components/viewer/Toolbar.tsx
@@ -405,10 +405,12 @@ function WLPresetsDropdown({ hideLabel = false }: { hideLabel?: boolean }) {
 function ProtocolPickerDropdown({
   onApplyProtocol,
   currentProtocolId,
+  disabled = false,
   hideLabel = false,
 }: {
   onApplyProtocol: (protocolId: string) => void;
   currentProtocolId: string | null;
+  disabled?: boolean;
   hideLabel?: boolean;
 }) {
   const [open, setOpen] = useState(false);
@@ -430,6 +432,7 @@ function ProtocolPickerDropdown({
   }, [open]);
 
   const handleToggle = useCallback(() => {
+    if (disabled) return;
     if (!open && buttonRef.current) {
       const rect = buttonRef.current.getBoundingClientRect();
       const dropdownWidth = 220;
@@ -437,19 +440,22 @@ function ProtocolPickerDropdown({
       setDropdownPos({ top: rect.bottom + 4, left: Math.min(rect.left, maxLeft) });
     }
     setOpen((v) => !v);
-  }, [open]);
+  }, [disabled, open]);
 
   return (
     <div className="relative">
       <button
         ref={buttonRef}
         onClick={handleToggle}
+        disabled={disabled}
         className={`flex items-center gap-1 text-xs font-medium px-2 py-1.5 rounded transition-colors ${
-          open
-            ? 'bg-blue-600 text-white'
-            : 'bg-zinc-800 text-zinc-300 hover:bg-zinc-700 hover:text-white'
+          disabled
+            ? 'bg-zinc-800 text-zinc-600 cursor-not-allowed'
+            : open
+              ? 'bg-blue-600 text-white'
+              : 'bg-zinc-800 text-zinc-300 hover:bg-zinc-700 hover:text-white'
         }`}
-        title="Hanging protocol"
+        title={disabled ? 'No applicable hanging protocols' : 'Hanging protocol'}
       >
         <IconProtocol className="w-3.5 h-3.5" />
         {!hideLabel && <span>Protocol</span>}
@@ -532,6 +538,7 @@ export default function Toolbar({
   );
   const currentProtocol = useViewerStore((s) => s.currentProtocol);
   const hasSessionData = useViewerStore((s) => s.sessionScans !== null);
+  const sessionScans = useViewerStore((s) => s.sessionScans);
   const setActiveTool = useViewerStore((s) => s.setActiveTool);
   const resetViewport = useViewerStore((s) => s.resetViewport);
   const toggleInvert = useViewerStore((s) => s.toggleInvert);
@@ -563,12 +570,13 @@ export default function Toolbar({
       </div>
 
       {/* ─── Protocol Picker ──────────────────────────────── */}
-      {hasSessionData && onApplyProtocol && !mprActive && (
+      {onApplyProtocol && !mprActive && (
         <>
           <Separator />
           <ProtocolPickerDropdown
             onApplyProtocol={onApplyProtocol}
             currentProtocolId={currentProtocol?.id ?? null}
+            disabled={!hasSessionData || !sessionScans || sessionScans.length === 0}
             hideLabel={textCollapsed}
           />
         </>

--- a/src/renderer/components/viewer/ViewportOverlay.tsx
+++ b/src/renderer/components/viewer/ViewportOverlay.tsx
@@ -7,6 +7,7 @@
  */
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { metaData } from '@cornerstonejs/core';
+import { wadouri } from '@cornerstonejs/dicom-image-loader';
 import {
   DEFAULT_OVERLAY_CORNERS,
   type OverlayCornerId,
@@ -56,6 +57,142 @@ const ORIENTATION_LABELS: Record<MPRPlane, { top: string; bottom: string; left: 
   CORONAL: { top: 'S', bottom: 'I', left: 'R', right: 'L' },
 };
 const PIXEL_SPACING_CACHE = new Map<string, { row: number; col: number } | null>();
+const PATIENT_ORIENTATION_CACHE = new Map<string, { top: string; bottom: string; left: string; right: string } | null>();
+
+function toWadouriUri(imageId: string): string {
+  return imageId.startsWith('wadouri:') ? imageId.slice(8) : imageId;
+}
+
+function oppositeOrientationToken(token: string): string {
+  const map: Record<string, string> = {
+    A: 'P',
+    P: 'A',
+    R: 'L',
+    L: 'R',
+    H: 'F',
+    F: 'H',
+    S: 'I',
+    I: 'S',
+  };
+  return token
+    .toUpperCase()
+    .split('')
+    .map((char) => map[char] ?? '')
+    .join('');
+}
+
+export function getOrientationMarkersFromPatientOrientation(raw: string): { top: string; bottom: string; left: string; right: string } | null {
+  const parts = raw
+    .split('\\')
+    .map((part) => part.trim().toUpperCase())
+    .filter((part) => part.length > 0);
+  if (parts.length < 2) return null;
+  const vertical = parts[0];
+  const horizontal = parts[1];
+  const bottom = oppositeOrientationToken(vertical);
+  const right = oppositeOrientationToken(horizontal);
+  if (!bottom || !right) return null;
+  return {
+    top: vertical,
+    bottom,
+    left: horizontal,
+    right,
+  };
+}
+
+function getStringTagValue(dataSet: { string?: (tag: string) => string | undefined } | undefined, tag: string): string {
+  return dataSet?.string?.(tag)?.trim() ?? '';
+}
+
+export function getCcMammographyOrientationMarkers(
+  patientMarkers: { top: string; bottom: string; left: string; right: string } | null,
+): { top: string; bottom: string; left: string; right: string } {
+  return {
+    top: 'H',
+    bottom: 'F',
+    left: patientMarkers?.left ?? 'L',
+    right: patientMarkers?.right ?? 'R',
+  };
+}
+
+function isMammographyImage(imageId: string | null): boolean {
+  if (!imageId) return false;
+  try {
+    const uri = toWadouriUri(imageId);
+    const dataSet = wadouri.dataSetCacheManager.get(uri);
+    return getStringTagValue(dataSet, 'x00080060').toUpperCase() === 'MG';
+  } catch {
+    return false;
+  }
+}
+
+function getMammographyOrientationMarkers(
+  imageId: string | null,
+  patientMarkers: { top: string; bottom: string; left: string; right: string } | null,
+  seriesDescription: string,
+): { top: string; bottom: string; left: string; right: string } | null {
+  if (!imageId) return null;
+
+  try {
+    const uri = toWadouriUri(imageId);
+    const dataSet = wadouri.dataSetCacheManager.get(uri);
+    const modality = getStringTagValue(dataSet, 'x00080060').toUpperCase();
+    if (modality !== 'MG') return null;
+
+    const viewPosition = getStringTagValue(dataSet, 'x00185101').toUpperCase();
+    const normalizedSeriesDescription = seriesDescription.trim().toUpperCase();
+    const isCcView =
+      viewPosition === 'CC'
+      || /\bCC\b/.test(normalizedSeriesDescription)
+      || normalizedSeriesDescription.includes('CRANIO-CAUDAL')
+      || normalizedSeriesDescription.includes('CRANIO CAUDAL');
+
+    if (isCcView) {
+      return getCcMammographyOrientationMarkers(patientMarkers);
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function getPatientOrientationMarkers(imageId: string | null): { top: string; bottom: string; left: string; right: string } | null {
+  if (!imageId) return null;
+  if (PATIENT_ORIENTATION_CACHE.has(imageId)) {
+    return PATIENT_ORIENTATION_CACHE.get(imageId) ?? null;
+  }
+
+  try {
+    const instance = metaData.get('instance', imageId) as
+      | { PatientOrientation?: unknown; patientOrientation?: unknown }
+      | undefined;
+    let raw = instance?.PatientOrientation ?? instance?.patientOrientation;
+    if (Array.isArray(raw)) {
+      raw = raw.join('\\');
+    }
+    if (typeof raw !== 'string' || raw.trim().length === 0) {
+      const uri = toWadouriUri(imageId);
+      const dataSet = wadouri.dataSetCacheManager.get(uri);
+      raw = dataSet?.string?.('x00200020');
+    }
+    if (typeof raw !== 'string' || raw.trim().length === 0) {
+      PATIENT_ORIENTATION_CACHE.set(imageId, null);
+      return null;
+    }
+
+    const markers = getOrientationMarkersFromPatientOrientation(raw);
+    if (!markers) {
+      PATIENT_ORIENTATION_CACHE.set(imageId, null);
+      return null;
+    }
+    PATIENT_ORIENTATION_CACHE.set(imageId, markers);
+    return markers;
+  } catch {
+    PATIENT_ORIENTATION_CACHE.set(imageId, null);
+    return null;
+  }
+}
 
 function toPositiveNumber(value: unknown): number | null {
   if (typeof value === 'number' && Number.isFinite(value) && value > 0) return value;
@@ -236,9 +373,6 @@ export default function ViewportOverlay({ panelId }: ViewportOverlayProps) {
       ? getCrosshairDisplayPoint(panelId, crosshairPoint)
       : null;
   const showCrosshairGuides = crosshairGuides !== null;
-  const shouldRenderOverlay =
-    viewport.totalImages > 0
-    && (showContextOverlay || showCrosshairGuides || showHorizontalRuler || showVerticalRuler || showOrientationMarkers);
 
   const crosshairText =
     activeTool === ToolName.Crosshairs && crosshairPoint && !crosshairSubjectMismatch
@@ -252,6 +386,18 @@ export default function ViewportOverlay({ panelId }: ViewportOverlayProps) {
     const clamped = Math.max(0, Math.min(panelImageIds.length - 1, preferred));
     return panelImageIds[clamped] ?? null;
   }, [panelImageIds, viewport.imageIndex, viewport.requestedImageIndex]);
+  const isMammographyView = useMemo(() => isMammographyImage(currentImageId), [currentImageId]);
+  const effectiveShowOrientationMarkers = showOrientationMarkers && !isMammographyView;
+
+  const shouldRenderOverlay =
+    viewport.totalImages > 0
+    && (
+      showContextOverlay
+      || showCrosshairGuides
+      || showHorizontalRuler
+      || showVerticalRuler
+      || effectiveShowOrientationMarkers
+    );
 
   useEffect(() => {
     if (!shouldRenderOverlay) return;
@@ -327,10 +473,20 @@ export default function ViewportOverlay({ panelId }: ViewportOverlayProps) {
 
   const horizontalRuler = rulers.horizontal;
   const verticalRuler = rulers.vertical;
+  const orientationMarkers = useMemo(() => {
+    if (panelOrientation === 'STACK') {
+      const patientMarkers = getPatientOrientationMarkers(currentImageId);
+      return getMammographyOrientationMarkers(currentImageId, patientMarkers, overlay.seriesDescription || scanSeriesDescription)
+        ?? patientMarkers
+        ?? ORIENTATION_LABELS[displayOrientation];
+    }
+    return ORIENTATION_LABELS[displayOrientation];
+  }, [currentImageId, displayOrientation, overlay.seriesDescription, panelOrientation, scanSeriesDescription]);
 
   const renderField = (field: OverlayFieldKey): React.ReactNode | null => {
     switch (field) {
       case 'orientationSelector':
+        if (isMammographyView) return null;
         return (
           <div className="pointer-events-auto">
             <select
@@ -502,15 +658,15 @@ export default function ViewportOverlay({ panelId }: ViewportOverlayProps) {
         </div>
       )}
 
-      {showOrientationMarkers && (
+      {effectiveShowOrientationMarkers && (
         <div
           data-testid={`viewport-overlay-orientation:${panelId}`}
           className="absolute inset-0 text-[11px] font-bold text-zinc-300 [text-shadow:_0_1px_2px_rgb(0_0_0_/_80%)]"
         >
-          <span className="absolute top-1.5 left-1/2 -translate-x-1/2">{ORIENTATION_LABELS[displayOrientation].top}</span>
-          <span className="absolute bottom-1.5 left-1/2 -translate-x-1/2">{ORIENTATION_LABELS[displayOrientation].bottom}</span>
-          <span className="absolute left-1.5 top-1/2 -translate-y-1/2">{ORIENTATION_LABELS[displayOrientation].left}</span>
-          <span className="absolute right-1.5 top-1/2 -translate-y-1/2">{ORIENTATION_LABELS[displayOrientation].right}</span>
+          <span className="absolute top-1.5 left-1/2 -translate-x-1/2">{orientationMarkers.top}</span>
+          <span className="absolute bottom-1.5 left-1/2 -translate-x-1/2">{orientationMarkers.bottom}</span>
+          <span className="absolute left-1.5 top-1/2 -translate-y-1/2">{orientationMarkers.left}</span>
+          <span className="absolute right-1.5 top-1/2 -translate-y-1/2">{orientationMarkers.right}</span>
         </div>
       )}
 

--- a/src/renderer/components/viewer/__tests__/ViewportOverlay.test.tsx
+++ b/src/renderer/components/viewer/__tests__/ViewportOverlay.test.tsx
@@ -5,7 +5,10 @@ import { useSegmentationStore } from '../../../stores/segmentationStore';
 import { useMetadataStore } from '../../../stores/metadataStore';
 import { useViewerStore } from '../../../stores/viewerStore';
 import { ToolName } from '@shared/types/viewer';
-import ViewportOverlay from '../ViewportOverlay';
+import ViewportOverlay, {
+  getCcMammographyOrientationMarkers,
+  getOrientationMarkersFromPatientOrientation,
+} from '../ViewportOverlay';
 import {
   OVERLAY_METADATA_FIXTURE,
   OVERLAY_PREFS_ALL_OFF,
@@ -15,16 +18,35 @@ import {
 import { expectOverlayContains, expectOverlayHidden, expectOverlayVisible } from '../../../test/overlay/overlayAsserts';
 import { renderWithOverlayStores } from '../../../test/overlay/renderWithStores';
 
+const overlayCoreMocks = vi.hoisted(() => ({
+  get: vi.fn((module: string) => {
+    if (module === 'instance') return {};
+    return { rowPixelSpacing: 0.8, columnPixelSpacing: 0.8 };
+  }),
+}));
+
+const overlayDicomMocks = vi.hoisted(() => ({
+  getDataSet: vi.fn(() => undefined),
+}));
+
 vi.mock('@cornerstonejs/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@cornerstonejs/core')>();
   return {
     ...actual,
     metaData: {
       ...actual.metaData,
-      get: vi.fn(() => ({ rowPixelSpacing: 0.8, columnPixelSpacing: 0.8 })),
+      get: overlayCoreMocks.get,
     },
   };
 });
+
+vi.mock('@cornerstonejs/dicom-image-loader', () => ({
+  wadouri: {
+    dataSetCacheManager: {
+      get: overlayDicomMocks.getDataSet,
+    },
+  },
+}));
 
 vi.mock('../../../lib/cornerstone/crosshairGeometry', () => ({
   getPanelDisplayPointForWorld: vi.fn(() => ({ x: 100, y: 80, width: 400, height: 320 })),
@@ -49,6 +71,13 @@ describe('ViewportOverlay', () => {
   beforeEach(() => {
     usePreferencesStore.setState(usePreferencesStore.getInitialState(), true);
     useSegmentationStore.setState(useSegmentationStore.getInitialState(), true);
+    overlayCoreMocks.get.mockReset();
+    overlayCoreMocks.get.mockImplementation((module: string) => {
+      if (module === 'instance') return {};
+      return { rowPixelSpacing: 0.8, columnPixelSpacing: 0.8 };
+    });
+    overlayDicomMocks.getDataSet.mockReset();
+    overlayDicomMocks.getDataSet.mockReturnValue(undefined);
   });
 
   it('does not render when overlay and marker/ruler flags are off', () => {
@@ -200,6 +229,7 @@ describe('ViewportOverlay', () => {
         panelId: OVERLAY_TEST_PANEL_ID,
         metadata: OVERLAY_METADATA_FIXTURE,
         overlayPrefs: OVERLAY_PREFS_ALL_ON,
+        panelImageIds: ['wadouri:https://example.org/mammo/tomo.dcm&frame=1'],
       },
     );
 
@@ -216,6 +246,84 @@ describe('ViewportOverlay', () => {
     expect(screen.queryByTestId(`viewport-overlay-horizontal-ruler:${OVERLAY_TEST_PANEL_ID}`)).not.toBeInTheDocument();
     expect(screen.queryByTestId(`viewport-overlay-vertical-ruler:${OVERLAY_TEST_PANEL_ID}`)).not.toBeInTheDocument();
     expect(screen.queryByTestId(`viewport-overlay-orientation:${OVERLAY_TEST_PANEL_ID}`)).not.toBeInTheDocument();
+  });
+
+  it('maps patient-orientation strings to overlay edge markers for projection images', () => {
+    expect(getOrientationMarkersFromPatientOrientation('P\\L')).toEqual({
+      top: 'P',
+      bottom: 'A',
+      left: 'L',
+      right: 'R',
+    });
+    expect(getOrientationMarkersFromPatientOrientation('A\\R')).toEqual({
+      top: 'A',
+      bottom: 'P',
+      left: 'R',
+      right: 'L',
+    });
+  });
+
+  it('uses head-foot markers for cranio-caudal mammography views', () => {
+    expect(getCcMammographyOrientationMarkers({
+      top: 'P',
+      bottom: 'A',
+      left: 'L',
+      right: 'R',
+    })).toEqual({
+      top: 'H',
+      bottom: 'F',
+      left: 'L',
+      right: 'R',
+    });
+  });
+
+  it('hides orientation markers for mammography stacks', () => {
+    overlayDicomMocks.getDataSet.mockReturnValue({
+      string: (tag: string) => {
+        if (tag === 'x00080060') return 'MG';
+        if (tag === 'x00185101') return 'CC';
+        return undefined;
+      },
+    });
+
+    renderWithOverlayStores(
+      <ViewportOverlay panelId={OVERLAY_TEST_PANEL_ID} />,
+      {
+        panelId: OVERLAY_TEST_PANEL_ID,
+        metadata: OVERLAY_METADATA_FIXTURE,
+        overlayPrefs: OVERLAY_PREFS_ALL_ON,
+      },
+    );
+
+    expect(screen.queryByTestId(`viewport-overlay-orientation:${OVERLAY_TEST_PANEL_ID}`)).not.toBeInTheDocument();
+  });
+
+  it('hides the orientation selector for mammography stacks', () => {
+    overlayDicomMocks.getDataSet.mockReturnValue({
+      string: (tag: string) => (tag === 'x00080060' ? 'MG' : undefined),
+    });
+
+    renderWithOverlayStores(
+      <ViewportOverlay panelId={OVERLAY_TEST_PANEL_ID} />,
+      {
+        panelId: OVERLAY_TEST_PANEL_ID,
+        metadata: OVERLAY_METADATA_FIXTURE,
+        overlayPrefs: {
+          ...OVERLAY_PREFS_ALL_ON,
+          corners: {
+            topLeft: ['orientationSelector'],
+            topRight: [],
+            bottomLeft: [],
+            bottomRight: [],
+          },
+        } as any,
+        viewport: {
+          totalImages: 5,
+        },
+      },
+    );
+
+    expect(screen.queryByTitle('Viewport orientation')).not.toBeInTheDocument();
   });
 
   it('renders horizontal and vertical rulers independently when enabled one at a time', () => {

--- a/src/renderer/lib/app/useBookmarks.ts
+++ b/src/renderer/lib/app/useBookmarks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   addPinnedItem,
   isPinned as isPinnedCheck,
@@ -19,7 +19,6 @@ export function useBookmarks(
   const [recentSessions, setRecentSessions] = useState<RecentSession[]>([]);
   const [navigateTo, setNavigateTo] = useState<NavigateToTarget | null>(null);
   const [showBookmarks, setShowBookmarks] = useState(false);
-  const bookmarksRef = useRef<HTMLDivElement>(null);
 
   const refreshBookmarks = useCallback(() => {
     if (serverUrl) {
@@ -34,17 +33,6 @@ export function useBookmarks(
   useEffect(() => {
     refreshBookmarks();
   }, [refreshBookmarks]);
-
-  useEffect(() => {
-    if (!showBookmarks) return;
-    function handleClick(e: MouseEvent) {
-      if (bookmarksRef.current && !bookmarksRef.current.contains(e.target as Node)) {
-        setShowBookmarks(false);
-      }
-    }
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
-  }, [showBookmarks]);
 
   const handleTogglePin = useCallback(
     (item: PinnedItem) => {
@@ -94,7 +82,6 @@ export function useBookmarks(
     setNavigateTo,
     showBookmarks,
     setShowBookmarks,
-    bookmarksRef,
     refreshBookmarks,
     handleTogglePin,
     handleBookmarkNavigate,

--- a/src/renderer/lib/cornerstone/__tests__/crosshairSyncService.test.ts
+++ b/src/renderer/lib/cornerstone/__tests__/crosshairSyncService.test.ts
@@ -3,7 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const metaDataGetMock = vi.hoisted(() => vi.fn());
 const scrollToIndexMock = vi.hoisted(() => vi.fn());
+const stackGetViewportMock = vi.hoisted(() => vi.fn(() => null));
 const mprScrollToIndexMock = vi.hoisted(() => vi.fn());
+const mprGetViewportMock = vi.hoisted(() => vi.fn(() => null));
+const mprGetSliceInfoMock = vi.hoisted(() => vi.fn(() => ({ sliceIndex: 0, totalSlices: 0 })));
 const getPanelDisplayPointForWorldMock = vi.hoisted(() => vi.fn());
 const getViewportForPanelMock = vi.hoisted(() => vi.fn());
 const getWorldPointFromClientPointMock = vi.hoisted(() => vi.fn());
@@ -81,13 +84,15 @@ vi.mock('@cornerstonejs/dicom-image-loader', () => ({
 
 vi.mock('../viewportService', () => ({
   viewportService: {
+    getViewport: stackGetViewportMock,
     scrollToIndex: scrollToIndexMock,
   },
 }));
 
 vi.mock('../mprService', () => ({
   mprService: {
-    getViewport: vi.fn(() => null),
+    getViewport: mprGetViewportMock,
+    getSliceInfo: mprGetSliceInfoMock,
     scrollToIndex: mprScrollToIndexMock,
   },
 }));
@@ -123,6 +128,9 @@ describe('crosshairSyncService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     viewerStoreMock.reset();
+    stackGetViewportMock.mockReturnValue(null);
+    mprGetViewportMock.mockReturnValue(null);
+    mprGetSliceInfoMock.mockReturnValue({ sliceIndex: 0, totalSlices: 0 });
     getPanelDisplayPointForWorldMock.mockReturnValue([1, 1]);
     getWorldPointFromClientPointMock.mockReturnValue([0, 0, 0]);
     // Invalidate any leftover metadata-loaded state from previous tests.
@@ -157,6 +165,65 @@ describe('crosshairSyncService', () => {
     expect(targetViewport.jumpToWorld).toHaveBeenCalledWith([10, 20, 30]);
     expect(state.viewports.panel_1?.requestedImageIndex).toBe(2);
     expect(scrollToIndexMock).not.toHaveBeenCalled();
+  });
+
+  it('syncs from the center of the source panel when requested', () => {
+    setMetadata({
+      'imagePlaneModule|img-source': { frameOfReferenceUID: 'FOR-1' },
+      'generalSeriesModule|img-source': { seriesInstanceUID: 'SER-1' },
+      'imagePlaneModule|img-target-a': { frameOfReferenceUID: 'FOR-1' },
+      'generalSeriesModule|img-target-a': { seriesInstanceUID: 'SER-1' },
+    });
+
+    const panelEl = document.createElement('div');
+    panelEl.setAttribute('data-panel-id', 'panel_0');
+    Object.defineProperty(panelEl, 'getBoundingClientRect', {
+      value: () => ({ left: 10, top: 20, width: 120, height: 80 }),
+    });
+    document.body.appendChild(panelEl);
+
+    const targetViewport = {
+      type: 'orthogonal',
+      jumpToWorld: vi.fn(() => true),
+      getCurrentImageIdIndex: vi.fn(() => 1),
+      render: vi.fn(),
+    };
+    getViewportForPanelMock.mockImplementation((panelId: string) => (
+      panelId === 'panel_1' ? targetViewport : null
+    ));
+    getWorldPointFromClientPointMock.mockReturnValue([7, 8, 9]);
+
+    crosshairSyncService.syncFromPanelCenter('panel_0');
+
+    expect(getWorldPointFromClientPointMock).toHaveBeenCalledWith('panel_0', 70, 60);
+    expect(targetViewport.jumpToWorld).toHaveBeenCalledWith([7, 8, 9]);
+    expect(viewerStoreMock.getState().crosshairWorldPoint).toEqual([7, 8, 9]);
+  });
+
+  it('syncs from an explicit client point inside the source panel', () => {
+    setMetadata({
+      'imagePlaneModule|img-source': { frameOfReferenceUID: 'FOR-1' },
+      'generalSeriesModule|img-source': { seriesInstanceUID: 'SER-1' },
+      'imagePlaneModule|img-target-a': { frameOfReferenceUID: 'FOR-1' },
+      'generalSeriesModule|img-target-a': { seriesInstanceUID: 'SER-1' },
+    });
+
+    const targetViewport = {
+      type: 'orthogonal',
+      jumpToWorld: vi.fn(() => true),
+      getCurrentImageIdIndex: vi.fn(() => 1),
+      render: vi.fn(),
+    };
+    getViewportForPanelMock.mockImplementation((panelId: string) => (
+      panelId === 'panel_1' ? targetViewport : null
+    ));
+    getWorldPointFromClientPointMock.mockReturnValue([4, 5, 6]);
+
+    crosshairSyncService.syncFromClientPoint('panel_0', 123, 456);
+
+    expect(getWorldPointFromClientPointMock).toHaveBeenCalledWith('panel_0', 123, 456);
+    expect(targetViewport.jumpToWorld).toHaveBeenCalledWith([4, 5, 6]);
+    expect(viewerStoreMock.getState().crosshairWorldPoint).toEqual([4, 5, 6]);
   });
 
   it('skips target panels that do not match frame-of-reference/series compatibility', () => {

--- a/src/renderer/lib/cornerstone/__tests__/dicomwebLoader.test.ts
+++ b/src/renderer/lib/cornerstone/__tests__/dicomwebLoader.test.ts
@@ -191,6 +191,25 @@ describe('dicomwebLoader', () => {
     ]);
   });
 
+  it('expands a single multiframe DICOM file into frame-addressable image ids', async () => {
+    setElectronApi({
+      getScanFiles: vi.fn(async () => ({
+        ok: true,
+        serverUrl: 'https://xnat.example',
+        files: [{ uri: '/scan/tomo.dcm', instanceNumber: 474 }],
+      })),
+    });
+
+    dicomwebMocks.uriDataSetMap.set('https://xnat.example/scan/tomo.dcm', {
+      string: (tag: string) => (tag === 'x00280008' ? '53' : undefined),
+    });
+
+    const ordered = await dicomwebLoader.getScanImageIds('sess-tomo', '474');
+    expect(ordered).toHaveLength(53);
+    expect(ordered[0]).toBe('wadouri:https://xnat.example/scan/tomo.dcm&frame=1');
+    expect(ordered[52]).toBe('wadouri:https://xnat.example/scan/tomo.dcm&frame=53');
+  });
+
   it('orders arbitrary image ids by metadata and returns identity for trivial inputs', async () => {
     setElectronApi();
 

--- a/src/renderer/lib/cornerstone/crosshairSyncService.ts
+++ b/src/renderer/lib/cornerstone/crosshairSyncService.ts
@@ -338,6 +338,38 @@ export const crosshairSyncService = {
   },
 
   /**
+   * Sync from a client-space point inside the source panel.
+   * Used for cursor-anchored shift-scroll anatomical alignment.
+   */
+  syncFromClientPoint(sourcePanelId: string, clientX: number, clientY: number): void {
+    const worldPoint = getWorldPointFromClientPoint(sourcePanelId, clientX, clientY);
+    if (!worldPoint) return;
+
+    crosshairSyncService.syncFromViewport(sourcePanelId, worldPoint);
+  },
+
+  /**
+   * Sync from the visual center of a panel's currently displayed slice.
+   * Used for temporary "hold Shift while scrolling" slice sync.
+   */
+  syncFromPanelCenter(sourcePanelId: string): void {
+    const panelEl = document.querySelector(`[data-panel-id="${sourcePanelId}"]`) as HTMLElement | null;
+    if (!panelEl) return;
+
+    const rect = panelEl.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return;
+
+    const worldPoint = getWorldPointFromClientPoint(
+      sourcePanelId,
+      rect.left + rect.width / 2,
+      rect.top + rect.height / 2,
+    );
+    if (!worldPoint) return;
+
+    crosshairSyncService.syncFromViewport(sourcePanelId, worldPoint);
+  },
+
+  /**
    * Publish crosshair coordinate globally and sync compatible viewports.
    *
    * For MPR/volume viewports: uses viewport-native `jumpToWorld`.

--- a/src/renderer/lib/cornerstone/dicomwebLoader.ts
+++ b/src/renderer/lib/cornerstone/dicomwebLoader.ts
@@ -48,6 +48,10 @@ function toWadouriUri(imageId: string): string {
   return imageId.startsWith('wadouri:') ? imageId.slice(8) : imageId;
 }
 
+function toFrameImageId(imageId: string, frameNumber: number): string {
+  return `${imageId}&frame=${frameNumber}`;
+}
+
 function parseNumber(value: unknown): number | null {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
   if (typeof value === 'string' && value.trim().length > 0) {
@@ -177,6 +181,20 @@ function scanCacheKey(sessionId: string, scanId: string): string {
 
 const scanImageIdsCache = new Map<string, ScanImageIdsCacheEntry>();
 const scanImageIdsInFlight = new Map<string, Promise<string[]>>();
+
+async function getNumberOfFramesForImageId(imageId: string): Promise<number> {
+  const uri = toWadouriUri(imageId);
+  try {
+    if (!wadouri.dataSetCacheManager.isLoaded(uri)) {
+      await wadouri.dataSetCacheManager.load(uri, undefined as any, imageId);
+    }
+    const dataSet = wadouri.dataSetCacheManager.get(uri);
+    const parsed = parseInt(String(dataSet?.string?.('x00280008') ?? ''), 10);
+    return Number.isFinite(parsed) && parsed > 1 ? parsed : 1;
+  } catch {
+    return 1;
+  }
+}
 
 async function sortImageIdsByDicomMetadata(
   imageIds: string[],
@@ -377,7 +395,27 @@ export const dicomwebLoader = {
         );
       }
 
-      const finalIds = entries.map((e) => e.imageId);
+      let finalIds = entries.map((e) => e.imageId);
+
+      // Some modalities (for example breast tomosynthesis) can arrive as a
+      // single multi-frame DICOM object rather than many single-frame files.
+      // Expand that one object into frame-addressable wadouri ids so the stack
+      // viewport can scroll through every frame instead of showing 1/1.
+      if (finalIds.length === 1) {
+        const baseImageId = finalIds[0];
+        const numberOfFrames = await getNumberOfFramesForImageId(baseImageId);
+        if (numberOfFrames > 1) {
+          finalIds = Array.from(
+            { length: numberOfFrames },
+            (_, frameIndex) => toFrameImageId(baseImageId, frameIndex + 1),
+          );
+          console.log(
+            `[dicomwebLoader] Expanded single-file multiframe scan ${sessionId}/${scanId} `
+            + `into ${numberOfFrames} frame imageIds`,
+          );
+        }
+      }
+
       scanImageIdsCache.set(key, { imageIds: [...finalIds] });
       return finalIds;
     })();

--- a/src/renderer/lib/hangingProtocolService.test.ts
+++ b/src/renderer/lib/hangingProtocolService.test.ts
@@ -107,4 +107,54 @@ describe('hangingProtocolService', () => {
     const result = applyProtocol(scans, protocol);
     expect(result.assignments.get(0)?.id).toBe('large');
   });
+
+  it('matches the mammography 4-up protocol into the requested 2x2 view order', () => {
+    const scans = [
+      scan('r-cc', { modality: 'MG', seriesDescription: 'R CC Breast Tomosynthesis Image', frames: 53 }),
+      scan('l-cc', { modality: 'MG', seriesDescription: 'L CC Breast Tomosynthesis Image', frames: 51 }),
+      scan('r-mlo', { modality: 'MG', seriesDescription: 'R MLO Breast Tomosynthesis Image', frames: 55 }),
+      scan('l-mlo', { modality: 'MG', seriesDescription: 'L MLO Breast Tomosynthesis Image', frames: 54 }),
+      scan('extra', { modality: 'MG', seriesDescription: 'Synthetic 2D C-View', frames: 1 }),
+    ];
+
+    const result = matchProtocol(scans);
+    expect(result.protocol.id).toBe('mg-tomosynthesis-4up');
+    expect(result.protocol.layout).toBe('2x2');
+    expect(result.assignments.get(0)?.id).toBe('r-cc');
+    expect(result.assignments.get(1)?.id).toBe('l-cc');
+    expect(result.assignments.get(2)?.id).toBe('r-mlo');
+    expect(result.assignments.get(3)?.id).toBe('l-mlo');
+    expect(result.unmatched.map((s) => s.id)).toEqual(['extra']);
+  });
+
+  it('keeps the standard mammography 4-up protocol for non-tomosynthesis MG views', () => {
+    const scans = [
+      scan('r-cc', { modality: 'MG', seriesDescription: 'R CC Mammogram', frames: 1 }),
+      scan('l-cc', { modality: 'MG', seriesDescription: 'L CC Mammogram', frames: 1 }),
+      scan('r-mlo', { modality: 'MG', seriesDescription: 'R MLO Mammogram', frames: 1 }),
+      scan('l-mlo', { modality: 'MG', seriesDescription: 'L MLO Mammogram', frames: 1 }),
+    ];
+
+    const result = matchProtocol(scans);
+    expect(result.protocol.id).toBe('mg-screening-4up');
+    expect(result.protocol.layout).toBe('2x2');
+    expect(result.assignments.get(0)?.id).toBe('r-cc');
+    expect(result.assignments.get(1)?.id).toBe('l-cc');
+    expect(result.assignments.get(2)?.id).toBe('r-mlo');
+    expect(result.assignments.get(3)?.id).toBe('l-mlo');
+  });
+
+  it('does not apply the mammography 4-up protocol when a required view is missing', () => {
+    const scans = [
+      scan('r-cc', { modality: 'MG', seriesDescription: 'R CC Breast Tomosynthesis Image', frames: 53 }),
+      scan('l-cc', { modality: 'MG', seriesDescription: 'L CC Breast Tomosynthesis Image', frames: 51 }),
+      scan('r-mlo', { modality: 'MG', seriesDescription: 'R MLO Breast Tomosynthesis Image', frames: 55 }),
+    ];
+
+    const result = matchProtocol(scans);
+    expect(result.protocol.id).not.toBe('mg-screening-4up');
+    expect(result.protocol.id).toBe('two-series');
+    expect(result.protocol.layout).toBe('1x2');
+    expect(result.assignments.size).toBe(2);
+  });
 });

--- a/src/renderer/lib/hangingProtocolService.ts
+++ b/src/renderer/lib/hangingProtocolService.ts
@@ -35,6 +35,13 @@ function scanMatchesMatcher(scan: XnatScan, matcher: ScanMatcher): boolean {
     if (!matched) return false;
   }
 
+  // Description contains ALL of the strings (case-insensitive)
+  if (matcher.descriptionContainsAll && matcher.descriptionContainsAll.length > 0) {
+    const desc = (scan.seriesDescription ?? '').toLowerCase();
+    const matched = matcher.descriptionContainsAll.every((s) => desc.includes(s.toLowerCase()));
+    if (!matched) return false;
+  }
+
   // Type contains ANY of the strings (case-insensitive)
   if (matcher.typeContains && matcher.typeContains.length > 0) {
     const type = (scan.type ?? '').toLowerCase();

--- a/src/shared/types/hangingProtocol.ts
+++ b/src/shared/types/hangingProtocol.ts
@@ -13,6 +13,8 @@ import type { XnatScan } from './xnat';
 export interface ScanMatcher {
   /** Match scan seriesDescription (case-insensitive substring) */
   descriptionContains?: string[];
+  /** Match scan seriesDescription containing ALL strings (case-insensitive) */
+  descriptionContainsAll?: string[];
   /** Match scan modality exactly */
   modality?: string;
   /** Match scan type (case-insensitive substring) */
@@ -64,6 +66,84 @@ export interface ProtocolResult {
 // ─── Built-in Protocols ──────────────────────────────────────────
 
 export const BUILT_IN_PROTOCOLS: HangingProtocol[] = [
+  {
+    id: 'mg-tomosynthesis-4up',
+    name: 'Tomosynthesis 4-Up',
+    modality: 'MG',
+    layout: '2x2',
+    priority: 25,
+    rules: [
+      {
+        panelIndex: 0,
+        label: 'R CC Tomo',
+        matcher: {
+          descriptionContains: ['r cc', 'right cc', 'rcc'],
+          descriptionContainsAll: ['tomo'],
+        },
+        required: true,
+      },
+      {
+        panelIndex: 1,
+        label: 'L CC Tomo',
+        matcher: {
+          descriptionContains: ['l cc', 'left cc', 'lcc'],
+          descriptionContainsAll: ['tomo'],
+        },
+        required: true,
+      },
+      {
+        panelIndex: 2,
+        label: 'R MLO Tomo',
+        matcher: {
+          descriptionContains: ['r mlo', 'right mlo', 'rmlo'],
+          descriptionContainsAll: ['tomo'],
+        },
+        required: true,
+      },
+      {
+        panelIndex: 3,
+        label: 'L MLO Tomo',
+        matcher: {
+          descriptionContains: ['l mlo', 'left mlo', 'lmlo'],
+          descriptionContainsAll: ['tomo'],
+        },
+        required: true,
+      },
+    ],
+  },
+  {
+    id: 'mg-screening-4up',
+    name: 'Mammography 4-Up',
+    modality: 'MG',
+    layout: '2x2',
+    priority: 20,
+    rules: [
+      {
+        panelIndex: 0,
+        label: 'R CC',
+        matcher: { descriptionContains: ['r cc', 'right cc', 'rcc'] },
+        required: true,
+      },
+      {
+        panelIndex: 1,
+        label: 'L CC',
+        matcher: { descriptionContains: ['l cc', 'left cc', 'lcc'] },
+        required: true,
+      },
+      {
+        panelIndex: 2,
+        label: 'R MLO',
+        matcher: { descriptionContains: ['r mlo', 'right mlo', 'rmlo'] },
+        required: true,
+      },
+      {
+        panelIndex: 3,
+        label: 'L MLO',
+        matcher: { descriptionContains: ['l mlo', 'left mlo', 'lmlo'] },
+        required: true,
+      },
+    ],
+  },
   {
     id: 'ct-contrast',
     name: 'CT Pre/Post Contrast',


### PR DESCRIPTION
## Summary
- surface breast tomosynthesis scans in the XNAT browser and expand single-file multiframe scans into full frame stacks
- add mammography and tomosynthesis 4-up hanging protocols and suppress stack orientation UI that does not apply to mammography views
- keep the hanging protocol menu visible but disabled when unavailable, and fix the pinned items dropdown so it reliably renders its contents

## Why
Tomosynthesis sessions were partially hidden or incorrectly presented in the app: tomo scans could be filtered out of the session browser, multiframe studies loaded as a single image, mammography views showed misleading orientation affordances, and two toolbar menus had inconsistent visibility behavior.

## Validation
- npm test -- src/renderer/components/connection/xnatBrowserUtils.test.ts src/renderer/components/viewer/__tests__/ViewportOverlay.test.tsx src/renderer/components/viewer/Toolbar.test.tsx src/renderer/lib/cornerstone/__tests__/dicomwebLoader.test.ts src/renderer/lib/hangingProtocolService.test.ts src/renderer/App.test.tsx
